### PR TITLE
NOT MERGED CI: run lint and tiered pytest on classic/develop PRs 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -111,7 +111,7 @@ jobs:
   test-integration:
     name: test-integration
     runs-on: ubuntu-latest
-    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    # Job-level `if: secrets.*` is invalid in GitHub Actions; skip inside the job when unset.
     strategy:
       fail-fast: false
       matrix:
@@ -144,6 +144,11 @@ jobs:
           poetry run pip install linkup-sdk
 
       - name: Run integration tests
-        run: poetry run pytest tests/ -m integration
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY secret not configured; skipping integration tests."
+            exit 0
+          fi
+          poetry run pytest tests/ -m integration

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,35 +1,149 @@
-name: Build and Test
+name: CI
 
 on:
   push:
-    branches: ["main", "development"]
+    branches: [main, classic/develop]
   pull_request:
-    branches: ["main", "development"]
+    branches: [main, classic/develop]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Sync lock file and install dev dependencies
+        run: |
+          poetry lock
+          poetry install --only dev --no-interaction
+
+      - name: Lint changed Python files (interpreter/, tests/, scripts/)
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Full-repo black/isort would fail on hundreds of files; lint only scoped
+          # paths, and on PRs/pushes only files touched in that change set.
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            git fetch origin "${GITHUB_BASE_REF}" --depth=1
+            DIFF_RANGE="origin/${GITHUB_BASE_REF}...HEAD"
+          elif [ "${GITHUB_EVENT_BEFORE}" != "0000000000000000000000000000000000000000" ]; then
+            DIFF_RANGE="${GITHUB_EVENT_BEFORE}..${GITHUB_SHA}"
+          else
+            echo "No prior commit; skipping lint (nothing to compare)."
+            exit 0
+          fi
+
+          mapfile -t FILES < <(
+            git diff --name-only --diff-filter=ACMRT "${DIFF_RANGE}" -- \
+              'interpreter/**/*.py' 'tests/**/*.py' 'scripts/**/*.py' || true
+          )
+
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No scoped Python files changed; lint passed."
+            exit 0
+          fi
+
+          echo "Linting ${#FILES[@]} file(s):"
+          printf '  %s\n' "${FILES[@]}"
+          poetry run black --check "${FILES[@]}"
+          poetry run isort --check-only "${FILES[@]}"
+
+  test-unit:
+    name: test-unit (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install poetry
+
+      - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install PowerShell
+        run: |
+          wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb" \
+            -O packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          sudo apt-get update
+          sudo apt-get install -y powershell
+
       - name: Install dependencies
         run: |
-          # Ensure dependencies are installed without relying on a lock file.
-          poetry update
-          poetry install -E server
-      - name: Test with pytest
+          poetry lock
+          poetry install -E server --no-interaction
+          poetry run pip install linkup-sdk
+
+      - name: Run unit tests
+        run: poetry run pytest tests/ -m "not integration"
+        env:
+          OPENAI_API_KEY: ""
+
+  test-integration:
+    name: test-integration
+    runs-on: ubuntu-latest
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
         run: |
-          poetry run pytest -s -x -k test_
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install PowerShell
+        run: |
+          wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb" \
+            -O packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          sudo apt-get update
+          sudo apt-get install -y powershell
+
+      - name: Install dependencies
+        run: |
+          poetry lock
+          poetry install -E server --no-interaction
+          poetry run pip install linkup-sdk
+
+      - name: Run integration tests
+        run: poetry run pytest tests/ -m integration
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,8 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Sync lock file and install dev dependencies
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
         run: |
           poetry lock
           poetry install --only dev --no-interaction
@@ -98,6 +100,8 @@ jobs:
           sudo apt-get install -y powershell
 
       - name: Install dependencies
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
         run: |
           poetry lock
           poetry install -E server --no-interaction
@@ -138,6 +142,8 @@ jobs:
           sudo apt-get install -y powershell
 
       - name: Install dependencies
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
         run: |
           poetry lock
           poetry install -E server --no-interaction

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -104,10 +104,17 @@ jobs:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
         run: |
           poetry lock
-          poetry install -E server --no-interaction
-          # tokenizers 0.19.x (from litellm) has no cp313 wheels; upgrade on 3.13 only.
           if [ "${{ matrix.python-version }}" = "3.13" ]; then
+            # litellm pins tokenizers 0.19.x, which has no cp313 wheels. Install deps via
+            # pip with a newer tokenizers, then install the project root only.
+            poetry self add poetry-plugin-export
+            poetry export -f requirements.txt -E server --without-hashes --without-urls -o /tmp/requirements.txt
+            grep -v '^tokenizers==' /tmp/requirements.txt > /tmp/requirements-no-tokenizers.txt
+            poetry run pip install -r /tmp/requirements-no-tokenizers.txt
             poetry run pip install 'tokenizers>=0.20.2'
+            poetry install -E server --only-root --no-interaction
+          else
+            poetry install -E server --no-interaction
           fi
           poetry run pip install linkup-sdk
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -112,6 +112,8 @@ jobs:
             grep -v '^tokenizers==' /tmp/requirements.txt > /tmp/requirements-no-tokenizers.txt
             poetry run pip install -r /tmp/requirements-no-tokenizers.txt
             poetry run pip install 'tokenizers>=0.20.2'
+            poetry export --only dev --without-hashes --without-urls -o /tmp/dev-requirements.txt
+            poetry run pip install -r /tmp/dev-requirements.txt
             poetry install -E server --only-root --no-interaction
           else
             poetry install -E server --no-interaction

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -105,6 +105,10 @@ jobs:
         run: |
           poetry lock
           poetry install -E server --no-interaction
+          # tokenizers 0.19.x (from litellm) has no cp313 wheels; upgrade on 3.13 only.
+          if [ "${{ matrix.python-version }}" = "3.13" ]; then
+            poetry run pip install 'tokenizers>=0.20.2'
+          fi
           poetry run pip install linkup-sdk
 
       - name: Run unit tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,3 +193,9 @@ target-version = ['py311']
 profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests requiring API keys or external services",
+]
+testpaths = ["tests"]

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -23,11 +23,19 @@ TEST_MODEL_MINI = os.environ.get("TEST_MODEL_MINI", "gpt-4o-mini")  # Default ch
 TEST_MODEL_MAIN = os.environ.get("TEST_MODEL_MAIN", "gpt-4o")  # Default smarter model
 TEST_API_KEY_ENV = os.environ.get("TEST_API_KEY_ENV", "OPENAI_API_KEY")  # Which env var to check (for both models)
 
-# Skip tests that require LLM API access when no API key is available
-requires_api_key = pytest.mark.skipif(
-    not os.environ.get(TEST_API_KEY_ENV),
-    reason=f"No {TEST_API_KEY_ENV} available - requires LLM access (models: {TEST_MODEL_MINI}/{TEST_MODEL_MAIN})"
-)
+# Skip tests that require LLM API access when no API key is available.
+# Also tagged integration so CI can run: pytest -m "not integration" (unit) / -m integration.
+def requires_api_key(func):
+    func = pytest.mark.integration(func)
+    return pytest.mark.skipif(
+        not os.environ.get(TEST_API_KEY_ENV),
+        reason=(
+            f"No {TEST_API_KEY_ENV} available - requires LLM access "
+            f"(models: {TEST_MODEL_MINI}/{TEST_MODEL_MAIN})"
+        ),
+    )(func)
+
+
 #####
 
 import multiprocessing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was broken

GitHub Actions workflow `.github/workflows/python-package.yml` only triggered on `main` and `development`, but the repository default branch is `classic/develop`. PRs targeting `classic/develop` (including agent PRs #4, #5, #7) therefore never ran pytest or lint — only the `task-list-completed` check appeared.

The old workflow also required `OPENAI_API_KEY` for all pytest runs, used fail-fast (`-x`), and did not separate lint from tests.

## What this PR does

Replaces the workflow with three jobs that trigger on **push** and **pull_request** to `main` and `classic/develop`:

| Job | Required for merge | Secrets | What it runs |
|-----|-------------------|---------|--------------|
| **lint** | Yes (once branch protection is enabled) | None | `black --check` and `isort --check-only` on **changed** Python files under `interpreter/`, `tests/`, and `scripts/` only |
| **test-unit** | Yes | None | `pytest tests/ -m "not integration"` on Python 3.10, 3.12, 3.13 |
| **test-integration** | No (optional) | `OPENAI_API_KEY` | `pytest tests/ -m integration` — skips in-step when the secret is unset (GitHub Actions does not allow `secrets.*` in job-level `if:`) |

Other details:

- Uses `actions/checkout@v4` and `actions/setup-python@v5`
- Concurrency group cancels superseded runs on the same PR/branch
- Installs PowerShell (`pwsh`) and `linkup-sdk` in test jobs so existing unit tests pass on Linux runners
- Runs `poetry lock` before install because `poetry.lock` is currently out of sync with `pyproject.toml` on `classic/develop` (avoids committing a massive lock-file-only diff in this infrastructure PR)
- Python 3.13 uses a pip export workaround: `tokenizers` 0.19.x (from `litellm`) has no cp313 wheels, so deps install via `poetry export` + `tokenizers>=0.20.2` before `poetry install --only-root`
- Adds `[tool.pytest.ini_options]` with an `integration` marker; API-key tests in `tests/test_interpreter.py` are tagged via the existing `requires_api_key` decorator

### Lint scoping

A full-repo black/isort check would fail on ~70 files under `interpreter/` and `tests/` alone. To avoid a mass reformat PR, **lint only runs on Python files changed in the PR/push** within `interpreter/`, `tests/`, and `scripts/`. This PR changes one scoped Python file (`tests/test_interpreter.py` — marker only), so lint validates that file only.

## Manual steps for repo owner

After this PR merges and CI is green:

1. **Enable branch protection** on `classic/develop` and `main` requiring status checks:
   - `lint`
   - `test-unit (Python 3.10)`
   - `test-unit (Python 3.12)`
   - `test-unit (Python 3.13)`
2. **Optional:** Add repository secret `OPENAI_API_KEY` to enable real integration test runs (the job currently passes with a skip message when unset).

## Effect on open PRs

Draft PRs #4, #5, and #7 target `classic/develop`. Once this lands on `classic/develop`, **rebase or push** those branches to pick up the new checks.

## Out of scope (per Phase 0 spec)

- No feature ports, history rewrites, or mass black reformat
- No Bugbot / Cursor review workflows
- No branch protection changes (human step above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7662e644-730e-42b9-9146-d110f0b5797d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7662e644-730e-42b9-9146-d110f0b5797d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

