### PR TITLE
fix(skills): drop unused lazy pynput import that masks errors on headless SSH

### DIFF
--- a/interpreter/core/computer/skills/skills.py
+++ b/interpreter/core/computer/skills/skills.py
@@ -7,13 +7,7 @@ import subprocess
 from pathlib import Path
 
 from ....terminal_interface.utils.oi_dir import oi_dir
-from ...utils.lazy_import import lazy_import
 from ..utils.recipient_utils import format_to_recipient
-
-# Lazy import, imported when needed to speed up start time
-aifs = lazy_import("aifs")
-pyautogui = lazy_import("pyautogui")
-pynput = lazy_import("pynput")
 
 element = None
 element_box = None

--- a/tests/core/computer/skills/test_skills.py
+++ b/tests/core/computer/skills/test_skills.py
@@ -1,0 +1,93 @@
+"""Regression tests for issue #3: lazy pynput import masking AttributeError."""
+
+import importlib
+import importlib.abc
+import importlib.util
+import sys
+
+import pytest
+
+SKILLS_MODULE = "interpreter.core.computer.skills.skills"
+
+
+def _install_headless_lazy_module(module_name):
+    """Register a PEP 562 lazy module that fails like pynput on headless SSH."""
+
+    class HeadlessLoader(importlib.abc.Loader):
+        def exec_module(self, module):
+            raise ImportError(
+                'this platform is not supported: ("failed to acquire X connection: '
+                'Bad display name \\"\\"", DisplayNameError(""))'
+            )
+
+    loader = HeadlessLoader()
+    spec = importlib.util.spec_from_loader(module_name, loader)
+    lazy_loader = importlib.util.LazyLoader(loader)
+    spec.loader = lazy_loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    lazy_loader.exec_module(module)
+    return module
+
+
+def _reload_skills_module():
+    if SKILLS_MODULE in sys.modules:
+        return importlib.reload(sys.modules[SKILLS_MODULE])
+    return importlib.import_module(SKILLS_MODULE)
+
+
+def test_skills_import_does_not_register_pynput():
+    """skills.py must not register pynput in sys.modules at import time (issue #3)."""
+    saved_modules = {}
+    for name in ("pynput", SKILLS_MODULE):
+        if name in sys.modules:
+            saved_modules[name] = sys.modules.pop(name)
+
+    try:
+        _reload_skills_module()
+        assert "pynput" not in sys.modules
+    finally:
+        for name, mod in saved_modules.items():
+            sys.modules[name] = mod
+
+
+def test_headless_lazy_pynput_masks_unrelated_attribute_error():
+    """Simulate headless SSH: lazy pynput in sys.modules can mask AttributeError."""
+    module_name = "_test_headless_pynput_fake"
+    saved = sys.modules.pop(module_name, None)
+
+    try:
+        _install_headless_lazy_module(module_name)
+
+        with pytest.raises(ImportError, match="not supported"):
+            try:
+                raise AttributeError(
+                    "'AnswerResult' object has no attribute 'answer'"
+                )
+            except AttributeError:
+                # IPython traceback formatting can touch modules in sys.modules
+                getattr(sys.modules[module_name], "keyboard")
+    finally:
+        sys.modules.pop(module_name, None)
+        if saved is not None:
+            sys.modules[module_name] = saved
+
+
+def test_attribute_error_unmasked_when_skills_does_not_preload_pynput():
+    """Importing skills leaves pynput out of sys.modules so errors stay visible."""
+    saved = {}
+    for name in ("pynput", SKILLS_MODULE):
+        if name in sys.modules:
+            saved[name] = sys.modules.pop(name)
+
+    try:
+        _reload_skills_module()
+        assert "pynput" not in sys.modules
+
+        with pytest.raises(AttributeError, match="answer"):
+            raise AttributeError(
+                "'AnswerResult' object has no attribute 'answer'"
+            )
+    finally:
+        for name, mod in saved.items():
+            sys.modules[name] = mod


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3. Supersedes closed PR #5 (which targeted `classic/develop`).

## Problem

`interpreter/core/computer/skills/skills.py` had unused module-level lazy imports:

```python
aifs = lazy_import("aifs")
pyautogui = lazy_import("pyautogui")
pynput = lazy_import("pynput")
```

`lazy_import("pynput")` registers `pynput` in `sys.modules` with a PEP 562 `LazyLoader`. When IPython formats a traceback, it can resolve that lazy module, triggering pynput's X11 initialization. On headless SSH (no `DISPLAY`), this raises an unrelated `ImportError` that masks the original `AttributeError`.

## Fix

Remove the unused lazy imports from `skills.py`. None of `aifs`, `pyautogui`, or `pynput` are referenced in this module.

Ported from `classic/develop` commit `33514efd` (branch `cursor/fix-issue-3-pynput-traceback-55da`).

## Tests

Added `tests/core/computer/skills/test_skills.py`:

- Verifies importing `skills` does not register `pynput` in `sys.modules`
- Simulates headless pynput failure via a fake lazy module (no pynput install required)
- Confirms `AttributeError` is not masked when `pynput` is absent from `sys.modules`

```bash
pytest tests/core/computer/skills/test_skills.py -v
```

All 3 tests pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1c6dad7-0360-4c46-b294-14d2e9dc8ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1c6dad7-0360-4c46-b294-14d2e9dc8ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

