### PR TITLE
CI: main-only ruff lint and pytest unit/integration split

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,17 +41,30 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[server]"
-          pip install pytest websockets requests
+          pip install pytest pytest-cov websockets requests
       - name: Run unit tests
-        run: pytest -m "not integration"
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.12" ]; then
+            pytest -m "not integration" --cov=interpreter --cov-report=xml
+          else
+            pytest -m "not integration"
+          fi
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-integration:
     runs-on: ubuntu-latest
-    if: ${{ secrets.OPENAI_API_KEY != '' }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12", "3.13"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -65,4 +78,9 @@ jobs:
       - name: Run integration tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: pytest -m integration
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY secret not configured; skipping integration tests."
+            exit 0
+          fi
+          pytest -m integration

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,35 +1,68 @@
-name: Build and Test
+name: CI
 
 on:
   push:
-    branches: ["main", "development"]
+    branches: [main]
   pull_request:
-    branches: ["main", "development"]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Lint with ruff
+        run: ruff check interpreter tests
+
+  test-unit:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
-
+        python-version: ["3.10", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
       - name: Install dependencies
         run: |
-          # Ensure dependencies are installed without relying on a lock file.
-          poetry update
-          poetry install -E server
-      - name: Test with pytest
+          python -m pip install --upgrade pip
+          pip install -e ".[server]"
+          pip install pytest websockets requests
+      - name: Run unit tests
+        run: pytest -m "not integration"
+
+  test-integration:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
         run: |
-          poetry run pytest -s -x -k test_
+          python -m pip install --upgrade pip
+          pip install -e ".[server]"
+          pip install pytest websockets requests
+      - name: Run integration tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: pytest -m integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent instructions
+
+## Branch naming
+
+Create branches as `cursor/<topic>-6eeb` (for example, `cursor/fix-foo-6eeb`).
+
+## Before opening a PR
+
+1. Run `ruff check interpreter tests` and fix any reported issues.
+2. Run `pytest -m "not integration"` and fix failures until green.
+3. If `OPENAI_API_KEY` is available locally, also run `pytest -m integration`.
+4. Commit and push your branch.
+5. Open a pull request targeting `main`.
+6. Do **not** merge the PR yourself.
+
+## Install
+
+Use editable pip install, not Poetry:
+
+```shell
+pip install -e ".[server]"
+pip install pytest ruff websockets requests
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Create branches as `cursor/<topic>-6eeb` (for example, `cursor/fix-foo-6eeb`).
 
 1. Run `ruff check interpreter tests` and fix any reported issues.
 2. Run `pytest -m "not integration"` and fix failures until green.
+3. Optional: `pytest -m "not integration" --cov=interpreter --cov-report=xml` (CI uploads coverage on Python 3.12).
 3. If `OPENAI_API_KEY` is available locally, also run `pytest -m integration`.
 4. Commit and push your branch.
 5. Open a pull request targeting `main`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <h1 align="center">● Open Interpreter</h1>
 
 <p align="center">
+    <a href="https://github.com/endolith/open-interpreter/actions/workflows/python-package.yml?query=branch%3Amain">
+        <img alt="CI" src="https://github.com/endolith/open-interpreter/actions/workflows/python-package.yml/badge.svg?branch=main"/></a>
     <a href="https://discord.gg/Hvz9Axh84z">
         <img alt="Discord" src="https://img.shields.io/discord/1146610656779440188?logo=discord&style=flat&logoColor=white"/></a>
     <a href="docs/README_JA.md"><img src="https://img.shields.io/badge/ドキュメント-日本語-white.svg" alt="JA doc"/></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,37 @@ target-version = ['py311']
 profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+exclude = ["examples"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+ignore = [
+    "E401",
+    "E402",
+    "E711",
+    "E712",
+    "E713",
+    "E721",
+    "E722",
+    "E741",
+    "F401",
+    "F541",
+    "F811",
+    "F841",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"interpreter/core/computer/display/display.py" = ["F821"]
+"interpreter/core/computer/display/point/point.py" = ["F821"]
+"interpreter/core/llm/utils/convert_to_openai_messages.py" = ["F821"]
+"interpreter/core/respond.py" = ["F821"]
+"tests/test_interpreter.py" = ["F821"]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that require OPENAI_API_KEY and call external LLM APIs",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    if os.environ.get("OPENAI_API_KEY"):
+        return
+
+    skip_integration = pytest.mark.skip(
+        reason="OPENAI_API_KEY not set; skipping integration test"
+    )
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -83,6 +83,7 @@ def run_auth_server():
 
 
 # @pytest.mark.skip(reason="Requires uvicorn, which we don't require by default")
+@pytest.mark.integration
 def test_authenticated_acknowledging_breaking_server():
     """
     Test the server when we have authentication and acknowledging one.
@@ -237,6 +238,7 @@ def run_server():
 
 
 # @pytest.mark.skip(reason="Requires uvicorn, which we don't require by default")
+@pytest.mark.integration
 def test_server():
     # Start the server in a new process
 
@@ -686,10 +688,12 @@ def test_pytes():
     assert False
 
 
+@pytest.mark.integration
 def test_ai_chat():
     print(interpreter.computer.ai.chat("hi"))
 
 
+@pytest.mark.integration
 def test_generator():
     """
     Sends two messages, makes sure everything is correct with display both on and off.
@@ -1020,6 +1024,7 @@ def test_i():
     assert full_response != ""
 
 
+@pytest.mark.integration
 def test_async():
     interpreter.chat("Hello!", blocking=False)
     print(interpreter.wait())
@@ -1123,6 +1128,7 @@ def test_spotlight():
     interpreter.computer.keyboard.hotkey("command", "space")
 
 
+@pytest.mark.integration
 def test_files():
     messages = [
         {"role": "user", "type": "message", "content": "Does this file exist?"},
@@ -1174,6 +1180,7 @@ def test_multiple_instances():
     assert agent_2.system_message == "u"
 
 
+@pytest.mark.integration
 def test_hello_world():
     hello_world_response = "Hello, World!"
 
@@ -1186,6 +1193,7 @@ def test_hello_world():
     ]
 
 
+@pytest.mark.integration
 def test_math():
     # we'll generate random integers between this min and max in our math tests
     min_number = randint(1, 99)
@@ -1262,18 +1270,21 @@ with open('numbers.txt', 'a+') as f:
     assert "5" not in content
 
 
+@pytest.mark.integration
 def test_delayed_exec():
     interpreter.chat(
         """Can you write a single block of code and execute it that prints something, then delays 1 second, then prints something else? No talk just code, execute the code. Thanks!"""
     )
 
 
+@pytest.mark.integration
 def test_nested_loops_and_multiple_newlines():
     interpreter.chat(
         """Can you write a nested for loop in python and shell and run them? Don't forget to properly format your shell script and use semicolons where necessary. Also put 1-3 newlines between each line in the code. Only generate and execute the code. Yes, execute the code instantly! No explanations. Thanks!"""
     )
 
 
+@pytest.mark.integration
 def test_write_to_file():
     interpreter.chat(
         """Write the word 'Washington' to a .txt file called file.txt. Instantly run the code! Save the file!"""
@@ -1286,6 +1297,7 @@ def test_write_to_file():
     assert "Washington" in messages[-1]["content"]
 
 
+@pytest.mark.integration
 def test_markdown():
     interpreter.chat(
         """Hi, can you test out a bunch of markdown features? Try writing a fenced code block, a table, headers, everything. DO NOT write the markdown inside a markdown code block, just write it raw."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes CI on `main` useful and passable without API keys.

- **Triggers:** `push` and `pull_request` on `main` only (drops `development` and `classic/develop`)
- **lint:** `ruff check interpreter tests`
- **test-unit:** `pytest -m "not integration"` on Python 3.10, 3.12, 3.13; **coverage upload on 3.12** via Codecov
- **test-integration:** optional; skips in-step when `OPENAI_API_KEY` secret unset (no invalid job-level `secrets` if)
- **Install:** `pip install -e ".[server]"` instead of Poetry
- **Permissions:** `contents: read`; concurrency cancel

## Setup for maintainer

1. Add `CODECOV_TOKEN` repo secret (link project at codecov.io for `endolith/open-interpreter`)
2. Optional: `OPENAI_API_KEY` for integration job

## Docs

- Adds CI badge to `README.md`
- Adds `AGENTS.md`

**You merge this** — agents must not merge workflow PRs.

Supersedes draft #11 PORT_CLUSTERS content if merged with #13 (handover docs).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71e617dc-e26a-436f-a12b-d216244d5e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71e617dc-e26a-436f-a12b-d216244d5e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

