### PR TITLE
Document fork handover and branch strategy (main vs classic/develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h1 align="center">● Open Interpreter</h1>
 
+> **Python fork:** Community-maintained Python edition. The upstream project is now a [Rust rewrite](https://github.com/openinterpreter/openinterpreter) (`oix`); Python development happens here. See [docs/FORK.md](docs/FORK.md) for branches (`main` = merge target, `classic/develop` = maintainer sandbox).
+
 <p align="center">
     <a href="https://discord.gg/Hvz9Axh84z">
         <img alt="Discord" src="https://img.shields.io/discord/1146610656779440188?logo=discord&style=flat&logoColor=white"/></a>

--- a/docs/FORK.md
+++ b/docs/FORK.md
@@ -1,0 +1,38 @@
+# Fork maintenance (endolith/open-interpreter)
+
+This repository is the **community-maintained Python** edition of Open Interpreter.
+
+The upstream [openinterpreter/openinterpreter](https://github.com/openinterpreter/openinterpreter) project now focuses on a **Rust rewrite** (default branch `oix`). Killian Lucas linked here as the Python fork in [this commit](https://github.com/openinterpreter/openinterpreter/commit/632f2a36ef06ff30431368c637ef488bbe5d508c).
+
+## Branches
+
+| Branch | Role |
+| ------ | ---- |
+| **`main`** | **Merge target.** Clean, reviewable feature PRs land here. CI runs here. |
+| **`classic/develop`** | Maintainer daily driver. Large accumulated diff (~hundreds of commits ahead of `main`). **Not** the merge target — port isolated features to `main` one PR at a time. Default branch today for convenience only. |
+| **`development`** | Legacy upstream branch. **Frozen / not becoming `main`.** Scheduled to be renamed `archive/development` (or deleted) once nothing references it. |
+| `classic/*` | Topic experiments; may be stale. |
+| `cursor/*` | Cloud agent branches (`cursor/<topic>-6eeb`). |
+
+See also [PORT_CLUSTERS.md](PORT_CLUSTERS.md) for how to port features from `classic/develop` → `main`.
+
+## PyPI
+
+The PyPI package name is still [`open-interpreter`](https://pypi.org/project/open-interpreter/). Transfer/rename is **TBD** (pending coordination with upstream). Until then, installs may still point at this repo or upstream depending on release tags.
+
+## OpenRouter attribution
+
+When provider code sets OpenRouter HTTP headers, use this fork's URL:
+
+- `OR_SITE_URL` → `https://github.com/endolith/open-interpreter`
+- `OR_APP_NAME` → `Open Interpreter` (or `Open Interpreter (Python fork)`)
+
+## CI and contributions
+
+- PRs target **`main`**.
+- CI: ruff + pytest (unit tests without API keys; integration optional with `OPENAI_API_KEY` secret). See [AGENTS.md](../AGENTS.md) once merged.
+- Lint/format: **ruff** (not black) on `main` going forward.
+
+## Upstream docs
+
+Hosted-model docs under `docs/language-models/` may still reference upstream URLs. Provider behavior on `main` may lag `classic/develop` until feature ports land.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documentation only — safe to merge before or with CI PR #12.

## Changes

- **docs/FORK.md** — fork handover: upstream `oix` (Rust), branch roles, PyPI TBD, OpenRouter URL
- **docs/PORT_CLUSTERS.md** — porting guide (`classic/develop` → `main`)
- **docs/CONTRIBUTING.md** — branch strategy table; links to `endolith/open-interpreter`
- **README.md** — callout that this is the Python fork; `main` is merge target

## Branch cheat sheet

| Branch | Role |
|--------|------|
| `main` | Merge target + CI |
| `classic/develop` | Maintainer sandbox (default for convenience) |
| `development` | Legacy — rename to `archive/development` planned |

Does not change runtime code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

