### PR TITLE
ROADMAP: document branch roles in project scope

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,6 +53,14 @@
 
 ## What's in our scope?
 
+This repository (`endolith/open-interpreter`) is the **Python** edition of Open Interpreter. The upstream [openinterpreter/openinterpreter](https://github.com/openinterpreter/openinterpreter) repo is a separate **Rust** rewrite (default branch `oix`).
+
+**Branches**
+
+- **`main`** — merge target; PRs and CI land here.
+- **`classic/develop`** — maintainer working branch (repo default today). Features are ported to `main` as isolated PRs, not merged wholesale.
+- **`development`** — legacy upstream branch; not maintained and not becoming `main`.
+
 Open Interpreter contains two projects which support each other, whose scopes are as follows:
 
 1. `core`, which is dedicated to figuring out how to get LLMs to safely control a computer. Right now, this means creating a real-time code execution environment that language models can operate.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Single-file change: adds a short **Branches** subsection under "What's in our scope?" in `docs/ROADMAP.md`.

States that this repo is the Python edition, upstream `oix` is Rust, and the roles of `main`, `classic/develop`, and `development`.

No FORK.md, no PORT_CLUSTERS.md, no README/CONTRIBUTING churn.

Replaces the broader (closed) handover approach in #13.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

