### PR TITLE
CI: unit tests on main without API key

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,35 +1,26 @@
-name: Build and Test
+name: CI
 
 on:
   push:
-    branches: ["main", "development"]
+    branches: [main]
   pull_request:
-    branches: ["main", "development"]
+    branches: [main]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.12"]
-
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install poetry
+      - name: Install and test
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-      - name: Install dependencies
-        run: |
-          # Ensure dependencies are installed without relying on a lock file.
-          poetry update
-          poetry install -E server
-      - name: Test with pytest
-        run: |
-          poetry run pytest -s -x -k test_
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          python -m pip install --upgrade pip
+          pip install -e ".[server]"
+          pip install pytest websockets requests
+          pytest -m "not integration"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "integration: requires an LLM API key (not run in default CI)"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if os.environ.get("OPENAI_API_KEY"):
+        return
+
+    skip_integration = pytest.mark.skip(
+        reason="OPENAI_API_KEY not set; skipping integration test"
+    )
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -83,6 +83,7 @@ def run_auth_server():
 
 
 # @pytest.mark.skip(reason="Requires uvicorn, which we don't require by default")
+@pytest.mark.integration
 def test_authenticated_acknowledging_breaking_server():
     """
     Test the server when we have authentication and acknowledging one.
@@ -237,6 +238,7 @@ def run_server():
 
 
 # @pytest.mark.skip(reason="Requires uvicorn, which we don't require by default")
+@pytest.mark.integration
 def test_server():
     # Start the server in a new process
 
@@ -686,10 +688,12 @@ def test_pytes():
     assert False
 
 
+@pytest.mark.integration
 def test_ai_chat():
     print(interpreter.computer.ai.chat("hi"))
 
 
+@pytest.mark.integration
 def test_generator():
     """
     Sends two messages, makes sure everything is correct with display both on and off.
@@ -1020,6 +1024,7 @@ def test_i():
     assert full_response != ""
 
 
+@pytest.mark.integration
 def test_async():
     interpreter.chat("Hello!", blocking=False)
     print(interpreter.wait())
@@ -1123,6 +1128,7 @@ def test_spotlight():
     interpreter.computer.keyboard.hotkey("command", "space")
 
 
+@pytest.mark.integration
 def test_files():
     messages = [
         {"role": "user", "type": "message", "content": "Does this file exist?"},
@@ -1174,6 +1180,7 @@ def test_multiple_instances():
     assert agent_2.system_message == "u"
 
 
+@pytest.mark.integration
 def test_hello_world():
     hello_world_response = "Hello, World!"
 
@@ -1186,6 +1193,7 @@ def test_hello_world():
     ]
 
 
+@pytest.mark.integration
 def test_math():
     # we'll generate random integers between this min and max in our math tests
     min_number = randint(1, 99)
@@ -1262,18 +1270,21 @@ with open('numbers.txt', 'a+') as f:
     assert "5" not in content
 
 
+@pytest.mark.integration
 def test_delayed_exec():
     interpreter.chat(
         """Can you write a single block of code and execute it that prints something, then delays 1 second, then prints something else? No talk just code, execute the code. Thanks!"""
     )
 
 
+@pytest.mark.integration
 def test_nested_loops_and_multiple_newlines():
     interpreter.chat(
         """Can you write a nested for loop in python and shell and run them? Don't forget to properly format your shell script and use semicolons where necessary. Also put 1-3 newlines between each line in the code. Only generate and execute the code. Yes, execute the code instantly! No explanations. Thanks!"""
     )
 
 
+@pytest.mark.integration
 def test_write_to_file():
     interpreter.chat(
         """Write the word 'Washington' to a .txt file called file.txt. Instantly run the code! Save the file!"""
@@ -1286,6 +1297,7 @@ def test_write_to_file():
     assert "Washington" in messages[-1]["content"]
 
 
+@pytest.mark.integration
 def test_markdown():
     interpreter.chat(
         """Hi, can you test out a bunch of markdown features? Try writing a fenced code block, a table, headers, everything. DO NOT write the markdown inside a markdown code block, just write it raw."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Minimal CI only — **3 files**, no ruff config, no AGENTS.md, no README badge, no Codecov.

## Changes

1. **`.github/workflows/python-package.yml`** — `main` only; `pip install -e ".[server]"`; `pytest -m "not integration"` on Python 3.10 and 3.12
2. **`tests/conftest.py`** — register `integration` marker; skip those tests when `OPENAI_API_KEY` unset
3. **`tests/test_interpreter.py`** — `@pytest.mark.integration` on 12 tests that call a real LLM

## Result

13 unit tests pass with no API key. Integration tests are skipped (not failed).

Follow-up PRs (separate): lint/ruff, mock LLM server, OpenRouter integration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

