### PR TITLE
CI: add ruff lint job

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Lint and Test
 
 on:
   push:
@@ -7,7 +7,19 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Ruff
+        run: |
+          pip install ruff
+          ruff check interpreter tests
+
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,32 @@ target-version = ['py311']
 profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+exclude = ["examples"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+ignore = [
+    "E401",
+    "E402",
+    "E711",
+    "E712",
+    "E713",
+    "E721",
+    "E722",
+    "E741",
+    "F401",
+    "F541",
+    "F811",
+    "F841",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"interpreter/core/computer/display/display.py" = ["F821"]
+"interpreter/core/computer/display/point/point.py" = ["F821"]
+"interpreter/core/llm/utils/convert_to_openai_messages.py" = ["F821"]
+"interpreter/core/respond.py" = ["F821"]
+"tests/test_interpreter.py" = ["F821"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a separate `lint` job running `ruff check interpreter tests` and minimal `[tool.ruff]` config in `pyproject.toml`.

**Merge after #16** (unit-test CI). Does not change test behavior.

Stack: #16 → this PR → mock LLM (#TBD) → OpenRouter smoke (#TBD).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

