### PR TITLE
CI: mock OpenAI-compatible server for local LLM tests

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Jobs, Python versions, and pytest commands: `.github/workflows/python-package.ym
 
 | Job | Runner | What runs |
 | --- | --- | --- |
-| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite + `linux_ci` language smokes (`tests/test_language_subprocess.py`) |
+| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite + `linux_ci` language smokes; includes `mock_llm` (local HTTP server, no API key) |
 | **Integration** | `ubuntu-latest` | `pytest -m integration` (same-repo PRs and `main` only) |
 | **Windows CI smoke** | `windows-latest` | `pytest -m windows_ci` (`tests/test_platform_ci.py`) |
 | **macOS CI smoke** | `macos-latest` | `pytest -m darwin_ci` (`tests/test_platform_ci.py`) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ ignore = [
 pythonpath = ["."]
 markers = [
     "integration: calls an LLM, costs money, and executes generated code without approval; requires OI_RUN_INTEGRATION=1 and OPENAI_API_KEY",
+    "mock_llm: uses a local OpenAI-compatible HTTP server (no API key)",
     "timeout(duration): fail if the test runs longer than duration seconds (pytest-timeout)",
     "linux_ci: runs on Linux CI and locally on Linux hosts",
     "windows_ci: runs on Windows CI and locally on Windows hosts",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,10 @@ def pytest_configure(config):
         "integration: calls an LLM and may execute generated code; "
         "requires OI_RUN_INTEGRATION=1 and OPENAI_API_KEY",
     )
+    config.addinivalue_line(
+        "markers",
+        "mock_llm: uses a local OpenAI-compatible HTTP server (no API key)",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/support/mock_openai_server.py
+++ b/tests/support/mock_openai_server.py
@@ -1,0 +1,79 @@
+"""Minimal OpenAI-compatible chat API for CI (no real LLM)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class _Handler(BaseHTTPRequestHandler):
+    reply_text = "Hello, World!"
+
+    def log_message(self, format, *args):  # noqa: A003
+        return
+
+    def do_POST(self):  # noqa: N802
+        if self.path not in ("/v1/chat/completions", "/chat/completions"):
+            self.send_error(404)
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length)) if length else {}
+        stream = body.get("stream", False)
+        content = self.reply_text
+
+        if stream:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunk = {
+                "choices": [{"delta": {"content": content}, "finish_reason": None}],
+            }
+            self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+            done = {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+            self.wfile.write(f"data: {json.dumps(done)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            return
+
+        payload = {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+        data = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+class MockOpenAIServer:
+    """In-process HTTP server that mimics OpenAI chat completions for tests."""
+
+    def __init__(self, reply_text: str = "Hello, World!"):
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        _Handler.reply_text = reply_text
+
+    @property
+    def api_base(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("server not started")
+        host, port = self._httpd.server_address
+        return f"http://{host}:{port}/v1"
+
+    def start(self):
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+            self._httpd = None

--- a/tests/test_mock_llm.py
+++ b/tests/test_mock_llm.py
@@ -1,0 +1,32 @@
+import pytest
+
+from interpreter import OpenInterpreter
+from tests.support.mock_openai_server import MockOpenAIServer
+
+pytestmark = pytest.mark.mock_llm
+
+
+@pytest.fixture
+def mock_llm_server():
+    """Start a local OpenAI-compatible server for the duration of a test."""
+    server = MockOpenAIServer(reply_text="Hello, World!")
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.mark.timeout(60)
+def test_chat_uses_mock_openai_api(mock_llm_server):
+    """chat() completes against a local OpenAI-compatible server without a real API key."""
+    interpreter = OpenInterpreter(disable_telemetry=True)
+    interpreter.llm.model = "openai/gpt-4o-mini"
+    interpreter.llm.api_base = mock_llm_server.api_base
+    interpreter.llm.api_key = "mock-key"
+    interpreter.llm.supports_functions = False
+    interpreter.llm._is_loaded = False
+
+    messages = interpreter.chat("Say hello.", display=False, stream=False, blocking=True)
+
+    assert messages[-1]["content"] == "Hello, World!"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto current `main` (single atomic commit).

## Evaluation

**Worth merging** — this is the base of the provider-port CI stack (#18 → #19). `main` has no OpenRouter/reasoning/DeepSeek LLM code yet; when that port lands from `classic/develop`, we need a way to exercise `interpreter.chat()` → LiteLLM without `OPENAI_API_KEY`. This PR provides that.

## What changed vs the original PR

- Rebased cleanly onto current CI (`python-package.yml` matrix, `conftest.py` integration gating, `pyproject.toml` markers).
- **No separate `test-mock-llm` workflow job** — the `mock_llm` test runs in the existing Linux unit-test matrix (no API key, ~3s). Simpler than duplicating install steps.
- Test hardened: `disable_telemetry=True`, `display=False`, `pytest.mark.timeout(60)`, docstrings per AGENTS.md.
- Registered `mock_llm` marker in `pyproject.toml` and `conftest.py`.

## Files

- `tests/support/mock_openai_server.py` — ThreadingHTTPServer, streaming + non-streaming `/v1/chat/completions`
- `tests/test_mock_llm.py` — one end-to-end `chat()` smoke against the mock
- `docs/CONTRIBUTING.md` — note that unit tests include `mock_llm`

**Next:** #19 (OpenRouter smoke) should rebase on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

