### PR TITLE
CI: OpenRouter smoke test (secret-gated)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,3 +24,17 @@ jobs:
           pip install -e ".[server]"
           pip install pytest websockets requests
           pytest -m "not integration"
+
+  test-mock-llm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Mock LLM tests
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[server]"
+          pip install pytest websockets requests
+          pytest -m mock_llm

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -38,3 +38,24 @@ jobs:
           pip install -e ".[server]"
           pip install pytest websockets requests
           pytest -m mock_llm
+
+  test-openrouter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: OpenRouter smoke tests
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OI_CI_MODEL: openrouter/openrouter/free
+        run: |
+          if [ -z "$OPENROUTER_API_KEY" ]; then
+            echo "OPENROUTER_API_KEY not configured; skipping openrouter smoke tests"
+            exit 0
+          fi
+          python -m pip install --upgrade pip
+          pip install -e ".[server]"
+          pip install pytest websockets requests
+          pytest -m openrouter -v

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "integration: requires an LLM API key (not run in default CI)"
     )
+    config.addinivalue_line(
+        "markers", "mock_llm: uses local mock OpenAI-compatible HTTP server"
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,15 +10,25 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "mock_llm: uses local mock OpenAI-compatible HTTP server"
     )
+    config.addinivalue_line(
+        "markers",
+        "openrouter: requires OPENROUTER_API_KEY (optional CI smoke test)",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    if os.environ.get("OPENAI_API_KEY"):
-        return
+    if not os.environ.get("OPENAI_API_KEY"):
+        skip_integration = pytest.mark.skip(
+            reason="OPENAI_API_KEY not set; skipping integration test"
+        )
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_integration)
 
-    skip_integration = pytest.mark.skip(
-        reason="OPENAI_API_KEY not set; skipping integration test"
-    )
-    for item in items:
-        if "integration" in item.keywords:
-            item.add_marker(skip_integration)
+    if not os.environ.get("OPENROUTER_API_KEY"):
+        skip_openrouter = pytest.mark.skip(
+            reason="OPENROUTER_API_KEY not set; skipping openrouter smoke test"
+        )
+        for item in items:
+            if "openrouter" in item.keywords:
+                item.add_marker(skip_openrouter)

--- a/tests/support/mock_openai_server.py
+++ b/tests/support/mock_openai_server.py
@@ -1,0 +1,77 @@
+"""Minimal OpenAI-compatible chat API for CI (no real LLM)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class _Handler(BaseHTTPRequestHandler):
+    reply_text = "Hello, World!"
+
+    def log_message(self, format, *args):  # noqa: A003
+        return
+
+    def do_POST(self):  # noqa: N802
+        if self.path not in ("/v1/chat/completions", "/chat/completions"):
+            self.send_error(404)
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length)) if length else {}
+        stream = body.get("stream", False)
+        content = self.reply_text
+
+        if stream:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunk = {
+                "choices": [{"delta": {"content": content}, "finish_reason": None}],
+            }
+            self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+            done = {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+            self.wfile.write(f"data: {json.dumps(done)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            return
+
+        payload = {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+        data = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+class MockOpenAIServer:
+    def __init__(self, reply_text: str = "Hello, World!"):
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        _Handler.reply_text = reply_text
+
+    @property
+    def api_base(self) -> str:
+        if self._httpd is None:
+            raise RuntimeError("server not started")
+        host, port = self._httpd.server_address
+        return f"http://{host}:{port}/v1"
+
+    def start(self):
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+            self._httpd = None

--- a/tests/test_mock_llm.py
+++ b/tests/test_mock_llm.py
@@ -1,0 +1,32 @@
+import pytest
+
+from interpreter import OpenInterpreter
+from tests.support.mock_openai_server import MockOpenAIServer
+
+pytestmark = pytest.mark.mock_llm
+
+
+@pytest.fixture
+def mock_llm_server():
+    server = MockOpenAIServer(reply_text="Hello, World!")
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def test_chat_uses_mock_openai_api(mock_llm_server):
+    interpreter = OpenInterpreter()
+    interpreter.llm.model = "openai/gpt-4o-mini"
+    interpreter.llm.api_base = mock_llm_server.api_base
+    interpreter.llm.api_key = "mock-key"
+    interpreter.llm.supports_functions = False
+    interpreter.llm._is_loaded = False
+
+    messages = interpreter.chat(
+        "Please reply with just the words Hello, World! and nothing else. "
+        "Do not run code."
+    )
+
+    assert messages[-1]["content"] == "Hello, World!"

--- a/tests/test_openrouter_smoke.py
+++ b/tests/test_openrouter_smoke.py
@@ -1,0 +1,22 @@
+import os
+
+import pytest
+
+from interpreter import OpenInterpreter
+
+pytestmark = pytest.mark.openrouter
+
+CI_MODEL = os.environ.get("OI_CI_MODEL", "openrouter/openrouter/free")
+
+
+def test_openrouter_simple_chat():
+    interpreter = OpenInterpreter()
+    interpreter.llm.model = CI_MODEL
+    interpreter.llm.supports_functions = False
+    interpreter.llm._is_loaded = False
+
+    messages = interpreter.chat(
+        "Reply with exactly the word pong and nothing else. Do not run code."
+    )
+
+    assert "pong" in messages[-1]["content"].lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Optional live smoke test against OpenRouter's free model tier.

- `@pytest.mark.openrouter` on `tests/test_openrouter_smoke.py`
- `conftest.py` skips openrouter tests when `OPENROUTER_API_KEY` is unset
- `test-openrouter` CI job exits 0 when the secret is missing; runs `pytest -m openrouter` when `OPENROUTER_API_KEY` is configured in repo secrets

Uses `OI_CI_MODEL=openrouter/openrouter/free` in CI.

**Merge after mock LLM PR.** Requires adding `OPENROUTER_API_KEY` to repo secrets for the job to actually run live tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-064d369e-95d6-47fe-a4d5-ff4043256eeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

