### PR TITLE
docs: overhaul README intro, comparisons, and ownership notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 > [!NOTE]
-> This is the **community-maintained Python version** of Open Interpreter. The original project has been rewritten in Rust and now focuses on codebase agents — see [openinterpreter/open-interpreter](https://github.com/openinterpreter/open-interpreter) ([openinterpreter.com](https://openinterpreter.com)). This fork continues the classic Python implementation. It is **not** affiliated with openinterpreter.com, and is not currently published to PyPI.
+> This is the **community-maintained Python version** of Open Interpreter. The original project has been rewritten in Rust and now focuses on codebase agents — see [openinterpreter/open-interpreter](https://github.com/openinterpreter/open-interpreter).
 
 <br>
 
@@ -26,17 +26,17 @@
 
 <br>
 
-**Open Interpreter** is an interactive terminal session where an LLM runs code and shell commands **on your machine** — Python, JavaScript, Bash, cmd, PowerShell, Ruby, R, Java, and more. Run `interpreter` after installing.
+**Open Interpreter** lets LLMs run code and shell commands locally — Python, JavaScript, Bash, cmd, PowerShell, Ruby, R, Java, and more. You use it through a **chatbot interface** in your terminal; run `interpreter` after installing.
 
-It is closest to hosted **Code Interpreter** tools ([OpenAI](https://developers.openai.com/api/docs/guides/tools-code-interpreter), [Mistral](https://docs.mistral.ai/studio-api/agents/agent-tools/code_interpreter), [Grok](https://docs.x.ai/developers/tools/code-execution), Gemini, etc.), but **local**: your full filesystem (not just one project folder), no upload/download step, persistent sessions you can return to days later, and the ability to run `sudo`, install packages, and use any CLI tool. Unlike those cloud sandboxes, **this is not sandboxed by default** — powerful and convenient, but dangerous if you are not paying attention.
+It is closest to hosted **Code Interpreter** tools ([OpenAI](https://developers.openai.com/api/docs/guides/tools-code-interpreter), [Mistral](https://docs.mistral.ai/studio-api/agents/agent-tools/code_interpreter), [Grok](https://docs.x.ai/developers/tools/code-execution), Gemini, etc.), but **on your machine**: your full filesystem (not just one project folder), no upload/download step, persistent sessions you can return to days later, and the ability to run `sudo`, install packages, and use any CLI tool. Unlike those cloud sandboxes, **this is not sandboxed by default** — powerful and convenient, but dangerous if you are not paying attention.
 
 | Compared to… | Open Interpreter |
 |---|---|
 | **Coding agents** (Claude Code, Cursor, Windsurf) | Less about patching a codebase; more about **one-off tasks** in a persistent, REPL-like session (closer to a Jupyter notebook than an IDE). |
 | **MCP-based agents** | Does not route work through MCP tool calls — it **runs code directly**. No MCP client support today. |
-| **[shell_gpt](https://github.com/ther1d/shell_gpt)** | Also translates natural language into shell commands, but with a **chat UI** where you can review, reject (`n`), or edit (`e`) code before it runs, and ask the model to revise. |
+| **Natural-language shell tools** | Also translate English into shell commands, but OI is a **chatbot** where you can review, reject (`n`), or edit (`e`) code before it runs, and ask the model to revise. |
 
-By default, OI asks before executing anything. Use `interpreter -y` or `interpreter.auto_run = True` to auto-approve (not recommended unless you know what you are doing).
+**⚠️ Note: You'll be asked to approve code before it's run.**
 
 Experimental [`safe_mode`](docs/SAFE_MODE.md) can scan code with semgrep, and an optional E2B profile can run Python in a remote sandbox — but **the default is full local access, with no isolation.**
 
@@ -69,7 +69,7 @@ Optional dependency groups (from `pyproject.toml`):
 pip install "open-interpreter[os,safe,local,server] @ git+https://github.com/endolith/open-interpreter.git"
 ```
 
-> An `open-interpreter` package may still exist on PyPI from the original project, but **this fork is not published there yet.** See [docs/getting-started/setup.mdx](docs/getting-started/setup.mdx) for optional dependencies and platform notes.
+> See [docs/getting-started/setup.mdx](docs/getting-started/setup.mdx) for optional dependencies and platform notes.
 
 ### Terminal
 
@@ -92,13 +92,20 @@ interpreter.chat() # Starts an interactive chat
 
 ### GitHub Codespaces
 
-Press the `,` key on this repository's GitHub page to create a codespace — a disposable cloud VM with open-interpreter pre-installed.
+Press the `,` key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.
 
 ## Comparison to hosted Code Interpreter
 
-Cloud **Code Interpreter** features (OpenAI, Mistral, Grok, Gemini, etc.) run code in a hosted, ephemeral sandbox: limited packages, upload size caps, timeouts, and state that disappears when the session ends.
+Hosted **Code Interpreter** features (OpenAI, Mistral, Grok, Gemini, etc.) run code in a remote, ephemeral sandbox that is hosted, closed-source, and heavily restricted:
 
-Open Interpreter runs on **your** machine instead — any package, any path on disk, shell commands and multiple languages, and conversation history that persists across sessions. The tradeoff is that **you** are responsible for what gets executed.
+- No internet access.
+- [Limited set of pre-installed packages](https://wfhbrian.com/artificial-intelligence/mastering-chatgpts-code-interpreter-list-of-python-packages/).
+- 100 MB maximum upload, 120.0 second runtime limit.
+- State is cleared (along with any generated files or links) when the environment dies.
+
+---
+
+Open Interpreter overcomes these limitations by running in your local environment. It has full access to the internet, isn't restricted by time or file size, can use any package or library, and supports shell commands and multiple languages beyond Python.
 
 ## Commands
 
@@ -400,4 +407,4 @@ Visit [our roadmap](docs/ROADMAP.md) to preview the future of Open Interpreter.
 
 > Having access to a junior programmer working at the speed of your fingertips ... can make new workflows effortless and efficient, as well as open the benefits of programming to new audiences.
 >
-> — _on the original release of OpenAI's Code Interpreter_
+> — _OpenAI's Code Interpreter Release_

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 > [!NOTE]
-> This is the **community-maintained Python version** of Open Interpreter. The original project has been rewritten in Rust and now focuses on codebase agents — see [openinterpreter/open-interpreter](https://github.com/openinterpreter/open-interpreter). This fork continues the classic Python implementation.
+> This is the **community-maintained Python version** of Open Interpreter. The original project has been rewritten in Rust and now focuses on codebase agents — see [openinterpreter/open-interpreter](https://github.com/openinterpreter/open-interpreter) ([openinterpreter.com](https://openinterpreter.com)). This fork continues the classic Python implementation. It is **not** affiliated with openinterpreter.com, and is not currently published to PyPI.
 
 <br>
 
@@ -26,7 +26,7 @@
 
 <br>
 
-**Open Interpreter** is a terminal chat where an LLM runs code and shell commands **on your machine** — Python, JavaScript, Bash, cmd, PowerShell, Ruby, R, Java, and more. Run `interpreter` after installing.
+**Open Interpreter** is an interactive terminal session where an LLM runs code and shell commands **on your machine** — Python, JavaScript, Bash, cmd, PowerShell, Ruby, R, Java, and more. Run `interpreter` after installing.
 
 It is closest to hosted **Code Interpreter** tools ([OpenAI](https://developers.openai.com/api/docs/guides/tools-code-interpreter), [Mistral](https://docs.mistral.ai/studio-api/agents/agent-tools/code_interpreter), [Grok](https://docs.x.ai/developers/tools/code-execution), Gemini, etc.), but **local**: your full filesystem (not just one project folder), no upload/download step, persistent sessions you can return to days later, and the ability to run `sudo`, install packages, and use any CLI tool. Unlike those cloud sandboxes, **this is not sandboxed by default** — powerful and convenient, but dangerous if you are not paying attention.
 
@@ -56,8 +56,6 @@ Experimental [`safe_mode`](docs/SAFE_MODE.md) can scan code with semgrep, and an
 
 ### Install
 
-From PyPI (may lag behind git):
-
 Install from this repository — **`main`** is the stable branch; **`classic/develop`** is the active development branch (reasoning models, OpenRouter/DeepSeek/Qwen, web search, etc.):
 
 ```shell
@@ -65,7 +63,13 @@ pip install git+https://github.com/endolith/open-interpreter.git              # 
 pip install git+https://github.com/endolith/open-interpreter.git@classic/develop  # bleeding edge
 ```
 
-> See [docs/getting-started/setup.mdx](docs/getting-started/setup.mdx) for optional dependencies and platform notes.
+Optional dependency groups (from `pyproject.toml`):
+
+```shell
+pip install "open-interpreter[os,safe,local,server] @ git+https://github.com/endolith/open-interpreter.git"
+```
+
+> An `open-interpreter` package may still exist on PyPI from the original project, but **this fork is not published there yet.** See [docs/getting-started/setup.mdx](docs/getting-started/setup.mdx) for optional dependencies and platform notes.
 
 ### Terminal
 
@@ -88,11 +92,11 @@ interpreter.chat() # Starts an interactive chat
 
 ### GitHub Codespaces
 
-Press the <kbd>,</kbd> key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.
+Press the `,` key on this repository's GitHub page to create a codespace — a disposable cloud VM with open-interpreter pre-installed.
 
-## Comparison to ChatGPT's Code Interpreter
+## Comparison to hosted Code Interpreter
 
-OpenAI's [Code Interpreter](https://openai.com/blog/chatgpt-plugins#code-interpreter) runs Python in a hosted, ephemeral sandbox: limited packages, upload size caps, timeouts, and state that disappears when the session ends.
+Cloud **Code Interpreter** features (OpenAI, Mistral, Grok, Gemini, etc.) run code in a hosted, ephemeral sandbox: limited packages, upload size caps, timeouts, and state that disappears when the session ends.
 
 Open Interpreter runs on **your** machine instead — any package, any path on disk, shell commands and multiple languages, and conversation history that persists across sessions. The tradeoff is that **you** are responsible for what gets executed.
 
@@ -352,9 +356,9 @@ Open Interpreter sends your conversation to an LLM (via [LiteLLM](https://docs.l
 
 Code runs in **persistent sessions**: a Jupyter kernel for Python, subprocesses for Shell/PowerShell/JavaScript/etc. Output is streamed back to the model until the task is done or you stop it. On Windows, `Shell` uses `cmd.exe`; `PowerShell` uses `powershell.exe` (or `pwsh` on other platforms).
 
-## Access Documentation Offline
+## Documentation
 
-The full [documentation](docs) is accessible on-the-go without the need for an internet connection.
+Docs live in the [`docs/`](docs/) folder in this repo (Markdown/MDX, originally set up for [Mintlify](https://mintlify.com/)). Browse on GitHub, or run a local preview server:
 
 [Node](https://nodejs.org/en) is a pre-requisite:
 
@@ -396,4 +400,4 @@ Visit [our roadmap](docs/ROADMAP.md) to preview the future of Open Interpreter.
 
 > Having access to a junior programmer working at the speed of your fingertips ... can make new workflows effortless and efficient, as well as open the benefits of programming to new audiences.
 >
-> — _OpenAI's Code Interpreter Release_
+> — _on the original release of OpenAI's Code Interpreter_

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@
     <a href="https://codecov.io/gh/endolith/open-interpreter">
         <img alt="codecov" src="https://codecov.io/gh/endolith/open-interpreter/branch/main/graph/badge.svg"/></a>
     <br>
-    <br><a href="https://www.openinterpreter.com/">Desktop App</a> | <a href="https://github.com/openinterpreter/openinterpreter">Open Interpreter (Rust)</a> | <a href="docs">Documentation</a><br>
+    <br><a href="docs/getting-started/setup.mdx">Setup</a> · <a href="docs/">Documentation</a><br>
 </p>
+
+> [!NOTE]
+> This is the **community-maintained Python version** of Open Interpreter. The original project has been rewritten in Rust and now focuses on codebase agents — see [openinterpreter/open-interpreter](https://github.com/openinterpreter/open-interpreter). This fork continues the classic Python implementation.
 
 <br>
 
@@ -23,16 +26,19 @@
 
 <br>
 
-**Open Interpreter** lets LLMs run code (Python, Javascript, Shell, and more) locally. You can chat with Open Interpreter through a ChatGPT-like interface in your terminal by running `$ interpreter` after installing.
+**Open Interpreter** is a terminal chat where an LLM runs code and shell commands **on your machine** — Python, JavaScript, Bash, cmd, PowerShell, Ruby, R, Java, and more. Run `interpreter` after installing.
 
-This provides a natural-language interface to your computer's general-purpose capabilities:
+It is closest to hosted **Code Interpreter** tools ([OpenAI](https://developers.openai.com/api/docs/guides/tools-code-interpreter), [Mistral](https://docs.mistral.ai/studio-api/agents/agent-tools/code_interpreter), [Grok](https://docs.x.ai/developers/tools/code-execution), Gemini, etc.), but **local**: your full filesystem (not just one project folder), no upload/download step, persistent sessions you can return to days later, and the ability to run `sudo`, install packages, and use any CLI tool. Unlike those cloud sandboxes, **this is not sandboxed by default** — powerful and convenient, but dangerous if you are not paying attention.
 
-- Create and edit photos, videos, PDFs, etc.
-- Control a Chrome browser to perform research
-- Plot, clean, and analyze large datasets
-- ...etc.
+| Compared to… | Open Interpreter |
+|---|---|
+| **Coding agents** (Claude Code, Cursor, Windsurf) | Less about patching a codebase; more about **one-off tasks** in a persistent, REPL-like session (closer to a Jupyter notebook than an IDE). |
+| **MCP-based agents** | Does not route work through MCP tool calls — it **runs code directly**. No MCP client support today. |
+| **[shell_gpt](https://github.com/ther1d/shell_gpt)** | Also translates natural language into shell commands, but with a **chat UI** where you can review, reject (`n`), or edit (`e`) code before it runs, and ask the model to revise. |
 
-**⚠️ Note: You'll be asked to approve code before it's run.**
+By default, OI asks before executing anything. Use `interpreter -y` or `interpreter.auto_run = True` to auto-approve (not recommended unless you know what you are doing).
+
+Experimental [`safe_mode`](docs/SAFE_MODE.md) can scan code with semgrep, and an optional E2B profile can run Python in a remote sandbox — but **the default is full local access, with no isolation.**
 
 ## Demo
 
@@ -50,23 +56,16 @@ This provides a natural-language interface to your computer's general-purpose ca
 
 ### Install
 
-This repository is Endolith's fork of the classic Python Open Interpreter.
+From PyPI (may lag behind git):
 
-This command will install **`main`** which is the default branch (stable base, CI, and merge target for ported changes):
-
-```shell
-pip install git+https://github.com/endolith/open-interpreter.git
-```
-
-> See our [setup guide](docs/getting-started/setup.mdx) for optional dependencies.
-
-For day-to-day use, however, you probably want to install **`classic/develop`** instead — that's the unstable branch maintained and used daily, with many changes and features vs the main branch, such as support for reasoning models, OpenRouter/DeepSeek/Qwen, web search tools, etc.:
+Install from this repository — **`main`** is the stable branch; **`classic/develop`** is the active development branch (reasoning models, OpenRouter/DeepSeek/Qwen, web search, etc.):
 
 ```shell
-pip install git+https://github.com/endolith/open-interpreter.git@classic/develop
+pip install git+https://github.com/endolith/open-interpreter.git              # main
+pip install git+https://github.com/endolith/open-interpreter.git@classic/develop  # bleeding edge
 ```
 
-For fork-specific features, model notes, and setup details, see the [`classic/develop` README](https://github.com/endolith/open-interpreter/blob/classic/develop/README.md).
+> See [docs/getting-started/setup.mdx](docs/getting-started/setup.mdx) for optional dependencies and platform notes.
 
 ### Terminal
 
@@ -93,20 +92,9 @@ Press the <kbd>,</kbd> key on this repository's GitHub page to create a codespac
 
 ## Comparison to ChatGPT's Code Interpreter
 
-OpenAI's release of [Code Interpreter](https://openai.com/blog/chatgpt-plugins#code-interpreter) with GPT-4 presents a fantastic opportunity to accomplish real-world tasks with ChatGPT.
+OpenAI's [Code Interpreter](https://openai.com/blog/chatgpt-plugins#code-interpreter) runs Python in a hosted, ephemeral sandbox: limited packages, upload size caps, timeouts, and state that disappears when the session ends.
 
-However, OpenAI's service is hosted, closed-source, and heavily restricted:
-
-- No internet access.
-- [Limited set of pre-installed packages](https://wfhbrian.com/artificial-intelligence/mastering-chatgpts-code-interpreter-list-of-python-packages/).
-- 100 MB maximum upload, 120.0 second runtime limit.
-- State is cleared (along with any generated files or links) when the environment dies.
-
----
-
-Open Interpreter overcomes these limitations by running in your local environment. It has full access to the internet, isn't restricted by time or file size, and can utilize any package or library.
-
-This combines the power of GPT-4's Code Interpreter with the flexibility of your local development environment.
+Open Interpreter runs on **your** machine instead — any package, any path on disk, shell commands and multiple languages, and conversation history that persists across sessions. The tradeoff is that **you** are responsible for what gets executed.
 
 ## Commands
 
@@ -184,15 +172,15 @@ Open Interpreter uses [LiteLLM](https://docs.litellm.ai/docs/providers/) to conn
 You can change the model by setting the model parameter:
 
 ```shell
-interpreter --model gpt-3.5-turbo
-interpreter --model claude-2
-interpreter --model command-nightly
+interpreter --model gpt-4o-mini
+interpreter --model claude-sonnet-4-6
+interpreter --model ollama/llama3.1
 ```
 
 In Python, set the model on the object:
 
 ```python
-interpreter.llm.model = "gpt-3.5-turbo"
+interpreter.llm.model = "gpt-4o-mini"
 ```
 
 [Find the appropriate "model" string for your language model here.](https://docs.litellm.ai/docs/providers/)
@@ -235,7 +223,7 @@ Our Python package gives you more control over each setting. To replicate and co
 ```python
 from interpreter import interpreter
 
-interpreter.offline = True # Disables online features like Open Procedures
+interpreter.offline = True # Disables online features (e.g. update checks)
 interpreter.llm.model = "openai/x" # Tells OI to send messages in OpenAI's format
 interpreter.llm.api_key = "fake_key" # LiteLLM, which we use to talk to LM Studio, requires this
 interpreter.llm.api_base = "http://localhost:1234/v1" # Point this at any OpenAI compatible server
@@ -340,7 +328,7 @@ pip install fastapi uvicorn
 uvicorn server:app --reload
 ```
 
-You can also start a server identical to the one above by simply running `interpreter.server()`.
+You can also start a built-in server with `interpreter --server` (uses `AsyncInterpreter` under the hood; requires the `[server]` extra).
 
 ## Android
 
@@ -348,23 +336,21 @@ The step-by-step guide for installing Open Interpreter on your Android device ca
 
 ## Safety Notice
 
-Since generated code is executed in your local environment, it can interact with your files and system settings, potentially leading to unexpected outcomes like data loss or security risks.
+**Open Interpreter is not sandboxed.** Generated code runs in your real environment with the same privileges as your user — it can read, write, and delete files anywhere you have access, run shell commands (including `sudo` if you approve them), and install software.
 
-**⚠️ Open Interpreter will ask for user confirmation before executing code.**
+By default, OI asks for confirmation before each code block (`y` to run, `n` to decline and let the model revise, `e` to edit the code yourself). You can bypass this with `interpreter -y` or `interpreter.auto_run = True`.
 
-You can run `interpreter -y` or set `interpreter.auto_run = True` to bypass this confirmation, in which case:
+- Treat it like handing your keyboard to someone else.
+- Be especially careful with destructive commands and credentials.
+- For isolation, consider Google Colab, an E2B profile, or your own VM — not the default setup.
 
-- Be cautious when requesting commands that modify files or system settings.
-- Watch Open Interpreter like a self-driving car, and be prepared to end the process by closing your terminal.
-- Consider running Open Interpreter in a restricted environment like Google Colab or Replit. These environments are more isolated, reducing the risks of executing arbitrary code.
-
-There is **experimental** support for a [safe mode](docs/SAFE_MODE.md) to help mitigate some risks.
+There is **experimental** support for [safe mode](docs/SAFE_MODE.md) (semgrep code scanning). It does not provide a sandbox.
 
 ## How Does it Work?
 
-Open Interpreter equips a [function-calling language model](https://platform.openai.com/docs/guides/function-calling) with an `exec()` function, which accepts a `language` (like "Python" or "JavaScript") and `code` to run.
+Open Interpreter sends your conversation to an LLM (via [LiteLLM](https://docs.litellm.ai/docs/providers/)). The model responds with markdown code blocks, or — on models that support it — an `execute` tool call with a `language` and `code`.
 
-We then stream the model's messages, code, and your system's outputs to the terminal as Markdown.
+Code runs in **persistent sessions**: a Jupyter kernel for Python, subprocesses for Shell/PowerShell/JavaScript/etc. Output is streamed back to the model until the task is done or you stop it. On Windows, `Shell` uses `cmd.exe`; `PowerShell` uses `powershell.exe` (or `pwsh` on other platforms).
 
 ## Access Documentation Offline
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Describe the changes you have made:

Overhauls the README for the community-maintained Python fork:

- Rewrites the opening to explain what OI is vs hosted Code Interpreter, coding agents, MCP tools, and natural-language shell tools
- Uses **chatbot interface** wording; restores the approval warning
- Clarifies unsandboxed local execution (bash/cmd/PowerShell/Python/etc.)
- Points docs/setup links to in-repo `docs/` instead of docs.openinterpreter.com
- Install from git (`endolith/open-interpreter`); removes stale openinterpreter.com/typeform links
- Restores full hosted Code Interpreter comparison (internet access, package limits, timeouts, ephemeral state)
- Restores full GitHub Codespaces instructions
- Fixes outdated technical details (How it Works, magic commands, model examples, `interpreter --server`, etc.)

### Reference any relevant issues (e.g. "Fixes #000"):

N/A — documentation only.

### Pre-Submission Checklist (optional but appreciated):

- [x] I have included relevant documentation updates (stored in /docs)
- [ ] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4932699-d76d-40e6-9714-1ec2635fbde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4932699-d76d-40e6-9714-1ec2635fbde3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

