### PR TITLE
Fix sed edit tool cross-drive failure on Windows

### DIFF
--- a/interpreter/core/tools/file_edit.py
+++ b/interpreter/core/tools/file_edit.py
@@ -8,6 +8,13 @@ Each runner is a thin wrapper that:
 
 Binary resolution mirrors resolve_bash.py: env-var override → PATH → Git usr/bin on Windows.
 The model never constructs shell command strings; flags and temp-file hygiene live here.
+
+In-place edit strategies (Windows cross-drive safety):
+  - stdout + atomic replace: sed, jq, yq, comby — tool emits the new file; we write a
+    temp sibling in the target's parent directory and os.replace().
+  - cwd in target's parent: gawk, patch — tool must edit in place (e.g. gawk without
+    print); run with cwd set to the target directory so tool temps stay on that drive.
+  - direct open: poke (binary), write (new files only).
 """
 
 import json
@@ -164,7 +171,17 @@ def _subprocess_text(result):
     return ((result.stdout or "") + (result.stderr or "")).strip()
 
 
+def _target_parent_dir(target):
+    """Parent directory of target; use as subprocess cwd for in-place tools on Windows."""
+    return str(Path(target).parent)
+
+
 def _atomic_replace_from_stdout(target, stdout_bytes):
+    """Write tool stdout into target atomically via a temp file in the target's directory.
+
+    Standard pattern for edit runners whose tool emits the full new file on stdout.
+    Keeps temp files on the same drive as the target (Windows cannot rename across drives).
+    """
     path = Path(target)
     fd, tmp = tempfile.mkstemp(
         suffix=path.suffix, prefix=path.name + ".", dir=str(path.parent)
@@ -231,10 +248,7 @@ def run_sed(target, code):
             os.remove(script_path)
 
     if result.returncode != 0:
-        raise RuntimeError(
-            _subprocess_text(result)
-            or f"sed exited with code {result.returncode}"
-        )
+        _run_failed("sed", result)
     _atomic_replace_from_stdout(target, result.stdout or b"")
     return "sed: OK"
 
@@ -256,19 +270,15 @@ def run_gawk(target, code):
         result = subprocess.run(
             [gawk, "-i", "inplace", "-f", prog_path, path.name],
             capture_output=True,
-            text=True,
-            cwd=str(path.parent),
+            cwd=_target_parent_dir(target),
         )
     finally:
         if os.path.isfile(prog_path):
             os.remove(prog_path)
 
     if result.returncode != 0:
-        raise RuntimeError(
-            (result.stderr or result.stdout or "").strip()
-            or f"gawk exited with code {result.returncode}"
-        )
-    out = (result.stdout or "").strip()
+        _run_failed("gawk", result)
+    out = _subprocess_text(result)
     return out if out else "gawk: OK"
 
 
@@ -279,32 +289,18 @@ def run_jq(target, code):
         raise ValueError("jq: no filter in code")
 
     jq = _resolve_jq()
-    path = Path(target)
-
-    # Write to a sibling temp file so os.replace() is atomic on the same filesystem
     filter_path = _write_temp_script(code, ".jq")
-    fd, tmp = tempfile.mkstemp(
-        suffix=path.suffix, prefix=path.name + ".", dir=str(path.parent)
-    )
-    os.close(fd)
     try:
         result = subprocess.run(
             [jq, "-f", filter_path, target],
             capture_output=True,
         )
         if result.returncode != 0:
-            raise RuntimeError(
-                _subprocess_text(result)
-                or f"jq exited with code {result.returncode}"
-            )
-        Path(tmp).write_bytes(result.stdout or b"")
-        os.replace(tmp, target)
-        tmp = None  # consumed; don't delete in finally
+            _run_failed("jq", result)
+        _atomic_replace_from_stdout(target, result.stdout or b"")
     finally:
         if os.path.isfile(filter_path):
             os.remove(filter_path)
-        if tmp and os.path.isfile(tmp):
-            os.remove(tmp)
 
     return "jq: OK"
 
@@ -354,24 +350,14 @@ def run_yq(target, code):
     path = Path(target)
     had_content = path.stat().st_size > 0
 
-    fd, tmp = tempfile.mkstemp(
-        suffix=path.suffix, prefix=path.name + ".", dir=str(path.parent)
-    )
-    os.close(fd)
-    try:
-        result = _run_yq_eval(yq, expr, target)
-        out = result.stdout or b""
-        if had_content and not out.strip():
-            raise RuntimeError(
-                "yq produced no output for a non-empty file "
-                "(file was not modified; check the expression)"
-            )
-        Path(tmp).write_bytes(out)
-        os.replace(tmp, target)
-        tmp = None
-    finally:
-        if tmp and os.path.isfile(tmp):
-            os.remove(tmp)
+    result = _run_yq_eval(yq, expr, target)
+    out = result.stdout or b""
+    if had_content and not out.strip():
+        raise RuntimeError(
+            "yq produced no output for a non-empty file "
+            "(file was not modified; check the expression)"
+        )
+    _atomic_replace_from_stdout(target, out)
 
     return "yq: OK"
 
@@ -520,14 +506,10 @@ def run_patch(target, code):
         [patch_bin, "-p0", "--forward", path.name],
         input=diff.encode("utf-8"),
         capture_output=True,
-        cwd=str(path.parent),
+        cwd=_target_parent_dir(target),
     )
     if result.returncode != 0:
-        stderr = (result.stderr or b"").decode("utf-8", errors="replace")
-        stdout = (result.stdout or b"").decode("utf-8", errors="replace")
-        raise RuntimeError(
-            (stderr or stdout).strip() or f"patch exited with code {result.returncode}"
-        )
+        _run_failed("patch", result)
     out = _subprocess_text(result)
     return out if out else "patch: OK"
 
@@ -569,7 +551,7 @@ def dry_run_edit(language, code, target):
             [patch_bin, "-p0", "--forward", "--dry-run", path.name],
             input=diff.encode("utf-8"),
             capture_output=True,
-            cwd=str(path.parent),
+            cwd=_target_parent_dir(target),
         )
         return _preview(result, append_diff=diff)
 

--- a/interpreter/core/tools/file_edit.py
+++ b/interpreter/core/tools/file_edit.py
@@ -126,13 +126,6 @@ def _resolve_patch():
     return _resolve_binary("INTERPRETER_PATCH", ["patch"])
 
 
-def _is_gnu_sed(sed_path):
-    result = subprocess.run(
-        [sed_path, "--version"], capture_output=True, text=True
-    )
-    return "GNU" in (result.stdout + result.stderr)
-
-
 # ---------------------------------------------------------------------------
 # Path validation
 # ---------------------------------------------------------------------------
@@ -216,7 +209,12 @@ def _write_temp_script(code, suffix, prefix="oi-edit-"):
 
 
 def run_sed(target, code):
-    """Apply a sed script in-place (-f file). One command per line or multi-line sed scripts."""
+    """Apply a sed script (-f file), replacing the file atomically.
+
+    Avoid sed -i: GNU sed creates its backup next to the process cwd, so on
+    Windows a target on another drive (e.g. D:\\) fails with "Invalid cross-device
+    link" when cwd is on C:\\. Write stdout to a sibling temp file instead.
+    """
     _validate_target(target, must_exist=True)
     if not code.strip():
         raise ValueError("sed: no commands in code")
@@ -224,37 +222,42 @@ def run_sed(target, code):
     sed = _resolve_sed()
     script_path = _write_temp_script(code, ".sed")
     try:
-        args = [sed]
-        if _is_gnu_sed(sed):
-            args.extend(["-i", "-f", script_path, target])
-        else:
-            args.extend(["-i", "", "-f", script_path, target])
-        result = subprocess.run(args, capture_output=True, text=True)
+        result = subprocess.run(
+            [sed, "-f", script_path, target],
+            capture_output=True,
+        )
     finally:
         if os.path.isfile(script_path):
             os.remove(script_path)
 
     if result.returncode != 0:
         raise RuntimeError(
-            (result.stderr or result.stdout or "").strip()
+            _subprocess_text(result)
             or f"sed exited with code {result.returncode}"
         )
+    _atomic_replace_from_stdout(target, result.stdout or b"")
     return "sed: OK"
 
 
 def run_gawk(target, code):
-    """Apply a gawk program in-place. Requires GNU awk (-i inplace)."""
+    """Apply a gawk program in-place. Requires GNU awk (-i inplace).
+
+    Run with cwd set to the target's directory so inplace temp files land on the
+    same Windows drive as the file (avoids cross-device rename errors).
+    """
     _validate_target(target, must_exist=True)
     if not code.strip():
         raise ValueError("gawk: no program in code")
 
     gawk = _resolve_gawk()
+    path = Path(target)
     prog_path = _write_temp_script(code, ".awk")
     try:
         result = subprocess.run(
-            [gawk, "-i", "inplace", "-f", prog_path, target],
+            [gawk, "-i", "inplace", "-f", prog_path, path.name],
             capture_output=True,
             text=True,
+            cwd=str(path.parent),
         )
     finally:
         if os.path.isfile(prog_path):

--- a/tests/core/tools/test_file_edit.py
+++ b/tests/core/tools/test_file_edit.py
@@ -166,6 +166,22 @@ class TestRunJq(unittest.TestCase):
             data = json.loads(open(target, encoding="utf-8").read())
             self.assertEqual(data["label"], "✅")
 
+    def test_run_jq_uses_atomic_replace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "data.json")
+            run_write(target, '{"a":1}\n')
+            with mock.patch(
+                "interpreter.core.tools.file_edit.subprocess.run"
+            ) as run_mock:
+                run_mock.return_value = mock.Mock(
+                    returncode=0, stdout=b'{"a":2}\n', stderr=b""
+                )
+                with mock.patch(
+                    "interpreter.core.tools.file_edit._atomic_replace_from_stdout"
+                ) as replace_mock:
+                    run_jq(target, ".a = 2")
+            replace_mock.assert_called_once_with(target, b'{"a":2}\n')
+
 
 @unittest.skipUnless(shutil.which("gawk"), "gawk not installed")
 class TestRunGawk(unittest.TestCase):
@@ -258,6 +274,22 @@ class TestRunYq(unittest.TestCase):
             self.assertIn("9090", preview["output"])
             self.assertEqual(open(target, encoding="utf-8").read(), original)
 
+    def test_run_yq_uses_atomic_replace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "config.yaml")
+            run_write(target, "port: 8080\n")
+            with mock.patch(
+                "interpreter.core.tools.file_edit._run_yq_eval"
+            ) as eval_mock:
+                eval_mock.return_value = mock.Mock(
+                    returncode=0, stdout=b"port: 9090\n", stderr=b""
+                )
+                with mock.patch(
+                    "interpreter.core.tools.file_edit._atomic_replace_from_stdout"
+                ) as replace_mock:
+                    run_yq(target, ".port = 9090")
+            replace_mock.assert_called_once_with(target, b"port: 9090\n")
+
 
 @unittest.skipUnless(shutil.which("patch"), "patch not installed")
 class TestRunPatch(unittest.TestCase):
@@ -275,6 +307,24 @@ class TestRunPatch(unittest.TestCase):
             )
             run_patch(target, diff)
             self.assertEqual(open(target, encoding="utf-8").read(), "baz\nbar\n")
+
+    def test_run_patch_uses_target_parent_cwd(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "demo.txt")
+            run_write(target, "foo\n")
+            with mock.patch(
+                "interpreter.core.tools.file_edit.subprocess.run"
+            ) as run_mock:
+                run_mock.return_value = mock.Mock(
+                    returncode=0, stdout=b"", stderr=b""
+                )
+                run_patch(
+                    target,
+                    f"--- {Path(target).name}\n+++ {Path(target).name}\n",
+                )
+            self.assertEqual(
+                run_mock.call_args.kwargs["cwd"], str(Path(target).parent)
+            )
 
 
 @unittest.skipUnless(shutil.which("comby"), "comby not installed")

--- a/tests/core/tools/test_file_edit.py
+++ b/tests/core/tools/test_file_edit.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from interpreter.core.tools.file_edit import (
     EDIT_LANGUAGES,
@@ -108,6 +109,24 @@ class TestRunSed(unittest.TestCase):
             run_sed(target, "s/aaa/AAA/\ns/bbb/BBB/\n")
             self.assertEqual(open(target, encoding="utf-8").read(), "AAA\nBBB\n")
 
+    def test_run_sed_does_not_use_inplace_flag(self):
+        """sed -i puts temp files in cwd; on Windows that breaks cross-drive targets."""
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "demo.txt")
+            run_write(target, "foo\n")
+            with mock.patch(
+                "interpreter.core.tools.file_edit.subprocess.run"
+            ) as run_mock:
+                completed = mock.Mock(returncode=0, stdout=b"bar\n", stderr=b"")
+                run_mock.return_value = completed
+                with mock.patch(
+                    "interpreter.core.tools.file_edit._atomic_replace_from_stdout"
+                ) as replace_mock:
+                    run_sed(target, "s/foo/bar/")
+            args = run_mock.call_args[0][0]
+            self.assertNotIn("-i", args)
+            replace_mock.assert_called_once_with(target, b"bar\n")
+
 
 @unittest.skipUnless(shutil.which("jq"), "jq not installed")
 class TestRunJq(unittest.TestCase):
@@ -159,6 +178,21 @@ class TestRunGawk(unittest.TestCase):
                 "{\n  gsub(/world/, \"earth\")\n  print\n}\n",
             )
             self.assertEqual(open(target, encoding="utf-8").read(), "hello earth\n")
+
+    def test_run_gawk_inplace_uses_target_parent_cwd(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "lines.txt")
+            run_write(target, "hello\n")
+            with mock.patch(
+                "interpreter.core.tools.file_edit.subprocess.run"
+            ) as run_mock:
+                run_mock.return_value = mock.Mock(
+                    returncode=0, stdout="", stderr=""
+                )
+                run_gawk(target, "{ print }")
+            _, kwargs = run_mock.call_args
+            self.assertEqual(kwargs["cwd"], str(Path(target).parent))
+            self.assertEqual(run_mock.call_args[0][0][-1], Path(target).name)
 
 
 @unittest.skipUnless(shutil.which("yq"), "yq not installed")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When using the `edit` tool with `sed` on Windows, editing a file on a different drive (e.g. `D:\...`) while the process cwd is on `C:\` fails with:

```
/usr/bin/sed: cannot rename ./sedj2N3RR: Invalid cross-device link
```

GNU sed's `-i` flag writes its temporary backup in the process cwd, then renames it over the target. On Windows, `rename()` cannot move files across drive letters.

## Fix

Harmonized edit runners around two cross-drive-safe patterns:

1. **stdout + atomic replace** (`_atomic_replace_from_stdout`) — sed, jq, yq, comby
   - Run tool without in-place flags, capture stdout, write a temp sibling in the target's parent directory, `os.replace()`.

2. **cwd in target's parent** (`_target_parent_dir`) — gawk, patch
   - Tools that must edit in place (e.g. gawk scripts without `print`) run with `cwd` set to the target directory so their temp files stay on the same drive.

Also: removed duplicated temp-file logic from jq/yq, unified error handling via `_run_failed`, and documented the strategy in the module docstring.

## Tests

- Regression test ensuring `run_sed` never passes `-i` and uses `_atomic_replace_from_stdout`.
- Regression tests for jq/yq atomic replace and gawk/patch target-parent cwd.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff982235-342e-4c79-a163-51e8c7c4bc3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff982235-342e-4c79-a163-51e8c7c4bc3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

