### PR TITLE
README: minimal targeted overhaul (atomic commits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 ### Install
 
-This repository is Endolith's fork of the classic Python Open Interpreter.
+This is the community-maintained Python version of Open Interpreter.
 
 This command will install **`main`** which is the default branch (stable base, CI, and merge target for ported changes):
 

--- a/README.md
+++ b/README.md
@@ -362,9 +362,9 @@ Open Interpreter equips a [function-calling language model](https://platform.ope
 
 We then stream the model's messages, code, and your system's outputs to the terminal as Markdown.
 
-## Access Documentation Offline
+## Documentation
 
-The full [documentation](docs) is accessible on-the-go without the need for an internet connection.
+The full [documentation](docs) lives in this repository.
 
 [Node](https://nodejs.org/en) is a pre-requisite:
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ There is **experimental** support for a [safe mode](docs/SAFE_MODE.md) to help m
 
 ## How Does it Work?
 
-Open Interpreter equips a [function-calling language model](https://platform.openai.com/docs/guides/function-calling) with an `exec()` function, which accepts a `language` (like "Python" or "JavaScript") and `code` to run.
+Open Interpreter equips a [function-calling language model](https://platform.openai.com/docs/guides/function-calling) with an `execute` tool, which accepts a `language` (like "Python" or "JavaScript") and `code` to run.
 
 We then stream the model's messages, code, and your system's outputs to the terminal as Markdown.
 

--- a/README.md
+++ b/README.md
@@ -90,22 +90,19 @@ interpreter.chat() # Starts an interactive chat
 
 Press the <kbd>,</kbd> key on this repository's GitHub page to create a codespace. After a moment, you'll receive a cloud virtual machine environment pre-installed with open-interpreter. You can then start interacting with it directly and freely confirm its execution of system commands without worrying about damaging the system.
 
-## Comparison to ChatGPT's Code Interpreter
+## Comparison to hosted Code Interpreter
 
-OpenAI's release of [Code Interpreter](https://openai.com/blog/chatgpt-plugins#code-interpreter) with GPT-4 presents a fantastic opportunity to accomplish real-world tasks with ChatGPT.
+Hosted **Code Interpreter** features in chatbot products ([OpenAI](https://developers.openai.com/api/docs/guides/tools-code-interpreter), [Mistral](https://docs.mistral.ai/studio-api/agents/agent-tools/code_interpreter), [Grok](https://docs.x.ai/developers/tools/code-execution), Gemini, etc.) run code in a remote, sandboxed environment that is closed-source and heavily restricted compared to your local machine:
 
-However, OpenAI's service is hosted, closed-source, and heavily restricted:
-
-- No internet access.
-- [Limited set of pre-installed packages](https://wfhbrian.com/artificial-intelligence/mastering-chatgpts-code-interpreter-list-of-python-packages/).
-- 100 MB maximum upload, 120.0 second runtime limit.
-- State is cleared (along with any generated files or links) when the environment dies.
+- Sandboxed environment — not your filesystem.
+- User code generally cannot access the open internet or call arbitrary APIs (details vary by provider).
+- Limited set of pre-installed packages.
+- Ephemeral sessions — state and files are cleared when the environment ends (timeouts vary by provider).
+- Upload and runtime limits (vary by provider).
 
 ---
 
 Open Interpreter overcomes these limitations by running in your local environment. It has full access to the internet, isn't restricted by time or file size, and can utilize any package or library.
-
-This combines the power of GPT-4's Code Interpreter with the flexibility of your local development environment.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ pip install fastapi uvicorn
 uvicorn server:app --reload
 ```
 
-You can also start a server identical to the one above by simply running `interpreter.server()`.
+You can also start a built-in server with `interpreter --server` (requires the `[server]` extra).
 
 ## Android
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,13 @@
 
 <br>
 
-**Open Interpreter** lets LLMs run code (Python, Javascript, Shell, and more) locally. You can chat with Open Interpreter through a ChatGPT-like interface in your terminal by running `$ interpreter` after installing.
+**Open Interpreter** lets LLMs run code and shell commands locally — Python, JavaScript, Bash, cmd, PowerShell, Ruby, R, Java, and more. You use it through a **chatbot interface** in your terminal; run `interpreter` after installing.
 
-This provides a natural-language interface to your computer's general-purpose capabilities:
-
-- Create and edit photos, videos, PDFs, etc.
-- Control a Chrome browser to perform research
-- Plot, clean, and analyze large datasets
-- ...etc.
+| Compared to… | Open Interpreter |
+|---|---|
+| **Coding agents** (Claude Code, Cursor, Windsurf) | Less about patching a codebase; more about **one-off tasks** in a persistent, REPL-like session (closer to a Jupyter notebook than an IDE). |
+| **MCP-based agents** | Does not route work through MCP tool calls — it **runs code directly**. No MCP client support today. |
+| **Natural-language shell tools** | Also translate English into shell commands, but OI is a **chatbot** where you can review, reject (`n`), or edit (`e`) code before it runs, and ask the model to revise. |
 
 **⚠️ Note: You'll be asked to approve code before it's run.**
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <br>
 
-**Open Interpreter** lets LLMs run code and shell commands locally — Python, JavaScript, Bash, cmd, PowerShell, Ruby, R, Java, and more. You use it through a **chatbot interface** in your terminal; run `interpreter` after installing.
+**Open Interpreter** lets LLMs run code and shell commands locally — Python, JavaScript, Bash, cmd, PowerShell, Ruby, R, Java, and more. You can chat with Open Interpreter through a **chatbot interface** in your terminal by running `interpreter` after installing.
 
 | Compared to… | Open Interpreter |
 |---|---|
@@ -94,11 +94,11 @@ Press the <kbd>,</kbd> key on this repository's GitHub page to create a codespac
 
 Hosted **Code Interpreter** features in chatbot products ([OpenAI](https://developers.openai.com/api/docs/guides/tools-code-interpreter), [Mistral](https://docs.mistral.ai/studio-api/agents/agent-tools/code_interpreter), [Grok](https://docs.x.ai/developers/tools/code-execution), Gemini, etc.) run code in a remote, sandboxed environment that is closed-source and heavily restricted compared to your local machine:
 
-- Sandboxed environment — not your filesystem.
-- User code generally cannot access the open internet or call arbitrary APIs (details vary by provider).
+- Sandboxed remote environment — not your local filesystem.
+- User code cannot freely access the internet or call arbitrary APIs (package installs may use provider-specific mirrors).
 - Limited set of pre-installed packages.
-- Ephemeral sessions — state and files are cleared when the environment ends (timeouts vary by provider).
-- Upload and runtime limits (vary by provider).
+- Ephemeral sessions — containers expire after inactivity (e.g. 20 minutes on the [OpenAI API](https://developers.openai.com/api/docs/guides/tools-code-interpreter)).
+- Upload and runtime limits (e.g. OpenAI allows up to 512 MB per file; details vary by provider).
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Minimal README updates based on review of the three overhaul branches. Each conceptual change is a separate commit; no unnecessary rewrites.

**Included:**
1. Chatbot interface wording, language/shell list, comparison table
2. Community-maintained attribution in install (keeps existing two-block main/develop install structure)
3. Generalize "ChatGPT's Code Interpreter" → hosted Code Interpreter across chatbot hosts; replace outdated sandbox bullets (100 MB / 120 s) with provider-varying restrictions
4. Fix `interpreter.server()` → `interpreter --server`
5. Fix `exec()` → `execute` tool in How Does it Work (minimal one-line change)
6. Rename "Access Documentation Offline" → "Documentation"

**Skipped (per review):**
- NOTE banner (Rust link already in header)
- Safety section rewrite
- Full How Does it Work rewrite
- Optional extras pip line / single install block
- Model example updates

Translated READMEs (`docs/README_*.md`) still have the old ChatGPT/exec()/server wording — follow-up if desired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb0cfde6-c1d3-4e78-ab35-6fd8bcccf423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb0cfde6-c1d3-4e78-ab35-6fd8bcccf423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

