### PR TITLE
Add unit tests for telemetry helpers

### DIFF
--- a/tests/core/utils/test_telemetry.py
+++ b/tests/core/utils/test_telemetry.py
@@ -36,3 +36,12 @@ def test_send_telemetry_posts_event():
     assert payload["event"] == "test_event"
     assert payload["properties"]["foo"] == "bar"
     assert "oi_version" in payload["properties"]
+
+
+def test_send_telemetry_swallows_errors():
+    """send_telemetry must not raise when the HTTP request fails (telemetry is non-blocking)."""
+    with mock.patch(
+        "interpreter.core.utils.telemetry.requests.post",
+        side_effect=Exception("network"),
+    ):
+        telemetry.send_telemetry("test_event")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto current `main`. The original branch bundled stale CI workflow commits and telemetry tests that **#110 already merged** (`test_get_or_create_uuid_*`, `test_send_telemetry_posts_event`).

This PR is now a single atomic commit adding the one case that was still missing:

- `test_send_telemetry_swallows_errors` — verifies `send_telemetry` does not raise when `requests.post` fails (telemetry is intentionally non-blocking).

Related: **#120** (telemetry off by default) is a separate behavioral change and remains open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc785de1-a40d-4001-bf8d-72dad50b33d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc785de1-a40d-4001-bf8d-72dad50b33d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

