### PR TITLE
Fix infinite loop on empty code blocks in respond()

### DIFF
--- a/interpreter/core/respond.py
+++ b/interpreter/core/respond.py
@@ -280,7 +280,9 @@ def respond(interpreter):
                         "format": "output",
                         "content": "Code block was empty. Please try again, be sure to write code before executing.",
                     }
-                    continue
+                    # Without breaking, the loop re-enters this branch forever because
+                    # messages[-1] is still type "code" with empty content.
+                    break
 
                 # Yield a message, such that the user can stop code execution if they want to
                 try:

--- a/tests/core/test_respond_empty_code.py
+++ b/tests/core/test_respond_empty_code.py
@@ -1,0 +1,55 @@
+import itertools
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.respond import respond
+
+
+class FakeLanguage:
+    name = "Python"
+    file_extension = "py"
+
+
+def _interpreter_with_code(code, language="python"):
+    terminal = SimpleNamespace(
+        languages=[FakeLanguage()],
+        get_language=lambda lang: FakeLanguage() if lang == "python" else None,
+    )
+    return SimpleNamespace(
+        system_message="",
+        custom_instructions="",
+        messages=[
+            {"role": "assistant", "type": "code", "format": language, "content": code}
+        ],
+        computer=SimpleNamespace(
+            terminal=terminal,
+            import_computer_api=False,
+            system_message="",
+            run=lambda *a, **k: iter([]),
+            verbose=False,
+            debug=False,
+            emit_images=False,
+            max_output=2800,
+            save_skills=True,
+            to_dict=lambda: {},
+        ),
+        llm=SimpleNamespace(run=lambda msgs: iter([]), supports_vision=False),
+        verbose=False,
+        debug=False,
+        auto_run=True,
+        loop=False,
+        loop_message="continue",
+        loop_breakers=[],
+        sync_computer=False,
+        offline=True,
+        os=False,
+        display_message=mock.Mock(),
+        max_budget=0,
+    )
+
+
+def test_empty_code_block_does_not_spin_forever():
+    interpreter = _interpreter_with_code("   ")
+    chunks = list(itertools.islice(respond(interpreter), 5))
+    assert len(chunks) == 1
+    assert "empty" in chunks[0]["content"].lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When `respond()` received a code message with empty/whitespace-only content, it yielded an error chunk and then `continue`d the main loop. Because `messages[-1]` was still a `type: "code"` message with empty content, the same branch ran again indefinitely.

This hung the VM during unit test development when `list(respond(...))` was used without `_respond_and_store` updating messages between iterations.

## Fix

`break` after yielding the empty-code error instead of `continue`.

## Test

Adds `tests/core/test_respond_empty_code.py` with a regression test that asserts the generator terminates after one error chunk.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc785de1-a40d-4001-bf8d-72dad50b33d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc785de1-a40d-4001-bf8d-72dad50b33d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

