### PR TITLE
Docs: fix interpreter.offline descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Our Python package gives you more control over each setting. To replicate and co
 ```python
 from interpreter import interpreter
 
-interpreter.offline = True # Disables online features like Open Procedures
+interpreter.offline = True # Disables online features (e.g. update checks, telemetry)
 interpreter.llm.model = "openai/x" # Tells OI to send messages in OpenAI's format
 interpreter.llm.api_key = "fake_key" # LiteLLM, which we use to talk to LM Studio, requires this
 interpreter.llm.api_base = "http://localhost:1234/v1" # Point this at any OpenAI compatible server

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -241,7 +241,7 @@ Nuestro paquete de Python le da más control sobre cada ajuste. Para replicar y 
 ```python
 from interpreter import interpreter
 
-interpreter.offline = True # Desactiva las características en línea como Procedimientos Abiertos
+interpreter.offline = True # Desactiva funciones en línea (p. ej. comprobación de actualizaciones, telemetría)
 interpreter.llm.model = "openai/x" # Indica a OI que envíe mensajes en el formato de OpenAI
 interpreter.llm.api_key = "fake_key" # LiteLLM, que utilizamos para hablar con LM Studio, requiere esto
 interpreter.llm.api_base = "http://localhost:1234/v1" # Apunta esto a cualquier servidor compatible con OpenAI

--- a/docs/README_UK.md
+++ b/docs/README_UK.md
@@ -241,7 +241,7 @@ for a more detailed guide check out [this video by Mike Bird](https://www.youtub
 ```python
 from interpreter import interpreter
 
-interpreter.offline = True # Вимикає такі онлайн-функції, як Open Procedures
+interpreter.offline = True # Вимикає онлайн-функції (наприклад, перевірку оновлень, телеметрію)
 interpreter.llm.model = "openai/x" # Каже AI надсилати повідомлення у форматі OpenAI
 interpreter.llm.api_key = "fake_key" # LiteLLM, який ми використовуємо для спілкування з LM Studio, вимагає api-ключ
 interpreter.llm.api_base = "http://localhost:1234/v1" # Познчате це на будь-якому сервері, сумісному з OpenAI

--- a/docs/guides/running-locally.mdx
+++ b/docs/guides/running-locally.mdx
@@ -42,7 +42,7 @@ In order to have a Python script use Open Interpreter locally, some fields need 
 ```python
 from interpreter import interpreter
 
-interpreter.offline = True
+interpreter.offline = True  # Disables online features (e.g. update checks, telemetry)
 interpreter.llm.model = "ollama/codestral"
 interpreter.llm.api_base = "http://localhost:11434"
 

--- a/docs/language-models/local-models/best-practices.mdx
+++ b/docs/language-models/local-models/best-practices.mdx
@@ -17,7 +17,7 @@ interpreter --local --max_tokens 1000 --context_window 3000
 ```python Python
 from interpreter import interpreter
 
-interpreter.offline = True # Disables online features like Open Procedures
+interpreter.offline = True # Disables online features (e.g. update checks, telemetry)
 interpreter.llm.model = "openai/x" # Tells OI to send messages in OpenAI's format
 interpreter.llm.api_key = "fake_key" # LiteLLM, which we use to talk to LM Studio, requires this
 interpreter.llm.api_base = "http://localhost:1234/v1" # Point this at any OpenAI compatible server

--- a/docs/language-models/local-models/janai.mdx
+++ b/docs/language-models/local-models/janai.mdx
@@ -25,7 +25,7 @@ interpreter --api_base http://localhost:1337/v1  --model <model_id>
 ```python Python
 from interpreter import interpreter
 
-interpreter.offline = True # Disables online features like Open Procedures
+interpreter.offline = True # Disables online features (e.g. update checks, telemetry)
 interpreter.llm.model = "<model_id>"
 interpreter.llm.api_base = "http://localhost:1337/v1 "
 

--- a/docs/language-models/local-models/lm-studio.mdx
+++ b/docs/language-models/local-models/lm-studio.mdx
@@ -46,7 +46,7 @@ For example, to connect to [LM Studio](https://lmstudio.ai/), use these settings
 ```python
 from interpreter import interpreter
 
-interpreter.offline = True # Disables online features like Open Procedures
+interpreter.offline = True # Disables online features (e.g. update checks, telemetry)
 interpreter.llm.model = "openai/x" # Tells OI to send messages in OpenAI's format
 interpreter.llm.api_key = "fake_key" # LiteLLM, which we use to talk to LM Studio, requires this
 interpreter.llm.api_base = "http://localhost:1234/v1" # Point this at any OpenAI compatible server

--- a/docs/language-models/local-models/ollama.mdx
+++ b/docs/language-models/local-models/ollama.mdx
@@ -27,7 +27,7 @@ interpreter --model ollama/<model-name>
 ```python Python
 from interpreter import interpreter
 
-interpreter.offline = True # Disables online features like Open Procedures
+interpreter.offline = True # Disables online features (e.g. update checks, telemetry)
 interpreter.llm.model = "ollama_chat/<model-name>"
 interpreter.llm.api_base = "http://localhost:11434"
 

--- a/docs/settings/all-settings.mdx
+++ b/docs/settings/all-settings.mdx
@@ -506,7 +506,7 @@ interpreter --local
 ```python Python
 from interpreter import interpreter
 
-interpreter.offline = True # Disables online features like Open Procedures
+interpreter.offline = True # Disables online features (e.g. update checks, telemetry)
 interpreter.llm.model = "openai/x" # Tells OI to send messages in OpenAI's format
 interpreter.llm.api_key = "fake_key" # LiteLLM, which we use to talk to local models, requires this
 interpreter.llm.api_base = "http://localhost:1234/v1" # Point this at any OpenAI compatible server
@@ -598,7 +598,7 @@ disable_telemetry: true
 
 ### Offline
 
-This boolean flag determines whether to enable or disable some offline features like [open procedures](https://open-procedures.replit.app/). Use this in conjunction with the `model` parameter to set your language model.
+When `True`, disables Open Interpreter features that contact the internet (your remote language model is unaffected): PyPI update checks, anonymous telemetry, conversation-contribution prompts, and offers to fall back to Open Interpreter's hosted `i` model. Local-model setups typically enable this so OI does not phone home while the LLM runs on localhost.
 
 <CodeGroup>
 
@@ -736,7 +736,7 @@ The `computer` object in `interpreter.computer` is a virtual computer that the A
 
 ### Offline
 
-Running the `computer` in offline mode will disable some online features, like the hosted [Computer API](https://api.openinterpreter.com/). Inherits from `interpreter.offline`.
+Separate from `interpreter.offline`. When `True`, the `computer` module skips the hosted [Computer API](https://api.openinterpreter.com/) (used for on-screen icon locating and OCR) and uses local fallbacks instead.
 
 <CodeGroup>
 

--- a/docs/usage/python/arguments.mdx
+++ b/docs/usage/python/arguments.mdx
@@ -51,16 +51,14 @@ interpreter.messages = messages # A list that resembles the one above
 
 #### `offline`
 
-<Info>This replaced `interpreter.local` in the New Computer Update (`0.2.0`).</Info>
+<Info>This replaced `interpreter.local` in the New Computer Update (`0.2.0`). The `--local` flag loads the `local.py` profile, which sets `offline = True`.</Info>
 
-This boolean flag determines whether to enable or disable some offline features like [open procedures](https://open-procedures.replit.app/).
+When `True`, disables Open Interpreter features that contact the internet (your remote language model is unaffected): PyPI update checks, anonymous telemetry, conversation-contribution prompts, and offers to fall back to Open Interpreter's hosted `i` model. Local-model setups typically enable this so OI does not phone home while the LLM runs on localhost.
 
 ```python
-interpreter.offline = True  # Check for updates, use procedures
-interpreter.offline = False  # Don't check for updates, don't use procedures
+interpreter.offline = True  # Disables online features (e.g. update checks, telemetry)
+interpreter.offline = False  # Default — online OI features enabled
 ```
-
-Use this in conjunction with the `model` parameter to set your language model.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects stale and inaccurate documentation for `interpreter.offline` and `computer.offline` after a full code audit.

## What `interpreter.offline` actually does

When `True`, the code disables Open Interpreter features that contact the internet (the remote LLM is unaffected):

- PyPI update check on startup (`start_terminal_interface.py`)
- Anonymous telemetry (`core.py`)
- Conversation-contribution prompts (`will_contribute`, `contributing_conversations.py`)
- Exit feedback prompt on Ctrl+C
- Offers to fall back to the hosted `i` model on API errors (`respond.py`)
- Some startup UI messages (`validate_llm_settings.py`, `terminal_interface.py`)

There is **no** "Open Procedures" feature in the codebase — only dead links in old docs.

## Other fixes

- **`docs/usage/python/arguments.mdx`**: comments were backwards (`True` was documented as enabling update checks)
- **`computer.offline`**: docs claimed it "inherits from `interpreter.offline`" — they are separate flags; only `computer.offline` gates the hosted Computer API in `display.py`
- Updated matching comments in `README.md`, `docs/README_ES.md`, `docs/README_UK.md`, and local-model guides

## Files changed

- `README.md`
- `docs/README_ES.md`, `docs/README_UK.md`
- `docs/usage/python/arguments.mdx`
- `docs/settings/all-settings.mdx`
- `docs/guides/running-locally.mdx`
- `docs/language-models/local-models/{best-practices,ollama,lm-studio,janai}.mdx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb0cfde6-c1d3-4e78-ab35-6fd8bcccf423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb0cfde6-c1d3-4e78-ab35-6fd8bcccf423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

