### PR TITLE
Fix Snowpark profile YAML parsing and ROADMAP heading levels

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,14 +51,14 @@
 - [ ] On update, check for new system message and ask user to overwrite theirs, or only let users pass in "custom instructions" which adds to our system message
   - [ ] I think we could have a config that's like... system_message_version. If system_message_version is below the current version, ask the user if we can overwrite it with the default config system message of that version. (This somewhat exists now but needs to be robust)
 
-# What's in our scope?
+## What's in our scope?
 
 Open Interpreter contains two projects which support each other, whose scopes are as follows:
 
 1. `core`, which is dedicated to figuring out how to get LLMs to safely control a computer. Right now, this means creating a real-time code execution environment that language models can operate.
 2. `terminal_interface`, a text-only way for users to direct the code-running LLM running inside `core`. This includes functions for connecting the `core` to various local and hosted LLMs (which the `core` itself should not know about).
 
-# What's not in our scope?
+## What's not in our scope?
 
 Our guiding philosophy is minimalism, so we have also decided to explicitly consider the following as **out of scope**:
 
@@ -69,7 +69,7 @@ Our guiding philosophy is minimalism, so we have also decided to explicitly cons
 
 This roadmap gets pretty rough from here. More like working notes.
 
-# Working Notes
+## Working Notes
 
 ## \* Roughly, how to build `computer.browser`:
 

--- a/interpreter/terminal_interface/profiles/defaults/snowpark.yml
+++ b/interpreter/terminal_interface/profiles/defaults/snowpark.yml
@@ -16,65 +16,65 @@ computer:
   import_computer_api: True # Gives OI a helpful Computer API designed for code interpreting language models
 
 # Custom Instructions
-custom_instructions: '''
-You are going to be connecting to Snowflake, the cloud data platform. You can use the Snowpark API to interact with Snowflake. Here are some common tasks you might want to do:
-- Connect to Snowflake
-- Run a query
+custom_instructions: |
+  You are going to be connecting to Snowflake, the cloud data platform. You can use the Snowpark API to interact with Snowflake. Here are some common tasks you might want to do:
+  - Connect to Snowflake
+  - Run a query
 
-You can use the Snowpark API to do these tasks. To create a session with snowpark, you have to first import the session object from snowpark and pandas, like so:
-```python
-from snowflake.snowpark import Session
-import pandas as pd
-```
-If this doesnt work, you may need to run the following commands to install snowpark and pandas:
-```python
-!pip install snowflake-snowpark-python
-!pip install pandas
-!pip install "snowflake-snowpark-python[pandas]"
-!pip install "snowflake-connector-python[pandas]"
-```
+  You can use the Snowpark API to do these tasks. To create a session with snowpark, you have to first import the session object from snowpark and pandas, like so:
+  ```python
+  from snowflake.snowpark import Session
+  import pandas as pd
+  ```
+  If this doesnt work, you may need to run the following commands to install snowpark and pandas:
+  ```python
+  !pip install snowflake-snowpark-python
+  !pip install pandas
+  !pip install "snowflake-snowpark-python[pandas]"
+  !pip install "snowflake-connector-python[pandas]"
+  ```
 
-Then, you can create a dictionary with the necessary connection parameters and create a session. You will access these values from the 
-environment variables:
-```python
-# Retrieve environment variables
-snowflake_account = os.getenv("SNOWFLAKE_ACCOUNT")
-snowflake_user = os.getenv("SNOWFLAKE_USER")
-snowflake_password = os.getenv("SNOWFLAKE_PASSWORD")
-snowflake_role = os.getenv("SNOWFLAKE_ROLE")
-snowflake_warehouse = os.getenv("SNOWFLAKE_WAREHOUSE")
-snowflake_database = os.getenv("SNOWFLAKE_DATABASE") 
-snowflake_schema = os.getenv("SNOWFLAKE_SCHEMA")
+  Then, you can create a dictionary with the necessary connection parameters and create a session. You will access these values from the 
+  environment variables:
+  ```python
+  # Retrieve environment variables
+  snowflake_account = os.getenv("SNOWFLAKE_ACCOUNT")
+  snowflake_user = os.getenv("SNOWFLAKE_USER")
+  snowflake_password = os.getenv("SNOWFLAKE_PASSWORD")
+  snowflake_role = os.getenv("SNOWFLAKE_ROLE")
+  snowflake_warehouse = os.getenv("SNOWFLAKE_WAREHOUSE")
+  snowflake_database = os.getenv("SNOWFLAKE_DATABASE") 
+  snowflake_schema = os.getenv("SNOWFLAKE_SCHEMA")
 
-# Create connection parameters dictionary
-connection_parameters = {
-    "account": snowflake_account,
-    "user": snowflake_user,
-    "password": snowflake_password,
-    "role": snowflake_role,
-    "warehouse": snowflake_warehouse, 
-    "database": snowflake_database, 
-    "schema": snowflake_schema,
-}
+  # Create connection parameters dictionary
+  connection_parameters = {
+      "account": snowflake_account,
+      "user": snowflake_user,
+      "password": snowflake_password,
+      "role": snowflake_role,
+      "warehouse": snowflake_warehouse, 
+      "database": snowflake_database, 
+      "schema": snowflake_schema,
+  }
 
-# Create a session
-session = Session.builder.configs(connection_parameters).create()
-```
-You should assume that the environment variables have already been set. 
-You can run a query against the snowflake data by using the session.sql() method. Then, you can turn the snowpark dataframe
-that is created into a pandas dataframe for use in other processes. Here is an example of how you can run a query:
-```python
-# Run a query
-query = "<your query goes here>"
-snowpark_dataframe = session.sql(query)
+  # Create a session
+  session = Session.builder.configs(connection_parameters).create()
+  ```
+  You should assume that the environment variables have already been set. 
+  You can run a query against the snowflake data by using the session.sql() method. Then, you can turn the snowpark dataframe
+  that is created into a pandas dataframe for use in other processes. Here is an example of how you can run a query:
+  ```python
+  # Run a query
+  query = "<your query goes here>"
+  snowpark_dataframe = session.sql(query)
 
-# Convert the snowpark dataframe to a pandas dataframe
-df = snowflake_dataframe.to_pandas()
-```
+  # Convert the snowpark dataframe to a pandas dataframe
+  df = snowpark_dataframe.to_pandas()
+  ```
 
-You can now use this dataframe to do whatever you need to do with the data.
+  You can now use this dataframe to do whatever you need to do with the data.
 
-'''  # This will be appended to the system message
+# This will be appended to the system message
 
 # General Configuration
 # auto_run: False  # If True, code will run without asking for confirmation


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebases onto current `main` and keeps only the changes worth landing:

## Snowpark profile (`snowpark.yml`)

Replaces invalid `'''` delimiters with a proper YAML `|` block scalar for `custom_instructions`.

On `main`, PyYAML parses the old format as a single-quoted string, so the loaded value literally starts and ends with `'` characters. This fixes the actual string passed to the LLM.

Restores `# This will be appended to the system message` on its own line after the block scalar. YAML supports comments fine; the old `'''  # comment` syntax was not valid YAML, which is why the comment could not stay inline there.

## ROADMAP heading levels

Demotes `# What's in our scope?`, `# What's not in our scope?`, and `# Working Notes` to `##`, since the document title is already `# Roadmap`.

## Dropped / already on main

- Markdown bold inside HTML `<p>` blocks (reverted)
- Ukrainian HTML→markdown header refactor (not kept)
- Translated README heading fixes (already done by README harmonization on `main`)
- Doc URL localization, setup links, desktop app links, command list updates (already on `main`)

## Testing

Verified `yaml.safe_load()` on the updated `snowpark.yml` produces a clean string starting with `You` (no leading/trailing quote artifacts).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-789fcd33-b245-4914-857d-b9c3df746c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-789fcd33-b245-4914-857d-b9c3df746c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

