### PR TITLE
Add unit tests for temperature=0 LLM API params

### DIFF
--- a/tests/core/llm/test_llm.py
+++ b/tests/core/llm/test_llm.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+from interpreter import OpenInterpreter
+
+_MESSAGES = [
+    {"role": "system", "type": "message", "content": "system"},
+    {"role": "user", "type": "message", "content": "hello"},
+]
+
+
+def _capture_llm_params(interpreter, temperature):
+    interpreter.llm.temperature = temperature
+    interpreter.llm.supports_functions = True
+    interpreter.llm.supports_vision = False
+    interpreter.llm._is_loaded = True
+    interpreter.llm.model = "gpt-4o-mini"
+
+    captured = {}
+
+    def capture_params(llm, params):
+        captured["params"] = params
+        return iter(())
+
+    with mock.patch(
+        "interpreter.core.llm.llm.run_tool_calling_llm", side_effect=capture_params
+    ):
+        list(interpreter.llm.run(_MESSAGES))
+
+    return captured["params"]
+
+
+def test_temperature_zero_is_sent_to_llm_api():
+    """temperature=0.0 must reach the API; `if self.temperature:` skipped it (falsy)."""
+
+    params = _capture_llm_params(OpenInterpreter(), 0.0)
+    assert params["temperature"] == 0.0
+
+
+def test_temperature_none_omitted_from_llm_api():
+    params = _capture_llm_params(OpenInterpreter(), None)
+    assert "temperature" not in params

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1266,8 +1266,11 @@ def test_shell_nested_loop_quoting():
     Deterministic: no LLM, no API. The old integration test tried to cover this
     via LLM-generated nested shell loops, which hung when quoting was malformed.
     """
-
-    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
+ 
+    if platform.system() == "Windows":
+        code = 'for %i in (a b) do for %j in (1 2) do echo %i_%j'
+    else:
+        code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
     chunks = interpreter.computer.run("shell", code)
     output = "".join(
         chunk.get("content", "")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds deterministic unit tests for the `temperature=0` API params regression (`if self.temperature:` skipped falsy `0.0`).

## Tests

- `test_temperature_zero_is_sent_to_llm_api` — mocks `run_tool_calling_llm` and asserts `params["temperature"] == 0.0`
- `test_temperature_none_omitted_from_llm_api` — asserts `temperature` key is absent when unset

No LLM/API calls. Should satisfy codecov branch coverage on `interpreter/core/llm/llm.py` lines 300–301.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa14b8e7-5b3c-4995-bc4f-fcace6218899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa14b8e7-5b3c-4995-bc4f-fcace6218899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

