### PR TITLE
Fix shell subprocess hangs in server integration tests

### DIFF
--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -72,7 +72,7 @@ class AsyncInterpreter(OpenInterpreter):
             # If the user is starting something, the interpreter should stop.
             if self.respond_thread is not None and self.respond_thread.is_alive():
                 self.stop_event.set()
-                self.respond_thread.join()
+                self.respond_thread.join(timeout=30)
             self.accumulate(chunk)
         elif "content" in chunk:
             self.accumulate(chunk)
@@ -89,7 +89,7 @@ class AsyncInterpreter(OpenInterpreter):
                 if command == "stop":
                     # Any start flag would have stopped it a moment ago, but to be sure:
                     self.stop_event.set()
-                    self.respond_thread.join()
+                    self.respond_thread.join(timeout=30)
                     return
                 if command == "go":
                     # This is to approve code.

--- a/interpreter/core/computer/terminal/languages/shell.py
+++ b/interpreter/core/computer/terminal/languages/shell.py
@@ -19,7 +19,16 @@ class Shell(SubprocessLanguage):
         if platform.system() == "Windows":
             self.start_cmd = ["cmd.exe"]
         else:
-            self.start_cmd = [os.environ.get("SHELL", "bash")]
+            shell = os.environ.get("SHELL", "bash")
+            shell_name = os.path.basename(shell)
+            # Skip rc/profile scripts. They can hang or block when HOME is on a slow
+            # or network-mounted filesystem (common cause of shell subprocess timeouts).
+            if shell_name == "bash":
+                self.start_cmd = [shell, "--norc", "--noprofile"]
+            elif shell_name == "zsh":
+                self.start_cmd = [shell, "-f"]
+            else:
+                self.start_cmd = [shell]
 
     def preprocess_code(self, code):
         return preprocess_shell(code)

--- a/interpreter/core/computer/terminal/languages/subprocess_language.py
+++ b/interpreter/core/computer/terminal/languages/subprocess_language.py
@@ -92,6 +92,10 @@ class SubprocessLanguage(BaseLanguage):
                 print(f"(after processing) Running processed code:\n{code}\n---")
 
             self.done.clear()
+            start_time = time.time()
+            max_runtime = float(
+                os.environ.get("INTERPRETER_SUBPROCESS_TIMEOUT", "120")
+            )
 
             try:
                 self.process.stdin.write(code + "\n")
@@ -120,6 +124,15 @@ class SubprocessLanguage(BaseLanguage):
                     return
 
         while True:
+            if time.time() - start_time > max_runtime:
+                self.terminate()
+                yield {
+                    "type": "console",
+                    "format": "output",
+                    "content": f"Execution timed out after {max_runtime}s",
+                }
+                return
+
             if not self.output_queue.empty():
                 yield self.output_queue.get()
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,12 @@ profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that call a live LLM API (require OPENAI_API_KEY)",
+    "timeout: per-test timeout from pytest-timeout",
+]
+
 [tool.ruff]
 line-length = 120
 target-version = "py310"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -2,6 +2,7 @@ import os
 import platform
 import re
 import signal
+import socket
 import time
 from random import randint
 
@@ -32,7 +33,24 @@ _SERVER_HOST = "127.0.0.1"
 _SERVER_PORT = 8000
 
 
+def _allocate_server_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((_SERVER_HOST, 0))
+        return sock.getsockname()[1]
+
+
+def _server_ws_url():
+    return f"ws://{_SERVER_HOST}:{_SERVER_PORT}/"
+
+
+def _server_http_url(path=""):
+    return f"http://{_SERVER_HOST}:{_SERVER_PORT}{path}"
+
+
 def _start_server_subprocess(target):
+    global _SERVER_PORT
+    _SERVER_PORT = _allocate_server_port()
+    os.environ["INTERPRETER_PORT"] = str(_SERVER_PORT)
     process = _MP_SPAWN.Process(target=target)
     process.start()
     return process
@@ -69,7 +87,12 @@ def _stop_server_subprocess(process):
 
 
 async def _wait_for_websocket_complete(
-    websocket, max_messages=500, recv_timeout=300.0, acknowledge=False
+    websocket,
+    max_messages=500,
+    recv_timeout=300.0,
+    acknowledge=False,
+    phase="unknown",
+    server_process=None,
 ):
     """Read WebSocket chunks until the server sends a 'complete' status.
 
@@ -81,13 +104,22 @@ async def _wait_for_websocket_complete(
     import json
 
     accumulated_content = ""
+    messages_received = 0
     for _ in range(max_messages):
+        if server_process is not None and not server_process.is_alive():
+            raise RuntimeError(
+                f"Server subprocess exited during WebSocket wait (phase: {phase}, "
+                f"exit code {server_process.exitcode}, port {_SERVER_PORT})"
+            )
         try:
             message = await asyncio.wait_for(websocket.recv(), timeout=recv_timeout)
         except asyncio.TimeoutError as exc:
             raise Exception(
-                f"No WebSocket message within {recv_timeout}s waiting for 'complete'"
+                f"No WebSocket message within {recv_timeout}s waiting for 'complete' "
+                f"(phase: {phase}, messages received: {messages_received}, "
+                f"port {_SERVER_PORT})"
             ) from exc
+        messages_received += 1
 
         message_data = json.loads(message)
         if acknowledge and "id" in message_data:
@@ -108,7 +140,10 @@ async def _wait_for_websocket_complete(
             print("Received expected message from server")
             return accumulated_content
 
-    raise Exception(f"Never received 'complete' status after {max_messages} messages")
+    raise Exception(
+        f"Never received 'complete' status after {max_messages} messages "
+        f"(phase: {phase}, port {_SERVER_PORT})"
+    )
 
 
 def _last_assistant_message(messages):
@@ -200,7 +235,7 @@ def test_authenticated_acknowledging_breaking_server():
     async def test_fastapi_server():
         import asyncio
 
-        async with websockets.connect("ws://127.0.0.1:8000/") as websocket:
+        async with websockets.connect(_server_ws_url()) as websocket:
             # Connect to the websocket
             print("Connected to WebSocket")
 
@@ -208,7 +243,7 @@ def test_authenticated_acknowledging_breaking_server():
             await websocket.send(json.dumps({"auth": "testing"}))
 
             # Sending POST request
-            post_url = "http://127.0.0.1:8000/settings"
+            post_url = _server_http_url("/settings")
             settings = {
                 "llm": {
                     "model": "gpt-4o-mini",
@@ -281,24 +316,24 @@ def test_authenticated_acknowledging_breaking_server():
         # Now let's hilariously keep going
         print("RESUMING")
 
-        async with websockets.connect("ws://127.0.0.1:8000/") as websocket:
+        async with websockets.connect(_server_ws_url()) as websocket:
             # Connect to the websocket
             print("Connected to WebSocket")
 
             # Sending message via WebSocket
             await websocket.send(json.dumps({"auth": "testing"}))
 
-            poem += await _wait_for_websocket_complete(websocket, acknowledge=True)
+            poem += await _wait_for_websocket_complete(
+                websocket, acknowledge=True, phase="auth_server_resume_poem"
+            )
 
             time.sleep(1)
             print("Is this a normal poem?")
             print(poem)
             time.sleep(1)
 
-    # Get the current event loop and run the test function
-    loop = asyncio.get_event_loop()
     try:
-        loop.run_until_complete(test_fastapi_server())
+        asyncio.run(test_fastapi_server())
     finally:
         _stop_server_subprocess(process)
 
@@ -331,7 +366,7 @@ def test_server():
     async def test_fastapi_server():
         import asyncio
 
-        async with websockets.connect("ws://127.0.0.1:8000/") as websocket:
+        async with websockets.connect(_server_ws_url()) as websocket:
             # Connect to the websocket
             print("Connected to WebSocket")
 
@@ -339,7 +374,7 @@ def test_server():
             await websocket.send(json.dumps({"auth": "dummy-api-key"}))
 
             # Sending POST request
-            post_url = "http://127.0.0.1:8000/settings"
+            post_url = _server_http_url("/settings")
             settings = {
                 "llm": {"model": "gpt-4o-mini"},
                 "messages": [
@@ -375,12 +410,14 @@ def test_server():
             print("WebSocket chunks sent")
 
             # Wait for a specific response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="secret_word_crunk", server_process=process
+            )
 
             assert "crunk" in accumulated_content
 
             # Send another POST request
-            post_url = "http://127.0.0.1:8000/settings"
+            post_url = _server_http_url("/settings")
             settings = {
                 "llm": {"model": "gpt-4o-mini"},
                 "messages": [
@@ -416,12 +453,14 @@ def test_server():
             print("WebSocket chunks sent")
 
             # Wait for a specific response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="secret_word_barloney", server_process=process
+            )
 
             assert "barloney" in accumulated_content
 
             # Send another POST request
-            post_url = "http://127.0.0.1:8000/settings"
+            post_url = _server_http_url("/settings")
             settings = {
                 "messages": [],
                 "custom_instructions": "",
@@ -450,12 +489,14 @@ def test_server():
             print("WebSocket chunks sent")
 
             # Wait for response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="math_code_auto_run_false", server_process=process
+            )
 
             time.sleep(5)
 
             # Send a GET request to /settings/messages
-            get_url = "http://127.0.0.1:8000/settings/messages"
+            get_url = _server_http_url("/settings/messages")
             response = requests.get(get_url)
             print("GET request sent, response:", response.json())
 
@@ -485,14 +526,16 @@ def test_server():
             )
 
             # Wait for a specific response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="go_execute_code", server_process=process
+            )
 
             assert "18893094989" in accumulated_content.replace(",", "")
 
             #### TEST FILE ####
 
             # Send another POST request
-            post_url = "http://127.0.0.1:8000/settings"
+            post_url = _server_http_url("/settings")
             settings = {"messages": [], "auto_run": True}
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
@@ -540,10 +583,12 @@ def test_server():
             print("WebSocket chunks sent")
 
             # Wait for response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="file_exists", server_process=process
+            )
 
             # Get messages
-            get_url = "http://127.0.0.1:8000/settings/messages"
+            get_url = _server_http_url("/settings/messages")
             response_json = requests.get(get_url).json()
             print("GET request sent, response:", response_json)
             if isinstance(response_json, str):
@@ -561,7 +606,7 @@ def test_server():
             #### TEST IMAGES ####
 
             # Send another POST request
-            post_url = "http://127.0.0.1:8000/settings"
+            post_url = _server_http_url("/settings")
             settings = {"messages": [], "auto_run": True}
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
@@ -610,10 +655,12 @@ def test_server():
             print("WebSocket chunks sent")
 
             # Wait for response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="vision_mcq", server_process=process
+            )
 
             # Get messages
-            get_url = "http://127.0.0.1:8000/settings/messages"
+            get_url = _server_http_url("/settings/messages")
             response_json = requests.get(get_url).json()
             print("GET request sent, response:", response_json)
             if isinstance(response_json, str):
@@ -628,7 +675,7 @@ def test_server():
 
             # Sending POST request to /run endpoint with code to kill a thread in Python
             # actually wait i dont think this will work..? will just kill the python interpreter
-            post_url = "http://127.0.0.1:8000/run"
+            post_url = _server_http_url("/run")
             code_data = {
                 "code": "import os, signal; os.kill(os.getpid(), signal.SIGINT)",
                 "language": "python",
@@ -636,10 +683,8 @@ def test_server():
             response = requests.post(post_url, json=code_data, timeout=30)
             print("POST request sent, response:", response.json())
 
-    # Get the current event loop and run the test function
-    loop = asyncio.get_event_loop()
     try:
-        loop.run_until_complete(test_fastapi_server())
+        asyncio.run(test_fastapi_server())
     finally:
         _stop_server_subprocess(process)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`test_server` hangs on the **file existence** turn (`phase: file_exists`): the LLM streams shell code (`test -f /something.txt ...`) but the client never receives console output or `complete`, then times out after 300s.

Likely cause on home Linux: bash subprocess starts with `$SHELL` and sources `.bashrc`/profile from HOME — when HOME or cwd is on a slow/network sync mount (`/mnt/Int_Butter/...`), that can block indefinitely.

## Fixes

### Product
- **`shell.py`**: start bash with `--norc --noprofile`, zsh with `-f`
- **`subprocess_language.py`**: `INTERPRETER_SUBPROCESS_TIMEOUT` (default 120s) so run loops cannot hang forever
- **`async_core.py`**: bound `respond_thread.join()` to 30s

### Tests
- Dynamic free port per server subprocess (avoids port 8000 collisions between server tests)
- `_wait_for_websocket_complete(..., phase=..., server_process=...)` for clearer failures
- `asyncio.run()` instead of deprecated `get_event_loop()`
- Register pytest `integration` / `timeout` markers in `pyproject.toml`

## Verify locally

```bash
pip install -e ".[server,dev]"
pytest tests/test_interpreter.py::test_server -sv --timeout=900
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa14b8e7-5b3c-4995-bc4f-fcace6218899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa14b8e7-5b3c-4995-bc4f-fcace6218899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

