### PR TITLE
Fix streaming shell output duplication for embedded consumers

### DIFF
--- a/docs/guides/streaming-response.mdx
+++ b/docs/guides/streaming-response.mdx
@@ -125,6 +125,8 @@ You'll then receive its output, if it produces any:
 {"role": "computer", "type": "console", "format": "output", "content": "1.4166666666666667\n"}
 ```
 
+Each `output` chunk is an incremental delta (for shell commands, typically one line at a time). Append each chunk's `content` to build the full output. Do not re-read `interpreter.messages[-1]` on every chunk while streaming—that list holds the accumulated history, not per-chunk snapshots.
+
 When the code is **finished** executing, this flag will be sent:
 
 ```

--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -360,7 +360,7 @@ class OpenInterpreter:
                         last_flag_base = None
 
                     if self.auto_run == False:
-                        yield chunk
+                        yield chunk.copy()
 
                     # We want to append this now, so even if content is never filled, we know that the execution didn't produce output.
                     # ... rethink this though.
@@ -402,7 +402,7 @@ class OpenInterpreter:
                                 for property in ["role", "type", "format"]
                             ]
                         ):
-                            self.messages.append(chunk)
+                            self.messages.append(chunk.copy())
                         else:
                             self.messages[-1]["content"] += chunk["content"]
                 else:
@@ -420,10 +420,11 @@ class OpenInterpreter:
 
                     # Add the chunk as a new message
                     if not is_ephemeral(chunk):
-                        self.messages.append(chunk)
+                        self.messages.append(chunk.copy())
 
-                # Yield the chunk itself
-                yield chunk
+                # Yield a copy so consumers keep incremental deltas; self.messages
+                # accumulates content on its own dicts (see issue #73).
+                yield chunk.copy()
 
                 # Truncate output if it's console output
                 if chunk["type"] == "console" and chunk["format"] == "output":

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -189,6 +189,55 @@ def test_hallucinations():
             break
 
 
+def test_streaming_output_chunks_are_incremental():
+    """
+    Regression test for issue #73: multi-line shell output must stream
+    incremental deltas. Previously, _respond_and_store reused the same dict
+    objects for yielded chunks and accumulated messages, so consumers that
+    held references to earlier chunks saw growing content on every new line.
+    """
+    from unittest.mock import patch
+
+    output_lines = ["file1\n", "file2\n", "file3\n"]
+    respond_chunks = [
+        {
+            "role": "computer",
+            "type": "console",
+            "format": "output",
+            "content": line,
+        }
+        for line in output_lines
+    ]
+
+    original_messages = interpreter.messages
+    try:
+        interpreter.messages = [
+            {
+                "role": "assistant",
+                "type": "code",
+                "format": "shell",
+                "content": "ls -l",
+            }
+        ]
+
+        with patch("interpreter.core.core.respond", return_value=iter(respond_chunks)):
+            yielded_output_chunks = []
+            for chunk in interpreter._respond_and_store():
+                if chunk.get("format") == "output":
+                    yielded_output_chunks.append(chunk)
+
+            assert [c["content"] for c in yielded_output_chunks] == output_lines
+
+            # Earlier yielded chunks must not be mutated as later lines arrive.
+            assert yielded_output_chunks[0]["content"] == "file1\n"
+            assert yielded_output_chunks[1]["content"] == "file2\n"
+
+            # Conversation history should still accumulate the full output.
+            assert interpreter.messages[-1]["content"] == "".join(output_lines)
+    finally:
+        interpreter.messages = original_messages
+
+
 def run_auth_server():
     os.environ["INTERPRETER_REQUIRE_ACKNOWLEDGE"] = "True"
     os.environ["INTERPRETER_API_KEY"] = "testing"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #73

## Problem

When embedding Open Interpreter and streaming shell command output (e.g. `ls -l`), consumers saw the same command repeated with progressively longer output — once per output line. For a directory with 3 files, the consumer would see 3 redundant `ls -l` blocks with 1, 2, and 3 lines respectively.

## Root cause

`_respond_and_store()` in `interpreter/core/core.py` used the **same dict objects** for both:

1. **Stream chunks** yielded to programmatic consumers (`interpreter.chat(stream=True, display=False)`)
2. **Accumulated message history** in `interpreter.messages`

When multi-line shell output arrived, later lines mutated `messages[-1]["content"]` in place — but that dict had already been yielded as the first output chunk. Consumers that re-read `interpreter.messages[-1]` (or held references to earlier yielded chunks) saw growing content on every new line.

## Fix

- Copy chunks before appending to `self.messages`
- Yield `chunk.copy()` so each streamed chunk is an immutable incremental delta
- `interpreter.messages` still accumulates the full output for LLM history

## Testing

- Added `test_streaming_output_chunks_are_incremental` regression test
- All non-integration tests pass locally (`pytest -m "not integration"`)

## Docs

Added a note to `docs/guides/streaming-response.mdx` clarifying that `output` chunks are incremental deltas and should be appended, not re-read from `interpreter.messages[-1]` during streaming.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf2b4b7b-942e-437b-9ce1-86cd9ad0aa49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf2b4b7b-942e-437b-9ce1-86cd9ad0aa49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that streamed output arrives as incremental chunks that should be appended to reconstruct the complete response.
  * Explained the difference between individual chunks and accumulated conversation history.

* **Bug Fixes**
  * Improved streaming behavior so incremental output remains independent from stored conversation history.

* **Tests**
  * Added coverage verifying streamed shell-output chunks and accumulated history remain correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->