### PR TITLE
fix(server): bind async code approval and harden non-loopback auth

### DIFF
--- a/docs/server/usage.mdx
+++ b/docs/server/usage.mdx
@@ -61,7 +61,13 @@ To control the server's behavior, send the following commands:
    ```json
    {"role": "user", "type": "command", "content": "go"}
    ```
-   This executes a generated code block and allows the agent to proceed.
+   This approves the pending code block shown in the most recent `confirmation` chunk and resumes execution of that exact code.
+
+   When the server sends a confirmation chunk, it includes a `confirmation_id` (SHA-256 digest of the language + code). Clients should send `go:<confirmation_id>` to bind approval to the reviewed code:
+
+   ```json
+   {"role": "user", "type": "command", "content": "go:abc123..."}
+   ```
 
    **Note**: If `auto_run` is set to `False`, the agent will pause after generating code blocks. You must send the "go" command to continue execution.
 
@@ -163,11 +169,12 @@ import requests
 settings = {
     "llm": {"model": "gpt-4"},
     "custom_instructions": "You only write Python code.",
-    "auto_run": True,
 }
 response = requests.post("http://localhost:8000/settings", json=settings)
 print(response.status_code)
 ```
+
+Sensitive settings such as `auto_run`, `safe_mode`, `system_message`, and `messages` cannot be changed through this endpoint.
 
 ### Retrieving Settings
 To get current settings, send a GET request to `http://localhost:8000/settings/{property}`.
@@ -304,6 +311,24 @@ from interpreter import AsyncInterpreter
 async_interpreter = AsyncInterpreter()
 async_interpreter.server.run()
 ```
+
+## Authentication
+
+By default, the server binds to `127.0.0.1` and does not require an API key. This matches the CLI model: you are running the server on your own machine.
+
+If you bind to a non-loopback address (for example `0.0.0.0`), the server requires `INTERPRETER_API_KEY`. When that variable is unset, the server generates a random key at startup and prints it.
+
+Set a fixed key before starting the server:
+
+```bash
+export INTERPRETER_API_KEY="your-secret-key"
+interpreter --server --host 0.0.0.0
+```
+
+Clients must then authenticate:
+
+- **WebSocket**: send `{"auth": "your-secret-key"}` as the first message.
+- **HTTP**: include the `X-API-KEY: your-secret-key` header.
 
 ## Advanced Usage: Accessing the FastAPI App Directly
 

--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -142,7 +142,12 @@ class AsyncInterpreter(OpenInterpreter):
 
         if "start" in chunk:
             # If the user is starting something, the interpreter should stop.
-            if self.respond_thread is not None and self.respond_thread.is_alive():
+            # Command blocks (e.g. go/stop) must not tear down a thread waiting on approval.
+            if (
+                self.respond_thread is not None
+                and self.respond_thread.is_alive()
+                and chunk.get("type") != "command"
+            ):
                 self.stop_event.set()
                 self._cancel_pending_approval()
                 self.respond_thread.join()

--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -1,6 +1,8 @@
 import asyncio
+import hashlib
 import json
 import os
+import secrets
 import shutil
 import socket
 import threading
@@ -40,6 +42,45 @@ except:
 
 complete_message = {"role": "server", "type": "status", "content": "complete"}
 
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+# Top-level interpreter attributes that must not be changed via POST /settings.
+SENSITIVE_SERVER_SETTINGS = frozenset(
+    {"auto_run", "safe_mode", "system_message", "messages"}
+)
+SENSITIVE_LLM_SETTINGS = frozenset({"api_base", "api_key"})
+
+
+def is_loopback_host(host: str) -> bool:
+    return host in LOOPBACK_HOSTS
+
+
+def confirmation_digest(confirmation_content: Dict[str, Any]) -> str:
+    """
+    Stable digest for a confirmation payload so approval can be bound to reviewed code.
+    """
+    language = confirmation_content.get("format", "")
+    code = confirmation_content.get("content", "")
+    payload = f"{language}\0{code}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def ensure_server_api_key(host: str) -> Optional[str]:
+    """
+    Non-loopback binds require an API key. Generate one when missing so the server
+    does not listen on the network without credentials.
+    """
+    if is_loopback_host(host):
+        return None
+
+    existing_key = os.getenv("INTERPRETER_API_KEY")
+    if existing_key:
+        return None
+
+    generated_key = secrets.token_urlsafe(32)
+    os.environ["INTERPRETER_API_KEY"] = generated_key
+    return generated_key
+
 
 class AsyncInterpreter(OpenInterpreter):
     def __init__(self, *args, **kwargs):
@@ -49,6 +90,11 @@ class AsyncInterpreter(OpenInterpreter):
         self.stop_event = threading.Event()
         self.output_queue = None
         self.unsent_messages = deque()
+        self._respond_iterator = None
+        self._approval_event = threading.Event()
+        self._approval_granted = False
+        self.pending_confirmation = None
+        self.pending_confirmation_digest = None
         self.id = os.getenv("INTERPRETER_ID", datetime.now().timestamp())
         self.print = False  # Will print output
 
@@ -62,6 +108,32 @@ class AsyncInterpreter(OpenInterpreter):
         # For the 01. This lets the OAI compatible server accumulate context before responding.
         self.context_mode = False
 
+    def _clear_pending_confirmation(self):
+        self.pending_confirmation = None
+        self.pending_confirmation_digest = None
+
+    def _cancel_pending_approval(self):
+        self._approval_granted = False
+        self._approval_event.set()
+
+    def _reset_respond_iterator(self):
+        self._respond_iterator = None
+        self._clear_pending_confirmation()
+
+    def _approve_pending_confirmation(self, digest: Optional[str] = None) -> bool:
+        if self.pending_confirmation is None:
+            return False
+
+        if (
+            digest is not None
+            and digest != self.pending_confirmation_digest
+        ):
+            return False
+
+        self._approval_granted = True
+        self._approval_event.set()
+        return True
+
     async def input(self, chunk):
         """
         Accumulates LMC chunks onto interpreter.messages.
@@ -72,6 +144,7 @@ class AsyncInterpreter(OpenInterpreter):
             # If the user is starting something, the interpreter should stop.
             if self.respond_thread is not None and self.respond_thread.is_alive():
                 self.stop_event.set()
+                self._cancel_pending_approval()
                 self.respond_thread.join()
             self.accumulate(chunk)
         elif "content" in chunk:
@@ -89,14 +162,44 @@ class AsyncInterpreter(OpenInterpreter):
                 if command == "stop":
                     # Any start flag would have stopped it a moment ago, but to be sure:
                     self.stop_event.set()
-                    self.respond_thread.join()
+                    self._cancel_pending_approval()
+                    if self.respond_thread is not None:
+                        self.respond_thread.join()
                     return
-                if command == "go":
-                    # This is to approve code.
-                    run_code = True
-                    pass
+                if command == "go" or command.startswith("go:"):
+                    digest = None
+                    if command.startswith("go:"):
+                        digest = command.split(":", 1)[1]
+
+                    if not self._approve_pending_confirmation(digest):
+                        if self.output_queue is not None:
+                            self.output_queue.sync_q.put(
+                                {
+                                    "role": "server",
+                                    "type": "error",
+                                    "content": "No pending code approval matches that request.",
+                                }
+                            )
+                            self.output_queue.sync_q.put(complete_message)
+                        return
+
+                    # Approval resumes the existing respond thread; do not start a new one.
+                    if self.respond_thread is not None and self.respond_thread.is_alive():
+                        return
+
+                    if self.output_queue is not None:
+                        self.output_queue.sync_q.put(
+                            {
+                                "role": "server",
+                                "type": "error",
+                                "content": "No active response is waiting for code approval.",
+                            }
+                        )
+                        self.output_queue.sync_q.put(complete_message)
+                    return
 
             self.stop_event.clear()
+            self._reset_respond_iterator()
             self.respond_thread = threading.Thread(
                 target=self.respond, args=(run_code,)
             )
@@ -110,12 +213,26 @@ class AsyncInterpreter(OpenInterpreter):
     def respond(self, run_code=None):
         for attempt in range(5):  # 5 attempts
             try:
-                if run_code == None:
+                if run_code is None:
                     run_code = self.auto_run
 
                 sent_chunks = False
 
-                for chunk_og in self._respond_and_store():
+                if self._respond_iterator is None:
+                    self._respond_iterator = iter(self._respond_and_store())
+
+                while True:
+                    if self.stop_event.is_set():
+                        self._cancel_pending_approval()
+                        self._reset_respond_iterator()
+                        return
+
+                    try:
+                        chunk_og = next(self._respond_iterator)
+                    except StopIteration:
+                        self._reset_respond_iterator()
+                        break
+
                     chunk = (
                         chunk_og.copy()
                     )  # This fixes weird double token chunks. Probably a deeper problem?
@@ -123,11 +240,35 @@ class AsyncInterpreter(OpenInterpreter):
                     if chunk["type"] == "confirmation":
                         if run_code:
                             run_code = False
+                        elif not self.auto_run:
+                            self.pending_confirmation = chunk["content"]
+                            self.pending_confirmation_digest = confirmation_digest(
+                                chunk["content"]
+                            )
+                            chunk["confirmation_id"] = self.pending_confirmation_digest
+
+                            if self.print:
+                                print("\n")
+                            if self.debug:
+                                print("Interpreter produced this chunk:", chunk)
+
+                            self.output_queue.sync_q.put(chunk)
+                            sent_chunks = True
+
+                            self._approval_granted = False
+                            self._approval_event.clear()
+                            self._approval_event.wait()
+
+                            if not self._approval_granted:
+                                self._reset_respond_iterator()
+                                return
+
+                            self._clear_pending_confirmation()
                             continue
-                        else:
-                            break
 
                     if self.stop_event.is_set():
+                        self._cancel_pending_approval()
+                        self._reset_respond_iterator()
                         return
 
                     if self.print:
@@ -280,14 +421,12 @@ def authenticate_function(key):
     """
     This function checks if the provided key is valid for authentication.
 
-    Returns True if the key is valid, False otherwise.
+    When INTERPRETER_API_KEY is unset, loopback-only servers accept any key so local
+    development stays frictionless. Non-loopback binds call ensure_server_api_key()
+    before listening, which sets INTERPRETER_API_KEY when it was missing.
     """
-    # Fetch the API key from the environment variables. If it's not set, return True.
     api_key = os.getenv("INTERPRETER_API_KEY", None)
 
-    # If the API key is not set in the environment variables, return True.
-    # Otherwise, check if the provided key matches the fetched API key.
-    # Return True if they match, False otherwise.
     if api_key is None:
         return True
     else:
@@ -325,10 +464,15 @@ def create_router(async_interpreter):
             + str(async_interpreter.server.port)
             + """/");
                     var lastMessageElement = null;
+                    var lastConfirmationId = null;
 
                     ws.onmessage = function(event) {
 
                         var eventData = JSON.parse(event.data);
+
+                        if (eventData.type === "confirmation" && eventData.confirmation_id) {
+                            lastConfirmationId = eventData.confirmation_id;
+                        }
 
                         """
             + (
@@ -407,7 +551,7 @@ def create_router(async_interpreter):
                     var commandBlock = {
                         "role": "user",
                         "type": "command",
-                        "content": "go"
+                        "content": lastConfirmationId ? ("go:" + lastConfirmationId) : "go"
                     };
                     ws.send(JSON.stringify(commandBlock));
 
@@ -643,12 +787,23 @@ def create_router(async_interpreter):
     async def set_settings(payload: Dict[str, Any]):
         for key, value in payload.items():
             print("Updating settings...")
-            # print(f"Updating settings: {key} = {value}")
-            if key in ["llm", "computer"] and isinstance(value, dict):
-                if key == "auto_run":
-                    return {
+            if key in SENSITIVE_SERVER_SETTINGS:
+                return JSONResponse(
+                    status_code=HTTP_403_FORBIDDEN,
+                    content={
                         "error": f"The setting {key} is not modifiable through the server due to security constraints."
-                    }, 403
+                    },
+                )
+            if key in ["llm", "computer"] and isinstance(value, dict):
+                if key == "llm":
+                    for sub_key in value:
+                        if sub_key in SENSITIVE_LLM_SETTINGS:
+                            return JSONResponse(
+                                status_code=HTTP_403_FORBIDDEN,
+                                content={
+                                    "error": f"The setting llm.{sub_key} is not modifiable through the server due to security constraints."
+                                },
+                            )
                 if hasattr(async_interpreter, key):
                     for sub_key, sub_value in value.items():
                         if hasattr(getattr(async_interpreter, key), sub_key):
@@ -1004,6 +1159,8 @@ class Server:
         if port is not None:
             self.port = port
 
+        generated_api_key = ensure_server_api_key(self.host)
+
         # Print server information
         if self.host == "0.0.0.0":
             print(
@@ -1015,6 +1172,15 @@ class Server:
             s.close()
         else:
             print(f"Server will run at http://{self.host}:{self.port}")
+
+        if generated_api_key:
+            print(
+                "Warning: INTERPRETER_API_KEY was not set. Generated one for this session:"
+            )
+            print(generated_api_key)
+            print(
+                "Pass it as the WebSocket `auth` message and HTTP `X-API-KEY` header."
+            )
 
         self.uvicorn_server.run()
 

--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -257,10 +257,12 @@ class AsyncInterpreter(OpenInterpreter):
 
                             self._approval_granted = False
                             self._approval_event.clear()
+                            self.output_queue.sync_q.put(complete_message)
                             self._approval_event.wait()
 
                             if not self._approval_granted:
                                 self._reset_respond_iterator()
+                                self.output_queue.sync_q.put(complete_message)
                                 return
 
                             self._clear_pending_confirmation()

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -128,6 +128,27 @@ class TestAsyncApprovalBinding(TestCase):
         self.assertFalse(self.interpreter._approve_pending_confirmation("deadbeef"))
 
 
+class TestAsyncInputCommandHandling(TestCase):
+    def setUp(self):
+        self.interpreter = AsyncInterpreter()
+        self.interpreter.auto_run = False
+        self.interpreter.output_queue = mock.MagicMock()
+        self.interpreter.output_queue.sync_q = mock.MagicMock()
+        self.interpreter.respond_thread = mock.MagicMock()
+        self.interpreter.respond_thread.is_alive.return_value = True
+
+    def test_command_start_does_not_require_join(self):
+        import asyncio
+
+        async def run():
+            await self.interpreter.input(
+                {"role": "user", "type": "command", "start": True}
+            )
+            self.interpreter.respond_thread.join.assert_not_called()
+
+        asyncio.run(run())
+
+
 class TestSettingsEndpointGuards(TestCase):
     def test_sensitive_settings_constant_includes_auto_run(self):
         self.assertIn("auto_run", SENSITIVE_SERVER_SETTINGS)

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -1,7 +1,15 @@
 import os
 from unittest import TestCase, mock
 
-from interpreter.core.async_core import AsyncInterpreter, Server
+from interpreter.core.async_core import (
+    AsyncInterpreter,
+    SENSITIVE_SERVER_SETTINGS,
+    Server,
+    authenticate_function,
+    confirmation_digest,
+    ensure_server_api_key,
+    is_loopback_host,
+)
 
 
 class TestServerConstruction(TestCase):
@@ -16,7 +24,7 @@ class TestServerConstruction(TestCase):
         a) no host and port are passed in, and
         b) no HOST and PORT are set.
         """
-        with mock.patch.dict(os.environ, {}):
+        with mock.patch.dict(os.environ, {}, clear=True):
             s = Server(AsyncInterpreter())
             self.assertEqual(s.host, Server.DEFAULT_HOST)
             self.assertEqual(s.port, Server.DEFAULT_PORT)
@@ -32,6 +40,7 @@ class TestServerConstruction(TestCase):
         with mock.patch.dict(
             os.environ,
             {"INTERPRETER_HOST": "this-is-supes-fake", "INTERPRETER_PORT": "9876"},
+            clear=True,
         ):
             sboth = Server(AsyncInterpreter(), host, port)
             self.assertEqual(sboth.host, host)
@@ -48,7 +57,87 @@ class TestServerConstruction(TestCase):
         with mock.patch.dict(
             os.environ,
             {"INTERPRETER_HOST": fake_host, "INTERPRETER_PORT": str(fake_port)},
+            clear=True,
         ):
             s = Server(AsyncInterpreter())
             self.assertEqual(s.host, fake_host)
             self.assertEqual(s.port, fake_port)
+
+
+class TestAsyncServerSecurityHelpers(TestCase):
+    def test_is_loopback_host(self):
+        self.assertTrue(is_loopback_host("127.0.0.1"))
+        self.assertTrue(is_loopback_host("localhost"))
+        self.assertTrue(is_loopback_host("::1"))
+        self.assertFalse(is_loopback_host("0.0.0.0"))
+
+    def test_confirmation_digest_is_stable(self):
+        payload = {"type": "code", "format": "python", "content": "print('hi')"}
+        self.assertEqual(
+            confirmation_digest(payload),
+            confirmation_digest(payload),
+        )
+        changed = {"type": "code", "format": "python", "content": "print('bye')"}
+        self.assertNotEqual(confirmation_digest(payload), confirmation_digest(changed))
+
+    def test_authenticate_function_without_api_key(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(authenticate_function(None))
+            self.assertTrue(authenticate_function("anything"))
+
+    def test_authenticate_function_with_api_key(self):
+        with mock.patch.dict(os.environ, {"INTERPRETER_API_KEY": "secret"}, clear=True):
+            self.assertTrue(authenticate_function("secret"))
+            self.assertFalse(authenticate_function("wrong"))
+            self.assertFalse(authenticate_function(None))
+
+    def test_ensure_server_api_key_loopback_does_not_generate(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(ensure_server_api_key("127.0.0.1"))
+            self.assertNotIn("INTERPRETER_API_KEY", os.environ)
+
+    def test_ensure_server_api_key_non_loopback_generates(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            generated = ensure_server_api_key("0.0.0.0")
+            self.assertIsNotNone(generated)
+            self.assertEqual(os.environ["INTERPRETER_API_KEY"], generated)
+
+
+class TestAsyncApprovalBinding(TestCase):
+    def setUp(self):
+        self.interpreter = AsyncInterpreter()
+        self.interpreter.auto_run = False
+
+    def test_approve_pending_confirmation_requires_pending_state(self):
+        self.assertFalse(self.interpreter._approve_pending_confirmation())
+
+    def test_approve_pending_confirmation_accepts_matching_digest(self):
+        payload = {"type": "code", "format": "python", "content": "print(1)"}
+        self.interpreter.pending_confirmation = payload
+        self.interpreter.pending_confirmation_digest = confirmation_digest(payload)
+
+        digest = self.interpreter.pending_confirmation_digest
+        self.assertTrue(self.interpreter._approve_pending_confirmation(digest))
+        self.assertTrue(self.interpreter._approval_granted)
+
+    def test_approve_pending_confirmation_rejects_wrong_digest(self):
+        payload = {"type": "code", "format": "python", "content": "print(1)"}
+        self.interpreter.pending_confirmation = payload
+        self.interpreter.pending_confirmation_digest = confirmation_digest(payload)
+
+        self.assertFalse(self.interpreter._approve_pending_confirmation("deadbeef"))
+
+
+class TestSettingsEndpointGuards(TestCase):
+    def test_sensitive_settings_constant_includes_auto_run(self):
+        self.assertIn("auto_run", SENSITIVE_SERVER_SETTINGS)
+
+    def test_post_settings_blocks_auto_run(self):
+        interpreter = AsyncInterpreter()
+        server = Server(interpreter)
+        from fastapi.testclient import TestClient
+
+        client = TestClient(server.app)
+        response = client.post("/settings", json={"auto_run": True})
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("auto_run", response.json()["error"])

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -587,9 +587,11 @@ def test_server():
 
                 accumulated_content = await _wait_for_websocket_complete(image_websocket)
 
+                # _wait_for_websocket_complete appends the status content "complete".
+                vision_reply = accumulated_content.removesuffix("complete")
                 assert re.search(
-                    r"\bB\b", accumulated_content, re.IGNORECASE
-                ), f"expected vision model to answer B (gradient), got: {accumulated_content!r}"
+                    r"\bB\b", vision_reply, re.IGNORECASE
+                ), f"expected vision model to answer B (gradient), got: {vision_reply!r}"
 
             # Sending POST request to /run endpoint with code to kill a thread in Python
             # actually wait i dont think this will work..? will just kill the python interpreter

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -329,6 +329,7 @@ def test_server():
     import websockets
 
     async def test_fastapi_server():
+        nonlocal process
         import asyncio
 
         async with websockets.connect("ws://127.0.0.1:8000/") as websocket:

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -589,19 +589,9 @@ def test_server():
             # Wait for response
             accumulated_content = await _wait_for_websocket_complete(websocket)
 
-            # Get messages
-            get_url = "http://127.0.0.1:8000/settings/messages"
-            response_json = requests.get(get_url).json()
-            print("GET request sent, response:", response_json)
-            if isinstance(response_json, str):
-                response_json = json.loads(response_json)
-            messages = response_json["messages"]
-
-            last_assistant = _last_assistant_message(messages)
-            assert last_assistant, "expected assistant message after image turn"
             assert re.search(
-                r"\bB\b", last_assistant, re.IGNORECASE
-            ), f"expected vision model to answer B (gradient), got: {last_assistant!r}"
+                r"\bB\b", accumulated_content, re.IGNORECASE
+            ), f"expected vision model to answer B (gradient), got: {accumulated_content!r}"
 
             # Sending POST request to /run endpoint with code to kill a thread in Python
             # actually wait i dont think this will work..? will just kill the python interpreter

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -543,55 +543,52 @@ def test_server():
 
             #### TEST IMAGES ####
 
-            base64png = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAADMElEQVR4nOzVwQnAIBQFQYXff81RUkQCOyDj1YOPnbXWPmeTRef+/3O/OyBjzh3CD95BfqICMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMO0TAAD//2Anhf4QtqobAAAAAElFTkSuQmCC"
+            # Message history can no longer be cleared via POST /settings, so restart
+            # the server for an isolated vision turn.
+            await websocket.close()
+            _stop_server_subprocess(process)
+            process = _start_server_subprocess(run_server)
+            _wait_for_server(process)
 
-            # Sending messages via WebSocket
-            await websocket.send(json.dumps({"role": "user", "start": True}))
-            await websocket.send(
-                json.dumps(
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": (
-                            "What do you see in this image? Reply with only one letter.\n"
-                            "A) a cat\n"
-                            "B) a color gradient\n"
-                            "C) a table of numbers\n"
-                            "D) a black rectangle"
-                        ),
-                    }
+            async with websockets.connect("ws://127.0.0.1:8000/") as image_websocket:
+                await image_websocket.send(json.dumps({"auth": "dummy-api-key"}))
+
+                base64png = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAADMElEQVR4nOzVwQnAIBQFQYXff81RUkQCOyDj1YOPnbXWPmeTRef+/3O/OyBjzh3CD95BfqICMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMO0TAAD//2Anhf4QtqobAAAAAElFTkSuQmCC"
+
+                await image_websocket.send(json.dumps({"role": "user", "start": True}))
+                await image_websocket.send(
+                    json.dumps(
+                        {
+                            "role": "user",
+                            "type": "message",
+                            "content": (
+                                "What do you see in this image? Reply with only one letter.\n"
+                                "A) a cat\n"
+                                "B) a color gradient\n"
+                                "C) a table of numbers\n"
+                                "D) a black rectangle"
+                            ),
+                        }
+                    )
                 )
-            )
-            await websocket.send(
-                json.dumps(
-                    {
-                        "role": "user",
-                        "type": "image",
-                        "format": "base64.png",
-                        "content": base64png,
-                    }
+                await image_websocket.send(
+                    json.dumps(
+                        {
+                            "role": "user",
+                            "type": "image",
+                            "format": "base64.png",
+                            "content": base64png,
+                        }
+                    )
                 )
-            )
-            # await websocket.send(
-            #     json.dumps(
-            #         {
-            #             "role": "user",
-            #             "type": "image",
-            #             "format": "path",
-            #             "content": "/Users/killianlucas/Documents/GitHub/open-interpreter/screen.png",
-            #         }
-            #     )
-            # )
+                await image_websocket.send(json.dumps({"role": "user", "end": True}))
+                print("WebSocket chunks sent")
 
-            await websocket.send(json.dumps({"role": "user", "end": True}))
-            print("WebSocket chunks sent")
+                accumulated_content = await _wait_for_websocket_complete(image_websocket)
 
-            # Wait for response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
-
-            assert re.search(
-                r"\bB\b", accumulated_content, re.IGNORECASE
-            ), f"expected vision model to answer B (gradient), got: {accumulated_content!r}"
+                assert re.search(
+                    r"\bB\b", accumulated_content, re.IGNORECASE
+                ), f"expected vision model to answer B (gradient), got: {accumulated_content!r}"
 
             # Sending POST request to /run endpoint with code to kill a thread in Python
             # actually wait i dont think this will work..? will just kill the python interpreter

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -215,13 +215,13 @@ def test_authenticated_acknowledging_breaking_server():
                     "execution_instructions": "",
                     "supports_functions": False,
                 },
-                "system_message": "You are a poem writing bot. Do not do anything but respond with a poem.",
-                "auto_run": True,
+                "custom_instructions": "You are a poem writing bot. Do not do anything but respond with a poem.",
             }
             response = requests.post(
                 post_url, json=settings, headers={"X-API-KEY": "testing"}
             )
             print("POST request sent, response:", response.json())
+            assert response.status_code == 200
 
             # Sending messages via WebSocket
             await websocket.send(
@@ -342,19 +342,11 @@ def test_server():
             post_url = "http://127.0.0.1:8000/settings"
             settings = {
                 "llm": {"model": "gpt-4o-mini"},
-                "messages": [
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": "The secret word is 'crunk'.",
-                    },
-                    {"role": "assistant", "type": "message", "content": "Understood."},
-                ],
                 "custom_instructions": "",
-                "auto_run": True,
             }
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
+            assert response.status_code == 200
 
             # Sending messages via WebSocket
             await websocket.send(
@@ -365,7 +357,10 @@ def test_server():
                     {
                         "role": "user",
                         "type": "message",
-                        "content": "What's the secret word?",
+                        "content": (
+                            "The secret word is 'crunk'. What is the secret word? "
+                            "Reply with only that word."
+                        ),
                     }
                 )
             )
@@ -383,19 +378,11 @@ def test_server():
             post_url = "http://127.0.0.1:8000/settings"
             settings = {
                 "llm": {"model": "gpt-4o-mini"},
-                "messages": [
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": "The secret word is 'barloney'.",
-                    },
-                    {"role": "assistant", "type": "message", "content": "Understood."},
-                ],
                 "custom_instructions": "",
-                "auto_run": True,
             }
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
+            assert response.status_code == 200
 
             # Sending messages via WebSocket
             await websocket.send(
@@ -406,7 +393,10 @@ def test_server():
                     {
                         "role": "user",
                         "type": "message",
-                        "content": "What's the secret word?",
+                        "content": (
+                            "The secret word is now 'barloney' (ignore any previous secret word). "
+                            "What is the secret word? Reply with only that word."
+                        ),
                     }
                 )
             )
@@ -423,13 +413,12 @@ def test_server():
             # Send another POST request
             post_url = "http://127.0.0.1:8000/settings"
             settings = {
-                "messages": [],
                 "custom_instructions": "",
-                "auto_run": False,
                 "verbose": False,
             }
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
+            assert response.status_code == 200
 
             # Sending messages via WebSocket
             await websocket.send(
@@ -490,12 +479,6 @@ def test_server():
             assert "18893094989" in accumulated_content.replace(",", "")
 
             #### TEST FILE ####
-
-            # Send another POST request
-            post_url = "http://127.0.0.1:8000/settings"
-            settings = {"messages": [], "auto_run": True}
-            response = requests.post(post_url, json=settings)
-            print("POST request sent, response:", response.json())
 
             # Sending messages via WebSocket
             await websocket.send(json.dumps({"role": "user", "start": True}))
@@ -559,12 +542,6 @@ def test_server():
             assert response.strip(" \n.").lower() == "no"
 
             #### TEST IMAGES ####
-
-            # Send another POST request
-            post_url = "http://127.0.0.1:8000/settings"
-            settings = {"messages": [], "auto_run": True}
-            response = requests.post(post_url, json=settings)
-            print("POST request sent, response:", response.json())
 
             base64png = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAADMElEQVR4nOzVwQnAIBQFQYXff81RUkQCOyDj1YOPnbXWPmeTRef+/3O/OyBjzh3CD95BfqICMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMO0TAAD//2Anhf4QtqobAAAAAElFTkSuQmCC"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the VATA-DSC-015 report about async/WebSocket server approval and auth. See **Review notes** below for threat-model context and per-change merge guidance.

### Code changes

1. **Approval binding** — `go` resumes the paused respond generator (with `confirmation_id` digest) instead of starting a fresh LLM completion.
2. **Non-loopback auth** — auto-generate `INTERPRETER_API_KEY` when binding beyond loopback without a key.
3. **`POST /settings` hardening** — block sensitive keys (`auto_run`, `messages`, etc.); fix dead `auto_run` guard and FastAPI `JSONResponse` status codes.
4. **Docs** — `docs/server/usage.mdx` updated for the above.
5. **Tests** — unit tests for server helpers/guards; integration tests adapted (no remote `messages`/`auto_run` seeding).

## Review notes (threat model + merge guidance)

### Context on the report

The report is technically correct about **server-mode behavior**, but the practical threat model is narrower than the writeup suggests.

Open Interpreter is intentionally a **local code runner**. The CLI banner ("will require approval before running code") already holds for the normal terminal path. The bugs are in the **async/WebSocket server path** (`AsyncInterpreter`).

**Main point:** if you expose this server to the LAN/internet (especially without auth), you are already letting people run arbitrary code on your machine. Fixing approval binding does not change that fundamental model — it fixes misleading UX and a correctness bug where `go` started a *new* LLM completion instead of resuming the code you reviewed. Conversation-history "swap" attacks are largely redundant with "attacker can already prompt the server."

Reasonable **hardening / bugfix** material, not a critical CVE for typical CLI-only users.

### Each change — what, why, independent merge value

**1. Approval binding (`go` resumes paused generator, `confirmation_id`)**
- *What:* `go` no longer spawns fresh `respond()`; server pauses at confirmation, emits hash, resumes same generator on approval.
- *Why:* Matches terminal behavior and documented server UX.
- *Merge alone?* **Medium** — useful if anyone uses server mode with `auto_run=False`. Not a threat-model game-changer for exposed servers.
- *Also:* command `start` chunks no longer kill the approval wait; `complete` status sent while paused.

**2. Non-loopback API key auto-generation**
- *What:* Non-loopback bind without `INTERPRETER_API_KEY` → generate and print one at startup. Loopback unchanged.
- *Why:* Obvious footgun on `0.0.0.0` without credentials.
- *Merge alone?* **Medium–high** — small, self-contained.

**3. `POST /settings` sensitive-key blocking**
- *What:* Block `auto_run`, `safe_mode`, `system_message`, `messages`, `llm.api_base`/`api_key`. Fix dead `auto_run` guard + FastAPI response handling.
- *Why:* Remote client could enable `auto_run` on an exposed server. **Most substantive security fix here**, separate from the approval-binding story.
- *Merge alone?* **High** — best cherry-pick. Related upstream: [#1767](https://github.com/openinterpreter/open-interpreter/issues/1767), [#1773](https://github.com/openinterpreter/open-interpreter/pull/1773).

**4. Docs** — only needed if corresponding code merges. **Low urgency** alone.

**5. Tests** — tied to whichever code changes land.

### Suggested cherry-picks

| Goal | Take |
|------|------|
| Minimal useful security fix | **#3 only** |
| Server deploy hygiene | **#2 + #3** |
| Correct server approval UX | **#1** (+ tests/docs) |
| All of it | Whole PR |

## Testing

- `pytest -m "not integration"` and integration job pass on CI.
- Unit tests in `tests/core/test_async_core.py`.

## Documentation

- `docs/server/usage.mdx`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd9b782d-cc61-4cc7-8504-3588c4f9192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd9b782d-cc61-4cc7-8504-3588c4f9192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

