### PR TITLE
fix(server): block sensitive attributes on POST /settings

### DIFF
--- a/docs/server/usage.mdx
+++ b/docs/server/usage.mdx
@@ -165,11 +165,12 @@ import requests
 settings = {
     "llm": {"model": "gpt-4"},
     "custom_instructions": "You only write Python code.",
-    "auto_run": True,
 }
 response = requests.post("http://localhost:8000/settings", json=settings)
 print(response.status_code)
 ```
+
+Sensitive settings such as `auto_run`, `safe_mode`, `system_message`, and `messages` cannot be changed through this endpoint.
 
 ### Retrieving Settings
 To get current settings, send a GET request to `http://localhost:8000/settings/{property}`.

--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -66,6 +66,13 @@ def is_websocket_origin_allowed(origin: Optional[str]) -> bool:
     return True
 
 
+# Top-level interpreter attributes that must not be changed via POST /settings.
+SENSITIVE_SERVER_SETTINGS = frozenset(
+    {"auto_run", "safe_mode", "system_message", "messages"}
+)
+SENSITIVE_LLM_SETTINGS = frozenset({"api_base", "api_key"})
+
+
 class AsyncInterpreter(OpenInterpreter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -672,12 +679,23 @@ def create_router(async_interpreter):
     async def set_settings(payload: Dict[str, Any]):
         for key, value in payload.items():
             print("Updating settings...")
-            # print(f"Updating settings: {key} = {value}")
-            if key in ["llm", "computer"] and isinstance(value, dict):
-                if key == "auto_run":
-                    return {
+            if key in SENSITIVE_SERVER_SETTINGS:
+                return JSONResponse(
+                    status_code=HTTP_403_FORBIDDEN,
+                    content={
                         "error": f"The setting {key} is not modifiable through the server due to security constraints."
-                    }, 403
+                    },
+                )
+            if key in ["llm", "computer"] and isinstance(value, dict):
+                if key == "llm":
+                    for sub_key in value:
+                        if sub_key in SENSITIVE_LLM_SETTINGS:
+                            return JSONResponse(
+                                status_code=HTTP_403_FORBIDDEN,
+                                content={
+                                    "error": f"The setting llm.{sub_key} is not modifiable through the server due to security constraints."
+                                },
+                            )
                 if hasattr(async_interpreter, key):
                     for sub_key, sub_value in value.items():
                         if hasattr(getattr(async_interpreter, key), sub_key):

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -5,6 +5,8 @@ from interpreter.core.async_core import (
     AsyncInterpreter,
     Server,
     is_websocket_origin_allowed,
+    SENSITIVE_LLM_SETTINGS,
+    SENSITIVE_SERVER_SETTINGS,
 )
 
 
@@ -69,3 +71,34 @@ class TestWebSocketOriginPolicy(TestCase):
 
     def test_remote_origins_rejected(self):
         self.assertFalse(is_websocket_origin_allowed("https://evil.example"))
+
+
+class TestSettingsEndpointGuards(TestCase):
+    def setUp(self):
+        from fastapi.testclient import TestClient
+
+        self.client = TestClient(Server(AsyncInterpreter()).app)
+
+    def _assert_settings_blocked(self, payload, error_substring):
+        response = self.client.post("/settings", json=payload)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn(error_substring, response.json()["error"])
+
+    def test_post_settings_blocks_sensitive_server_attributes(self):
+        """POST /settings must reject top-level keys that control execution or history."""
+        for key in SENSITIVE_SERVER_SETTINGS:
+            with self.subTest(key=key):
+                self._assert_settings_blocked({key: True}, key)
+
+    def test_post_settings_blocks_sensitive_llm_attributes(self):
+        """POST /settings must reject llm.api_key and llm.api_base."""
+        for sub_key in SENSITIVE_LLM_SETTINGS:
+            with self.subTest(sub_key=sub_key):
+                self._assert_settings_blocked(
+                    {"llm": {sub_key: "secret"}}, f"llm.{sub_key}"
+                )
+
+    def test_post_settings_allows_non_sensitive_llm_model(self):
+        """Non-sensitive llm fields like model remain writable via POST /settings."""
+        response = self.client.post("/settings", json={"llm": {"model": "gpt-4o-mini"}})
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -235,13 +235,13 @@ def test_authenticated_acknowledging_breaking_server():
                     "execution_instructions": "",
                     "supports_functions": False,
                 },
-                "system_message": "You are a poem writing bot. Do not do anything but respond with a poem.",
-                "auto_run": True,
+                "custom_instructions": "You are a poem writing bot. Do not do anything but respond with a poem.",
             }
             response = requests.post(
                 post_url, json=settings, headers={"X-API-KEY": "testing"}
             )
             print("POST request sent, response:", response.json())
+            assert response.status_code == 200
 
             # Sending messages via WebSocket
             await websocket.send(
@@ -354,6 +354,7 @@ def test_server():
     import websockets
 
     async def test_fastapi_server():
+        nonlocal process
         import asyncio
 
         async with websockets.connect("ws://127.0.0.1:8000/") as websocket:
@@ -367,19 +368,11 @@ def test_server():
             post_url = "http://127.0.0.1:8000/settings"
             settings = {
                 "llm": {"model": "gpt-4o-mini"},
-                "messages": [
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": "The secret word is 'crunk'.",
-                    },
-                    {"role": "assistant", "type": "message", "content": "Understood."},
-                ],
                 "custom_instructions": "",
-                "auto_run": True,
             }
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
+            assert response.status_code == 200
 
             # Sending messages via WebSocket
             await websocket.send(
@@ -390,7 +383,10 @@ def test_server():
                     {
                         "role": "user",
                         "type": "message",
-                        "content": "What's the secret word?",
+                        "content": (
+                            "The secret word is 'crunk'. What is the secret word? "
+                            "Reply with only that word."
+                        ),
                     }
                 )
             )
@@ -408,19 +404,11 @@ def test_server():
             post_url = "http://127.0.0.1:8000/settings"
             settings = {
                 "llm": {"model": "gpt-4o-mini"},
-                "messages": [
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": "The secret word is 'barloney'.",
-                    },
-                    {"role": "assistant", "type": "message", "content": "Understood."},
-                ],
                 "custom_instructions": "",
-                "auto_run": True,
             }
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
+            assert response.status_code == 200
 
             # Sending messages via WebSocket
             await websocket.send(
@@ -431,7 +419,10 @@ def test_server():
                     {
                         "role": "user",
                         "type": "message",
-                        "content": "What's the secret word?",
+                        "content": (
+                            "The secret word is now 'barloney' (ignore any previous secret word). "
+                            "What is the secret word? Reply with only that word."
+                        ),
                     }
                 )
             )
@@ -448,13 +439,12 @@ def test_server():
             # Send another POST request
             post_url = "http://127.0.0.1:8000/settings"
             settings = {
-                "messages": [],
                 "custom_instructions": "",
-                "auto_run": False,
                 "verbose": False,
             }
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
+            assert response.status_code == 200
 
             # Sending messages via WebSocket
             await websocket.send(
@@ -517,23 +507,8 @@ def test_server():
 
             #### TEST FILE ####
 
-            # Send another POST request
-            # auto_run=False: this turn only checks the model's text answer about a file
-            # path (judged via computer.ai.chat). We must not auto-execute shell code here
-            # or the server can hang before WebSocket 'complete' — unrelated to fish/$SHELL.
-            # custom_instructions steers plain-text replies; _last_assistant_text handles
-            # models that still emit a code block instead of a message.
-            post_url = "http://127.0.0.1:8000/settings"
-            settings = {
-                "messages": [],
-                "auto_run": False,
-                "custom_instructions": (
-                    "Answer in plain text only. Do not write or run code."
-                ),
-            }
-            response = requests.post(post_url, json=settings)
-            print("POST request sent, response:", response.json())
-
+            # auto_run/messages cannot be reset via POST /settings (blocked for security).
+            # Continue on the same WebSocket; _last_assistant_text handles code-only replies.
             user_start = {"role": "user", "start": True}
             file_question = {
                 "role": "user",
@@ -581,74 +556,54 @@ def test_server():
 
             #### TEST IMAGES ####
 
-            # Send another POST request
-            # auto_run=False again so vision MCQ is text-only. custom_instructions=""
-            # clears the file-turn "plain text only" prompt for this image turn.
-            post_url = "http://127.0.0.1:8000/settings"
-            settings = {"messages": [], "auto_run": False, "custom_instructions": ""}
-            response = requests.post(post_url, json=settings)
-            print("POST request sent, response:", response.json())
+            # Message history can no longer be cleared via POST /settings, so restart
+            # the server for an isolated vision turn.
+            await websocket.close()
+            _stop_server_subprocess(process)
+            process = _start_server_subprocess(run_server)
+            _wait_for_server(process)
 
-            base64png = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAADMElEQVR4nOzVwQnAIBQFQYXff81RUkQCOyDj1YOPnbXWPmeTRef+/3O/OyBjzh3CD95BfqICMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMO0TAAD//2Anhf4QtqobAAAAAElFTkSuQmCC"
+            async with websockets.connect("ws://127.0.0.1:8000/") as image_websocket:
+                await image_websocket.send(json.dumps({"auth": "dummy-api-key"}))
 
-            # Sending messages via WebSocket
-            await websocket.send(json.dumps({"role": "user", "start": True}))
-            await websocket.send(
-                json.dumps(
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": (
-                            "What do you see in this image? Reply with only one letter.\n"
-                            "A) a cat\n"
-                            "B) a color gradient\n"
-                            "C) a table of numbers\n"
-                            "D) a black rectangle"
-                        ),
-                    }
+                base64png = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAADMElEQVR4nOzVwQnAIBQFQYXff81RUkQCOyDj1YOPnbXWPmeTRef+/3O/OyBjzh3CD95BfqICMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMO0TAAD//2Anhf4QtqobAAAAAElFTkSuQmCC"
+
+                await image_websocket.send(json.dumps({"role": "user", "start": True}))
+                await image_websocket.send(
+                    json.dumps(
+                        {
+                            "role": "user",
+                            "type": "message",
+                            "content": (
+                                "What do you see in this image? Reply with only one letter.\n"
+                                "A) a cat\n"
+                                "B) a color gradient\n"
+                                "C) a table of numbers\n"
+                                "D) a black rectangle"
+                            ),
+                        }
+                    )
                 )
-            )
-            await websocket.send(
-                json.dumps(
-                    {
-                        "role": "user",
-                        "type": "image",
-                        "format": "base64.png",
-                        "content": base64png,
-                    }
+                await image_websocket.send(
+                    json.dumps(
+                        {
+                            "role": "user",
+                            "type": "image",
+                            "format": "base64.png",
+                            "content": base64png,
+                        }
+                    )
                 )
-            )
-            # await websocket.send(
-            #     json.dumps(
-            #         {
-            #             "role": "user",
-            #             "type": "image",
-            #             "format": "path",
-            #             "content": "/Users/killianlucas/Documents/GitHub/open-interpreter/screen.png",
-            #         }
-            #     )
-            # )
+                await image_websocket.send(json.dumps({"role": "user", "end": True}))
+                print("WebSocket chunks sent")
 
-            await websocket.send(json.dumps({"role": "user", "end": True}))
-            print("WebSocket chunks sent")
+                accumulated_content = await _wait_for_websocket_complete(image_websocket)
 
-            # Wait for response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
-
-            # Get messages
-            get_url = "http://127.0.0.1:8000/settings/messages"
-            response_json = requests.get(get_url).json()
-            print("GET request sent, response:", response_json)
-            if isinstance(response_json, str):
-                response_json = json.loads(response_json)
-            messages = response_json["messages"]
-
-            # Same message-or-stream fallback as the file MCQ turn above.
-            last_assistant = _last_assistant_text(messages) or accumulated_content
-            assert last_assistant, "expected assistant response after image turn"
-            assert re.search(
-                r"\bB\b", last_assistant, re.IGNORECASE
-            ), f"expected vision model to answer B (gradient), got: {last_assistant!r}"
+                # _wait_for_websocket_complete appends the status content "complete".
+                vision_reply = accumulated_content.removesuffix("complete")
+                assert re.search(
+                    r"\bB\b", vision_reply, re.IGNORECASE
+                ), f"expected vision model to answer B (gradient), got: {vision_reply!r}"
 
             # Sending POST request to /run endpoint with code to kill a thread in Python
             # actually wait i dont think this will work..? will just kill the python interpreter

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -193,6 +193,11 @@ def run_auth_server():
     os.environ["INTERPRETER_REQUIRE_ACKNOWLEDGE"] = "True"
     os.environ["INTERPRETER_API_KEY"] = "testing"
     async_interpreter = AsyncInterpreter()
+    # auto_run and system_message are blocked on POST /settings; set them at startup.
+    async_interpreter.auto_run = True
+    async_interpreter.custom_instructions = (
+        "You are a poem writing bot. Do not do anything but respond with a poem."
+    )
     async_interpreter.print = False
     async_interpreter.server.run()
 
@@ -235,7 +240,6 @@ def test_authenticated_acknowledging_breaking_server():
                     "execution_instructions": "",
                     "supports_functions": False,
                 },
-                "custom_instructions": "You are a poem writing bot. Do not do anything but respond with a poem.",
             }
             response = requests.post(
                 post_url, json=settings, headers={"X-API-KEY": "testing"}
@@ -288,20 +292,23 @@ def test_authenticated_acknowledging_breaking_server():
                 ):
                     raise (
                         Exception(
-                            "It shouldn't have finished this soon, accumulated_content is: "
-                            + accumulated_content
+                            "It shouldn't have finished this soon, poem so far is: "
+                            + poem
                         )
                     )
 
             await websocket.close()
             print("Disconnected from WebSocket")
 
-        time.sleep(3)
+        # Give uvicorn time to finish tearing down the first WebSocket session.
+        time.sleep(5)
 
         # Now let's hilariously keep going
         print("RESUMING")
 
-        async with websockets.connect("ws://127.0.0.1:8000/") as websocket:
+        async with websockets.connect(
+            "ws://127.0.0.1:8000/", open_timeout=30
+        ) as websocket:
             # Connect to the websocket
             print("Connected to WebSocket")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`POST /settings` applied arbitrary keys via `setattr`. A client that could reach the server could set `auto_run`, `messages`, `system_message`, and other sensitive fields. The existing `auto_run` guard was dead code (it lived inside the `llm`/`computer` branch) and tuple `(dict, 403)` returns are ignored by FastAPI anyway.

## What this changes

- Reject `auto_run`, `safe_mode`, `system_message`, `messages`, and sensitive `llm.*` keys before any `setattr`.
- Return proper `JSONResponse` 403 responses.
- Update docs example and integration tests that previously seeded state through `/settings`.

## Threat (plain terms)

Anything that can talk to your Open Interpreter server could flip `auto_run` on remotely and skip the confirmation step for future code. This only matters if the server is reachable (localhost or network). It is unrelated to browser Origin checks or the `go` approval bug.

## Testing

- Unit test: `test_post_settings_blocks_auto_run`
- Integration tests updated for blocked keys

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd9b782d-cc61-4cc7-8504-3588c4f9192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd9b782d-cc61-4cc7-8504-3588c4f9192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

