### PR TITLE
fix(server): reject WebSocket connections from non-localhost Origins

### DIFF
--- a/docs/server/usage.mdx
+++ b/docs/server/usage.mdx
@@ -24,6 +24,8 @@ async_interpreter.server.run(port=8000)  # Default port is 8000, but you can cus
 ### Establishing a Connection
 Connect to the WebSocket server at `ws://localhost:8000/`.
 
+The server rejects WebSocket connections whose browser `Origin` header is not `http://127.0.0.1` or `http://localhost`. This blocks other websites you have open from driving the server while still allowing the bundled page, other local web UIs, and non-browser clients (which usually send no `Origin` header).
+
 ### Message Format
 Open Interpreter uses an extended version of OpenAI's message format called [LMC messages](../protocols/lmc-messages.mdx) that allow for rich, multi-part messages. **Messages must be sent between start and end flags.** Here's the basic structure:
 

--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -9,6 +9,7 @@ import traceback
 from collections import deque
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 import shortuuid
 from pydantic import BaseModel
@@ -30,6 +31,7 @@ try:
         Request,
         UploadFile,
         WebSocket,
+        WebSocketException,
     )
     from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
     from starlette.status import HTTP_403_FORBIDDEN
@@ -39,6 +41,29 @@ except:
 
 
 complete_message = {"role": "server", "type": "status", "content": "complete"}
+
+LOCAL_ORIGIN_HOSTS = frozenset({"127.0.0.1", "localhost", "[::1]"})
+
+
+def is_websocket_origin_allowed(origin: Optional[str]) -> bool:
+    """
+    Browsers attach an Origin header to cross-origin WebSocket connections. Reject
+    remote origins so a page open in another site cannot drive a loopback server.
+
+    Non-browser clients (for example the Python websockets library) usually omit
+    Origin; allow missing values so local tooling keeps working.
+    """
+    if not origin:
+        return True
+    if origin == "null":
+        return True
+
+    parsed = urlparse(origin)
+    if parsed.scheme != "http":
+        return False
+    if parsed.hostname not in LOCAL_ORIGIN_HOSTS:
+        return False
+    return True
 
 
 class AsyncInterpreter(OpenInterpreter):
@@ -436,6 +461,10 @@ def create_router(async_interpreter):
 
     @router.websocket("/")
     async def websocket_endpoint(websocket: WebSocket):
+        origin = websocket.headers.get("origin")
+        if not is_websocket_origin_allowed(origin):
+            raise WebSocketException(code=1008, reason="Origin not allowed")
+
         await websocket.accept()
 
         try:  # solving it ;)/ # killian super wrote this

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -1,7 +1,11 @@
 import os
 from unittest import TestCase, mock
 
-from interpreter.core.async_core import AsyncInterpreter, Server
+from interpreter.core.async_core import (
+    AsyncInterpreter,
+    Server,
+    is_websocket_origin_allowed,
+)
 
 
 class TestServerConstruction(TestCase):
@@ -52,3 +56,16 @@ class TestServerConstruction(TestCase):
             s = Server(AsyncInterpreter())
             self.assertEqual(s.host, fake_host)
             self.assertEqual(s.port, fake_port)
+
+
+class TestWebSocketOriginPolicy(TestCase):
+    def test_missing_origin_allowed_for_local_clients(self):
+        self.assertTrue(is_websocket_origin_allowed(None))
+        self.assertTrue(is_websocket_origin_allowed(""))
+
+    def test_localhost_origins_allowed(self):
+        self.assertTrue(is_websocket_origin_allowed("http://127.0.0.1:8000"))
+        self.assertTrue(is_websocket_origin_allowed("http://localhost:8000"))
+
+    def test_remote_origins_rejected(self):
+        self.assertFalse(is_websocket_origin_allowed("https://evil.example"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Any website you have open in a browser can open `ws://127.0.0.1:8000/` and drive the Open Interpreter server. The browser sends `Origin: https://that-site.com`; the server currently accepts everyone. JavaScript on the page cannot spoof Origin — the browser sets it.

The attacker can send prompts and `go` and get code executed. They do not need you to click approve.

## What this changes

- Before `websocket.accept()`, check the `Origin` header.
- **Allow:** missing Origin (Python `websockets` clients and most local tooling), `null`, `http://127.0.0.1:*`, `http://localhost:*`
- **Reject:** `https://evil.example` and other non-localhost origins

## Threat (plain terms)

You run `interpreter --server` on your machine. You visit a malicious page. That page talks to your local server and runs code through it. This fix blocks that browser-driven path while keeping normal local use working.

## Testing

- Unit tests for `is_websocket_origin_allowed` in `tests/core/test_async_core.py`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd9b782d-cc61-4cc7-8504-3588c4f9192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd9b782d-cc61-4cc7-8504-3588c4f9192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

