### PR TITLE
fix(server): run the code shown when go approves execution

### DIFF
--- a/docs/server/usage.mdx
+++ b/docs/server/usage.mdx
@@ -63,7 +63,13 @@ To control the server's behavior, send the following commands:
    ```json
    {"role": "user", "type": "command", "content": "go"}
    ```
-   This executes a generated code block and allows the agent to proceed.
+   This approves the pending code block shown in the most recent `confirmation` chunk and resumes execution of that exact code.
+
+   When the server sends a confirmation chunk, it includes a `confirmation_id` (SHA-256 digest of the language + code). Clients should send `go:<confirmation_id>` to bind approval to the reviewed code:
+
+   ```json
+   {"role": "user", "type": "command", "content": "go:abc123..."}
+   ```
 
    **Note**: If `auto_run` is set to `False`, the agent will pause after generating code blocks. You must send the "go" command to continue execution.
 

--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import json
 import os
 import shutil
@@ -73,6 +74,16 @@ SENSITIVE_SERVER_SETTINGS = frozenset(
 SENSITIVE_LLM_SETTINGS = frozenset({"api_base", "api_key"})
 
 
+def confirmation_digest(confirmation_content: Dict[str, Any]) -> str:
+    """
+    Stable digest for a confirmation payload so approval can be bound to reviewed code.
+    """
+    language = confirmation_content.get("format", "")
+    code = confirmation_content.get("content", "")
+    payload = f"{language}\0{code}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
 class AsyncInterpreter(OpenInterpreter):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -81,6 +92,11 @@ class AsyncInterpreter(OpenInterpreter):
         self.stop_event = threading.Event()
         self.output_queue = None
         self.unsent_messages = deque()
+        self._respond_iterator = None
+        self._approval_event = threading.Event()
+        self._approval_granted = False
+        self.pending_confirmation = None
+        self.pending_confirmation_digest = None
         self.id = os.getenv("INTERPRETER_ID", datetime.now().timestamp())
         self.print = False  # Will print output
 
@@ -94,6 +110,29 @@ class AsyncInterpreter(OpenInterpreter):
         # For the 01. This lets the OAI compatible server accumulate context before responding.
         self.context_mode = False
 
+    def _clear_pending_confirmation(self):
+        self.pending_confirmation = None
+        self.pending_confirmation_digest = None
+
+    def _cancel_pending_approval(self):
+        self._approval_granted = False
+        self._approval_event.set()
+
+    def _reset_respond_iterator(self):
+        self._respond_iterator = None
+        self._clear_pending_confirmation()
+
+    def _approve_pending_confirmation(self, digest: Optional[str] = None) -> bool:
+        if self.pending_confirmation is None:
+            return False
+
+        if digest is not None and digest != self.pending_confirmation_digest:
+            return False
+
+        self._approval_granted = True
+        self._approval_event.set()
+        return True
+
     async def input(self, chunk):
         """
         Accumulates LMC chunks onto interpreter.messages.
@@ -102,8 +141,14 @@ class AsyncInterpreter(OpenInterpreter):
 
         if "start" in chunk:
             # If the user is starting something, the interpreter should stop.
-            if self.respond_thread is not None and self.respond_thread.is_alive():
+            # Command blocks (e.g. go/stop) must not tear down a thread waiting on approval.
+            if (
+                self.respond_thread is not None
+                and self.respond_thread.is_alive()
+                and chunk.get("type") != "command"
+            ):
                 self.stop_event.set()
+                self._cancel_pending_approval()
                 self.respond_thread.join()
             self.accumulate(chunk)
         elif "content" in chunk:
@@ -121,14 +166,44 @@ class AsyncInterpreter(OpenInterpreter):
                 if command == "stop":
                     # Any start flag would have stopped it a moment ago, but to be sure:
                     self.stop_event.set()
-                    self.respond_thread.join()
+                    self._cancel_pending_approval()
+                    if self.respond_thread is not None:
+                        self.respond_thread.join()
                     return
-                if command == "go":
-                    # This is to approve code.
-                    run_code = True
-                    pass
+                if command == "go" or command.startswith("go:"):
+                    digest = None
+                    if command.startswith("go:"):
+                        digest = command.split(":", 1)[1]
+
+                    if not self._approve_pending_confirmation(digest):
+                        if self.output_queue is not None:
+                            self.output_queue.sync_q.put(
+                                {
+                                    "role": "server",
+                                    "type": "error",
+                                    "content": "No pending code approval matches that request.",
+                                }
+                            )
+                            self.output_queue.sync_q.put(complete_message)
+                        return
+
+                    # Approval resumes the existing respond thread; do not start a new one.
+                    if self.respond_thread is not None and self.respond_thread.is_alive():
+                        return
+
+                    if self.output_queue is not None:
+                        self.output_queue.sync_q.put(
+                            {
+                                "role": "server",
+                                "type": "error",
+                                "content": "No active response is waiting for code approval.",
+                            }
+                        )
+                        self.output_queue.sync_q.put(complete_message)
+                    return
 
             self.stop_event.clear()
+            self._reset_respond_iterator()
             self.respond_thread = threading.Thread(
                 target=self.respond, args=(run_code,)
             )
@@ -142,12 +217,26 @@ class AsyncInterpreter(OpenInterpreter):
     def respond(self, run_code=None):
         for attempt in range(5):  # 5 attempts
             try:
-                if run_code == None:
+                if run_code is None:
                     run_code = self.auto_run
 
                 sent_chunks = False
 
-                for chunk_og in self._respond_and_store():
+                if self._respond_iterator is None:
+                    self._respond_iterator = iter(self._respond_and_store())
+
+                while True:
+                    if self.stop_event.is_set():
+                        self._cancel_pending_approval()
+                        self._reset_respond_iterator()
+                        return
+
+                    try:
+                        chunk_og = next(self._respond_iterator)
+                    except StopIteration:
+                        self._reset_respond_iterator()
+                        break
+
                     chunk = (
                         chunk_og.copy()
                     )  # This fixes weird double token chunks. Probably a deeper problem?
@@ -155,11 +244,37 @@ class AsyncInterpreter(OpenInterpreter):
                     if chunk["type"] == "confirmation":
                         if run_code:
                             run_code = False
+                        elif not self.auto_run:
+                            self.pending_confirmation = chunk["content"]
+                            self.pending_confirmation_digest = confirmation_digest(
+                                chunk["content"]
+                            )
+                            chunk["confirmation_id"] = self.pending_confirmation_digest
+
+                            if self.print:
+                                print("\n")
+                            if self.debug:
+                                print("Interpreter produced this chunk:", chunk)
+
+                            self.output_queue.sync_q.put(chunk)
+                            sent_chunks = True
+
+                            self._approval_granted = False
+                            self._approval_event.clear()
+                            self.output_queue.sync_q.put(complete_message)
+                            self._approval_event.wait()
+
+                            if not self._approval_granted:
+                                self._reset_respond_iterator()
+                                self.output_queue.sync_q.put(complete_message)
+                                return
+
+                            self._clear_pending_confirmation()
                             continue
-                        else:
-                            break
 
                     if self.stop_event.is_set():
+                        self._cancel_pending_approval()
+                        self._reset_respond_iterator()
                         return
 
                     if self.print:
@@ -357,10 +472,15 @@ def create_router(async_interpreter):
             + str(async_interpreter.server.port)
             + """/");
                     var lastMessageElement = null;
+                    var lastConfirmationId = null;
 
                     ws.onmessage = function(event) {
 
                         var eventData = JSON.parse(event.data);
+
+                        if (eventData.type === "confirmation" && eventData.confirmation_id) {
+                            lastConfirmationId = eventData.confirmation_id;
+                        }
 
                         """
             + (
@@ -439,7 +559,7 @@ def create_router(async_interpreter):
                     var commandBlock = {
                         "role": "user",
                         "type": "command",
-                        "content": "go"
+                        "content": lastConfirmationId ? ("go:" + lastConfirmationId) : "go"
                     };
                     ws.send(JSON.stringify(commandBlock));
 

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -4,6 +4,7 @@ from unittest import TestCase, mock
 from interpreter.core.async_core import (
     AsyncInterpreter,
     Server,
+    confirmation_digest,
     is_websocket_origin_allowed,
     SENSITIVE_LLM_SETTINGS,
     SENSITIVE_SERVER_SETTINGS,
@@ -102,3 +103,192 @@ class TestSettingsEndpointGuards(TestCase):
         """Non-sensitive llm fields like model remain writable via POST /settings."""
         response = self.client.post("/settings", json={"llm": {"model": "gpt-4o-mini"}})
         self.assertEqual(response.status_code, 200)
+
+class TestAsyncApprovalBinding(TestCase):
+    def setUp(self):
+        self.interpreter = AsyncInterpreter()
+        self.interpreter.auto_run = False
+
+    def test_confirmation_digest_is_stable(self):
+        payload = {"type": "code", "format": "python", "content": "print('hi')"}
+        self.assertEqual(
+            confirmation_digest(payload),
+            confirmation_digest(payload),
+        )
+
+    def test_approve_pending_confirmation_requires_pending_state(self):
+        self.assertFalse(self.interpreter._approve_pending_confirmation())
+
+    def test_approve_pending_confirmation_accepts_matching_digest(self):
+        payload = {"type": "code", "format": "python", "content": "print(1)"}
+        self.interpreter.pending_confirmation = payload
+        self.interpreter.pending_confirmation_digest = confirmation_digest(payload)
+
+        digest = self.interpreter.pending_confirmation_digest
+        self.assertTrue(self.interpreter._approve_pending_confirmation(digest))
+        self.assertTrue(self.interpreter._approval_granted)
+
+    def test_approve_pending_confirmation_rejects_wrong_digest(self):
+        payload = {"type": "code", "format": "python", "content": "print(1)"}
+        self.interpreter.pending_confirmation = payload
+        self.interpreter.pending_confirmation_digest = confirmation_digest(payload)
+
+        self.assertFalse(self.interpreter._approve_pending_confirmation("deadbeef"))
+
+
+class TestAsyncInputCommandHandling(TestCase):
+    def setUp(self):
+        self.interpreter = AsyncInterpreter()
+        self.interpreter.auto_run = False
+        self.interpreter.output_queue = mock.MagicMock()
+        self.interpreter.output_queue.sync_q = mock.MagicMock()
+        self.interpreter.respond_thread = mock.MagicMock()
+        self.interpreter.respond_thread.is_alive.return_value = True
+
+    def _run_go_command(self, command="go"):
+        import asyncio
+
+        async def run():
+            await self.interpreter.input(
+                {"role": "user", "type": "command", "start": True}
+            )
+            await self.interpreter.input(
+                {"role": "user", "type": "command", "content": command}
+            )
+            await self.interpreter.input(
+                {"role": "user", "type": "command", "end": True}
+            )
+
+        asyncio.run(run())
+
+    def _error_messages(self):
+        return [
+            call.args[0].get("content", "")
+            for call in self.interpreter.output_queue.sync_q.put.call_args_list
+            if call.args[0].get("type") == "error"
+        ]
+
+    def test_command_start_does_not_require_join(self):
+        import asyncio
+
+        async def run():
+            await self.interpreter.input(
+                {"role": "user", "type": "command", "start": True}
+            )
+            self.interpreter.respond_thread.join.assert_not_called()
+
+        asyncio.run(run())
+
+    def test_go_command_without_pending_confirmation_emits_error(self):
+        """go with no pending code must not start a new respond thread."""
+        self._run_go_command("go")
+        self.assertIn("No pending code approval", self._error_messages()[0])
+
+    def test_go_command_with_wrong_digest_emits_error(self):
+        """go:<digest> must match the pending confirmation payload."""
+        payload = {"type": "code", "format": "python", "content": "print(1)"}
+        self.interpreter.pending_confirmation = payload
+        self.interpreter.pending_confirmation_digest = confirmation_digest(payload)
+
+        self._run_go_command("go:deadbeef")
+        self.assertIn("No pending code approval", self._error_messages()[0])
+
+    def test_go_command_with_matching_digest_and_live_thread_returns(self):
+        """go:<digest> resumes the paused respond thread instead of spawning another."""
+        payload = {"type": "code", "format": "python", "content": "print(1)"}
+        digest = confirmation_digest(payload)
+        self.interpreter.pending_confirmation = payload
+        self.interpreter.pending_confirmation_digest = digest
+        self.interpreter.respond_thread.is_alive.return_value = True
+
+        self._run_go_command(f"go:{digest}")
+
+        self.assertEqual(self._error_messages(), [])
+        self.interpreter.respond_thread.start.assert_not_called()
+
+    def test_go_command_with_matching_digest_but_dead_thread_emits_error(self):
+        """go:<digest> after the respond thread exited cannot resume execution."""
+        payload = {"type": "code", "format": "python", "content": "print(1)"}
+        digest = confirmation_digest(payload)
+        self.interpreter.pending_confirmation = payload
+        self.interpreter.pending_confirmation_digest = digest
+        self.interpreter.respond_thread.is_alive.return_value = False
+
+        self._run_go_command(f"go:{digest}")
+
+        self.assertIn("No active response is waiting", self._error_messages()[0])
+
+
+class TestAsyncRespondApproval(TestCase):
+    def setUp(self):
+        self.interpreter = AsyncInterpreter()
+        self.interpreter.auto_run = False
+        self.mock_q = mock.MagicMock()
+        self.interpreter.output_queue = mock.MagicMock(sync_q=self.mock_q)
+
+    def _confirmation_payload(self):
+        return {"format": "python", "content": "print(1)"}
+
+    def _run_respond_with_chunks(self, chunks, approve=True):
+        import threading
+        import time
+
+        def fake_store():
+            yield from chunks
+
+        with mock.patch.object(self.interpreter, "_respond_and_store", fake_store):
+
+            def respond_thread():
+                self.interpreter.respond()
+
+            worker = threading.Thread(target=respond_thread)
+            worker.start()
+            time.sleep(0.05)
+            self.interpreter._approval_granted = approve
+            self.interpreter._approval_event.set()
+            worker.join(timeout=5)
+            self.assertFalse(worker.is_alive())
+
+    def test_respond_waits_for_approval_then_continues(self):
+        """With auto_run off, confirmation chunks pause until go approves the digest."""
+        confirmation = {
+            "type": "confirmation",
+            "role": "computer",
+            "content": self._confirmation_payload(),
+        }
+        console = {
+            "type": "console",
+            "role": "computer",
+            "format": "output",
+            "content": "ok",
+        }
+
+        self._run_respond_with_chunks([confirmation, console], approve=True)
+
+        put_chunks = [call.args[0] for call in self.mock_q.put.call_args_list]
+        confirmation_puts = [c for c in put_chunks if c.get("type") == "confirmation"]
+        self.assertEqual(len(confirmation_puts), 1)
+        self.assertEqual(
+            confirmation_puts[0]["confirmation_id"],
+            confirmation_digest(self._confirmation_payload()),
+        )
+        self.assertTrue(any(c.get("content") == "ok" for c in put_chunks))
+
+    def test_respond_stops_when_approval_denied(self):
+        """Denied approval must not run code after the confirmation chunk."""
+        confirmation = {
+            "type": "confirmation",
+            "role": "computer",
+            "content": self._confirmation_payload(),
+        }
+        console = {
+            "type": "console",
+            "role": "computer",
+            "format": "output",
+            "content": "ok",
+        }
+
+        self._run_respond_with_chunks([confirmation, console], approve=False)
+
+        put_chunks = [call.args[0] for call in self.mock_q.put.call_args_list]
+        self.assertFalse(any(c.get("content") == "ok" for c in put_chunks))

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -563,8 +563,9 @@ def test_server():
 
             #### TEST IMAGES ####
 
-            # Message history can no longer be cleared via POST /settings, so restart
-            # the server for an isolated vision turn.
+            # Fresh server for an isolated vision turn. With approval binding, reusing
+            # the same WebSocket after auto_run=False can leave a pending confirmation
+            # and the stream ends with only "complete".
             await websocket.close()
             _stop_server_subprocess(process)
             process = _start_server_subprocess(run_server)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In CLI mode, when you approve code, the same paused response continues and runs the block you reviewed.

In WebSocket server mode, `go` used to start a **new** `respond()` call. That made a **new LLM request** with the same conversation history, then executed whatever that second request produced — not necessarily the code shown at confirmation time.

## What this changes

- Pause the existing respond generator at the confirmation chunk.
- Emit `confirmation_id` (hash of language + code).
- `go` / `go:<confirmation_id>` resumes that generator instead of starting over.
- Do not kill the waiting thread when a `command` `start` chunk arrives (otherwise `go` never reached the waiter).

## Threat (plain terms)

You use server mode, review streamed code, send `go`, and a different completion may run. This is about the approval gate being wrong — not about a random website connecting (that is a separate issue).

CLI behavior was already correct; the web server diverged because it ran `respond()` in a background thread and treated `go` as “start a new respond with `run_code=True`” instead of resuming the paused generator.

## Testing

- Unit tests for digest + approval helpers in `tests/core/test_async_core.py`
- Existing server integration test covers the `go` path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd9b782d-cc61-4cc7-8504-3588c4f9192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd9b782d-cc61-4cc7-8504-3588c4f9192c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

