### PR TITLE
Split CI: Linux full suite, Win/Mac OS-only smokes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,7 +33,8 @@ jobs:
           pip install ruff
           ruff check interpreter tests
 
-  test:
+  test-linux:
+    name: Unit tests (Linux)
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
@@ -50,13 +51,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[server,dev]"
           if [ "${{ matrix.python-version }}" = "3.14" ]; then
-            pytest -m "not integration" \
+            pytest -m "not integration and not windows_ci and not darwin_ci" \
               --cov=interpreter \
               --cov-branch \
               --cov-report=xml \
               --cov-report=term-missing
           else
-            pytest -m "not integration"
+            pytest -m "not integration and not windows_ci and not darwin_ci"
           fi
 
       - name: Upload coverage report
@@ -66,13 +67,44 @@ jobs:
           name: coverage-report
           path: coverage.xml
 
+  test-windows:
+    name: Windows CI smoke
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install and run Windows-only tests
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[server,dev]"
+          pytest -m windows_ci -v
+
+  test-macos:
+    name: macOS CI smoke
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install and run macOS-only tests
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[server,dev]"
+          pytest -m darwin_ci -v
+
   codecov:
     name: Upload to Codecov
-    needs: test
+    needs: test-linux
     if: >-
       github.event_name != 'workflow_dispatch' &&
       !cancelled() &&
-      needs.test.result == 'success'
+      needs.test-linux.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,6 +55,21 @@ Once you've forked the code and created a new branch for your work, you can run 
 3. Install dependencies by running `poetry install`.
 4. Run the program with `poetry run interpreter`. Run tests with `poetry run pytest -s -x`.
 
+### CI test layout
+
+GitHub Actions splits work by OS so Linux runs the full suite without re-running everything on Windows and macOS:
+
+| Job | Runner | What runs |
+| --- | --- | --- |
+| **Unit tests (Linux)** | `ubuntu-latest` | Full unit suite (`pytest -m "not integration and not windows_ci and not darwin_ci"`), Python 3.10–3.14, plus language subprocess smokes in `tests/test_language_subprocess.py` |
+| **Integration** | `ubuntu-latest` | LLM tests (`pytest -m integration`), same-repo PRs and `main` only |
+| **Windows CI smoke** | `windows-latest` | Only `@pytest.mark.windows_ci` — `cmd.exe`, PowerShell, Windows paths, `tests` import path |
+| **macOS CI smoke** | `macos-latest` | Only `@pytest.mark.darwin_ci` — real `osascript`, Unix `$SHELL` |
+
+Platform-only tests live in `tests/test_platform_ci.py`. When fixing cross-platform bugs, add or extend the marker for that OS rather than running the full ~300-test suite on every runner.
+
+Locally: `pytest -m windows_ci` on Windows, `pytest -m darwin_ci` on a Mac, or the usual `pytest -m "not integration"` on Linux. `linux_ci` tests are skipped automatically off Linux.
+
 **Note**: This project uses [`black`](https://black.readthedocs.io/en/stable/index.html) and [`isort`](https://pypi.org/project/isort/) via a [`pre-commit`](https://pre-commit.com/) hook to ensure consistent code style. If you need to bypass it for some reason, you can `git commit` with the `--no-verify` flag.
 
 ### Installing New Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,4 +153,7 @@ pythonpath = ["."]
 markers = [
     "integration: requires an LLM API key (not run in default CI)",
     "timeout(duration): fail if the test runs longer than duration seconds (pytest-timeout)",
+    "linux_ci: subprocess or OS checks that only run on Linux CI (full unit job)",
+    "windows_ci: Windows-only CI smoke (cmd.exe, PowerShell, Windows paths)",
+    "darwin_ci: macOS-only CI smoke (AppleScript, Darwin shell)",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 import pytest
 
@@ -12,12 +13,25 @@ def pytest_configure(config):
 def pytest_collection_modifyitems(config, items):
     # Cloud agent runtime secrets are injected as normal environment variables
     # (e.g. OPENAI_API_KEY), so this check works the same locally and in CI.
-    if os.environ.get("OPENAI_API_KEY"):
-        return
+    if not os.environ.get("OPENAI_API_KEY"):
+        skip_integration = pytest.mark.skip(
+            reason="OPENAI_API_KEY not set; skipping integration test"
+        )
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_integration)
 
-    skip_integration = pytest.mark.skip(
-        reason="OPENAI_API_KEY not set; skipping integration test"
-    )
+    _PLATFORM_MARKERS = {
+        "linux_ci": "Linux",
+        "windows_ci": "Windows",
+        "darwin_ci": "Darwin",
+    }
+    current = platform.system()
     for item in items:
-        if "integration" in item.keywords:
-            item.add_marker(skip_integration)
+        for marker, required_os in _PLATFORM_MARKERS.items():
+            if marker in item.keywords and current != required_os:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=f"{marker} only runs on {required_os} (this host is {current})"
+                    )
+                )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -57,6 +57,16 @@ def require_bash_compatible_shell():
         )
 
 
+def console_output_text(chunks):
+    """Join console output chunks from ``computer.run`` / ``terminal.run``."""
+
+    return "".join(
+        chunk.get("content", "")
+        for chunk in chunks
+        if chunk.get("format") == "output"
+    )
+
+
 def patch_expanduser(monkeypatch, module, home):
     """Make expanduser('~') resolve to home (HOME is unreliable on Windows)."""
 

--- a/tests/terminal_interface/test_magic_commands.py
+++ b/tests/terminal_interface/test_magic_commands.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest import mock
 
+import pytest
+
 from interpreter.terminal_interface import magic_commands
 
 from tests.helpers import TEST_LLM_MODEL
@@ -85,6 +87,7 @@ def test_get_downloads_path_uses_home_on_posix(monkeypatch, tmp_path):
     assert (tmp_path / "Downloads").exists()
 
 
+@pytest.mark.windows_ci
 def test_get_downloads_path_windows(monkeypatch, tmp_path):
     monkeypatch.setattr(magic_commands.os, "name", "nt")
     monkeypatch.setenv("USERPROFILE", str(tmp_path))

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1286,6 +1286,7 @@ with open('numbers.txt', 'a+') as f:
     assert "5" not in content
 
 
+@pytest.mark.linux_ci
 @pytest.mark.timeout(30)
 def test_shell_nested_loop_quoting():
     """Shell execution must pass nested quotes/variables through unchanged.
@@ -1296,13 +1297,12 @@ def test_shell_nested_loop_quoting():
     Uses bash-style loop syntax fed to subprocess_language, which spawns
     os.environ["SHELL"]. If SHELL is fish (or other non-bash), fail immediately
     (see require_bash_compatible_shell) instead of hanging forever.
+
+    Windows cmd.exe variant lives in tests/test_platform_ci.py (``windows_ci``).
     """
     require_bash_compatible_shell()
 
-    if platform.system() == "Windows":
-        code = 'for %i in (a b) do for %j in (1 2) do echo %i_%j'
-    else:
-        code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
+    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
     chunks = interpreter.computer.run("shell", code)
     output = "".join(
         chunk.get("content", "")

--- a/tests/test_language_subprocess.py
+++ b/tests/test_language_subprocess.py
@@ -1,0 +1,73 @@
+"""Real subprocess smokes for languages supported on Linux CI.
+
+Unit tests mock preprocess/detect helpers; these catch hangs, missing binaries,
+and marker parsing against a live interpreter process. Run in the Linux unit job
+only (``linux_ci``); skipped locally on Windows/macOS when running the full suite.
+"""
+
+import shutil
+
+import pytest
+
+from interpreter import OpenInterpreter
+from tests.helpers import console_output_text, require_bash_compatible_shell
+
+
+@pytest.fixture
+def interpreter():
+    oi = OpenInterpreter()
+    oi.conversation_history = False
+    return oi
+
+
+@pytest.mark.linux_ci
+@pytest.mark.timeout(60)
+def test_python_subprocess_smoke(interpreter):
+    chunks = list(interpreter.computer.run("python", 'print("py_ok")'))
+    assert "py_ok" in console_output_text(chunks)
+
+
+@pytest.mark.linux_ci
+@pytest.mark.timeout(30)
+def test_javascript_subprocess_smoke(interpreter):
+    if shutil.which("node") is None:
+        pytest.skip("node not installed")
+    chunks = list(interpreter.computer.run("javascript", 'console.log("js_ok")'))
+    assert "js_ok" in console_output_text(chunks)
+
+
+@pytest.mark.linux_ci
+@pytest.mark.timeout(30)
+def test_shell_bash_echo_smoke(interpreter):
+    require_bash_compatible_shell()
+    chunks = list(interpreter.computer.run("shell", "echo shell_ok"))
+    assert "shell_ok" in console_output_text(chunks)
+
+
+@pytest.mark.linux_ci
+@pytest.mark.timeout(30)
+def test_shell_bash_nested_loop_quoting(interpreter):
+    require_bash_compatible_shell()
+    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
+    chunks = list(interpreter.computer.run("shell", code))
+    output = console_output_text(chunks)
+    assert "a_1" in output
+    assert "b_2" in output
+
+
+@pytest.mark.linux_ci
+@pytest.mark.timeout(30)
+def test_ruby_subprocess_smoke(interpreter):
+    if shutil.which("irb") is None:
+        pytest.skip("irb not installed")
+    chunks = list(interpreter.computer.run("ruby", 'puts "ruby_ok"'))
+    assert "ruby_ok" in console_output_text(chunks)
+
+
+@pytest.mark.linux_ci
+@pytest.mark.timeout(30)
+def test_r_subprocess_smoke(interpreter):
+    if shutil.which("R") is None:
+        pytest.skip("R not installed")
+    chunks = list(interpreter.computer.run("r", 'cat("r_ok\\n")'))
+    assert "r_ok" in console_output_text(chunks)

--- a/tests/test_platform_ci.py
+++ b/tests/test_platform_ci.py
@@ -1,0 +1,92 @@
+"""Minimal per-OS CI smokes: real subprocess / path behavior not covered by mocks.
+
+Linux CI runs the full unit suite (see test_language_subprocess.py for language
+e2e). Windows and macOS CI jobs run only tests marked ``windows_ci`` or
+``darwin_ci`` here — cmd.exe, PowerShell, AppleScript, and related quirks from
+cross-platform test development.
+"""
+
+import os
+
+import pytest
+
+from interpreter import OpenInterpreter
+from interpreter.core.computer.terminal.languages.shell import Shell
+from tests.helpers import console_output_text
+
+
+@pytest.fixture
+def interpreter():
+    oi = OpenInterpreter()
+    oi.conversation_history = False
+    return oi
+
+
+# --- Windows (cmd.exe, PowerShell, USERPROFILE paths, test package imports) ---
+
+
+@pytest.mark.windows_ci
+def test_windows_imports_tests_package():
+    """Regression: ``from tests.helpers import ...`` must work (pyproject pythonpath)."""
+
+    from tests.helpers import TEST_LLM_MODEL
+
+    assert TEST_LLM_MODEL
+
+
+@pytest.mark.windows_ci
+def test_shell_start_cmd_uses_cmd_exe():
+    shell = Shell()
+    assert shell.start_cmd == ["cmd.exe"]
+
+
+@pytest.mark.windows_ci
+@pytest.mark.timeout(30)
+def test_shell_cmd_echo_smoke(interpreter):
+    chunks = list(interpreter.computer.run("shell", "echo shell_ok"))
+    assert "shell_ok" in console_output_text(chunks)
+
+
+@pytest.mark.windows_ci
+@pytest.mark.timeout(30)
+def test_shell_cmd_nested_loop_quoting(interpreter):
+    """cmd.exe nested ``for`` loops — distinct quoting from bash (Linux CI)."""
+
+    code = "for %i in (a b) do for %j in (1 2) do echo %i_%j"
+    chunks = list(interpreter.computer.run("shell", code))
+    output = console_output_text(chunks)
+    assert "a_1" in output
+    assert "b_2" in output
+
+
+@pytest.mark.windows_ci
+@pytest.mark.timeout(30)
+def test_powershell_subprocess_smoke(interpreter):
+    chunks = list(interpreter.computer.run("powershell", 'Write-Output "ps_ok"'))
+    assert "ps_ok" in console_output_text(chunks)
+
+
+# --- macOS (osascript, Unix $SHELL) ---
+
+
+@pytest.mark.darwin_ci
+def test_shell_start_cmd_uses_shell_env():
+    shell = Shell()
+    assert shell.start_cmd == [os.environ.get("SHELL", "bash")]
+
+
+@pytest.mark.darwin_ci
+@pytest.mark.timeout(30)
+def test_shell_bash_nested_loop_quoting(interpreter):
+    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
+    chunks = list(interpreter.computer.run("shell", code))
+    output = console_output_text(chunks)
+    assert "a_1" in output
+    assert "b_2" in output
+
+
+@pytest.mark.darwin_ci
+@pytest.mark.timeout(30)
+def test_applescript_subprocess_smoke(interpreter):
+    chunks = list(interpreter.computer.run("applescript", 'return "as_ok"'))
+    assert "as_ok" in console_output_text(chunks)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Splits GitHub Actions so Linux runs the full unit + integration suite while Windows and macOS only run OS-specific subprocess smokes (~6 and ~3 tests respectively).

## CI layout

| Job | Runner | Command |
|-----|--------|---------|
| **Unit tests (Linux)** | `ubuntu-latest` | `pytest -m "not integration and not windows_ci and not darwin_ci"` (Python 3.10–3.14) |
| **Integration** | `ubuntu-latest` | unchanged — `pytest -m integration` |
| **Windows CI smoke** | `windows-latest` | `pytest -m windows_ci` (6 tests) |
| **macOS CI smoke** | `macos-latest` | `pytest -m darwin_ci` (3 tests) |

## What's tested where

**Linux** (full mocked suite + new subprocess smokes in `tests/test_language_subprocess.py`):
- Python, JavaScript, bash shell, Ruby, R — real `computer.run` e2e
- Existing `linux_ci` shell nested-loop test in `test_interpreter.py`

**Windows** (`tests/test_platform_ci.py` + marked magic command test):
- `tests` package import path (Windows `pythonpath` regression)
- `cmd.exe` start_cmd, echo, nested `for` loops
- PowerShell subprocess smoke
- `USERPROFILE` / Downloads path

**macOS**:
- Unix `$SHELL` start_cmd, bash nested loops
- Real `osascript` AppleScript smoke

## Markers

- `linux_ci` — subprocess/language tests; auto-skipped off Linux
- `windows_ci` / `darwin_ci` — only collected in their respective CI jobs; auto-skipped elsewhere

Documented in `docs/CONTRIBUTING.md`.

Stacks on #85 (`cursor/more-unit-tests-mocks-33d6`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

