### PR TITLE
test: add mocked unit test suite (~300 tests)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ The build backend is Poetry, but CI installs via pip. The package manager may ch
 - **Shell tests on Unix** that feed bash-syntax snippets to `subprocess_language` should call `require_bash_compatible_shell()` from `tests.helpers`: Non-bash `$SHELL` (e.g. fish) hangs instead of failing.
 - **Shared test helpers** live in `tests/helpers.py` (import `from tests.helpers import …`). Do not import from `conftest.py` — it is not a stable import path on all platforms.
 - **Computer subsystem tests** use `COMPUTER_TOOL_SUBSYSTEMS` in `tests/helpers.py` — update when `_get_all_computer_tools_list` changes (until [#101](https://github.com/endolith/open-interpreter/issues/101) lands).
+- Most of the unit tests were written after the fact by AI, with the assumption that the current state of the code was correct (which is likely not true in all cases).  Keep that in mind when a test fails.  Is your code actually wrong, or was the test written to validate incorrect code?
 
 ### Documentation
 

--- a/tests/computer_use/tools/test_base.py
+++ b/tests/computer_use/tools/test_base.py
@@ -1,0 +1,25 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_base_path = (
+    Path(__file__).resolve().parents[3] / "interpreter/computer_use/tools/base.py"
+)
+_spec = importlib.util.spec_from_file_location("computer_use_base", _base_path)
+_base = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_base)
+
+ToolResult = _base.ToolResult
+
+
+def test_tool_result_add_concatenates_strings():
+    """Combining two ToolResults with output fields merges them into one concatenated string."""
+    combined = ToolResult(output="hello") + ToolResult(output=" world")
+    assert combined.output == "hello world"
+
+
+def test_tool_result_add_conflicting_images_raises():
+    """Adding ToolResults that both carry base64_image raises ValueError because images cannot be merged."""
+    with pytest.raises(ValueError, match="Cannot combine tool results"):
+        _ = ToolResult(base64_image="aaa") + ToolResult(base64_image="bbb")

--- a/tests/computer_use/tools/test_bash.py
+++ b/tests/computer_use/tools/test_bash.py
@@ -1,0 +1,48 @@
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_base = Path(__file__).resolve().parents[3] / "interpreter/computer_use/tools"
+
+for mod_name, filename in [
+    ("interpreter.computer_use.tools.base", "base.py"),
+    ("interpreter.computer_use.tools.bash", "bash.py"),
+]:
+    spec = importlib.util.spec_from_file_location(mod_name, _base / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+
+_bash = sys.modules["interpreter.computer_use.tools.bash"]
+BashTool = _bash.BashTool
+ToolError = sys.modules["interpreter.computer_use.tools.base"].ToolError
+
+
+async def _fake_bash_session_start(self):
+    """Avoid spawning a real shell (os.setsid is Unix-only; breaks on Windows)."""
+    self._started = True
+    self._process = mock.Mock(returncode=None)
+
+
+@pytest.fixture
+def bash_without_subprocess():
+    with mock.patch.object(_bash._BashSession, "start", _fake_bash_session_start):
+        yield
+
+
+def test_bash_tool_restart(bash_without_subprocess):
+    """BashTool with restart=True reports a successful restart in the system message without running a command."""
+    tool = BashTool()
+    result = asyncio.run(tool(restart=True))
+    assert "restarted" in result.system
+
+
+def test_bash_tool_no_command_raises(bash_without_subprocess):
+    """BashTool raises ToolError when invoked without a command, since there is nothing to execute."""
+    tool = BashTool()
+    with pytest.raises(ToolError, match="no command"):
+        asyncio.run(tool())

--- a/tests/computer_use/tools/test_collection.py
+++ b/tests/computer_use/tools/test_collection.py
@@ -1,0 +1,53 @@
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+_base = Path(__file__).resolve().parents[3] / "interpreter/computer_use/tools"
+
+for mod_name, rel in [
+    ("interpreter.computer_use.tools.base", "base.py"),
+    ("interpreter.computer_use.tools.collection", "collection.py"),
+]:
+    spec = importlib.util.spec_from_file_location(mod_name, _base / rel.split("/")[-1])
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+
+ToolCollection = sys.modules["interpreter.computer_use.tools.collection"].ToolCollection
+ToolError = sys.modules["interpreter.computer_use.tools.base"].ToolError
+ToolFailure = sys.modules["interpreter.computer_use.tools.base"].ToolFailure
+ToolResult = sys.modules["interpreter.computer_use.tools.base"].ToolResult
+
+
+class DummyTool:
+    def to_params(self):
+        return {"name": "demo", "type": "custom"}
+
+    async def __call__(self, **kwargs):
+        return ToolResult(output=f"ok:{kwargs.get('x')}")
+
+
+def test_tool_collection_runs_registered_tool():
+    """ToolCollection.run dispatches to a registered tool by name and returns its ToolResult."""
+    collection = ToolCollection(DummyTool())
+    result = asyncio.run(collection.run(name="demo", tool_input={"x": 1}))
+    assert result.output == "ok:1"
+
+
+def test_tool_collection_unknown_tool_returns_failure():
+    """ToolCollection.run returns ToolFailure instead of raising when the requested tool name is not registered."""
+    collection = ToolCollection(DummyTool())
+    result = asyncio.run(collection.run(name="missing", tool_input={}))
+    assert isinstance(result, ToolFailure)
+
+
+def test_tool_collection_tool_error_becomes_failure():
+    """ToolCollection.run catches ToolError from a tool and wraps it in ToolFailure so callers get a structured error."""
+    class BadTool(DummyTool):
+        async def __call__(self, **kwargs):
+            raise ToolError("boom")
+
+    collection = ToolCollection(BadTool())
+    result = asyncio.run(collection.run(name="demo", tool_input={}))
+    assert result.error == "boom"

--- a/tests/computer_use/tools/test_edit.py
+++ b/tests/computer_use/tools/test_edit.py
@@ -1,0 +1,95 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_tools = Path(__file__).resolve().parents[3] / "interpreter/computer_use/tools"
+
+for mod_name, filename in [
+    ("interpreter.computer_use.tools.base", "base.py"),
+    ("interpreter.computer_use.tools.run", "run.py"),
+    ("interpreter.computer_use.tools.edit", "edit.py"),
+]:
+    spec = importlib.util.spec_from_file_location(mod_name, _tools / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+
+ToolError = sys.modules["interpreter.computer_use.tools.base"].ToolError
+EditTool = sys.modules["interpreter.computer_use.tools.edit"].EditTool
+
+
+def test_validate_path_requires_absolute():
+    """EditTool.validate_path rejects relative paths because file operations require an absolute location."""
+    tool = EditTool()
+    with pytest.raises(ToolError, match="not an absolute path"):
+        tool.validate_path("view", Path("relative.txt"))
+
+
+def test_validate_path_create_requires_missing_file(tmp_path):
+    """The create command accepts only paths that do not yet exist and rejects paths to existing files."""
+    tool = EditTool()
+    new_file = tmp_path / "new.txt"
+    tool.validate_path("create", new_file)
+    new_file.write_text("exists")
+    with pytest.raises(ToolError, match="already exists"):
+        tool.validate_path("create", new_file)
+
+
+def test_str_replace_replaces_unique_match(tmp_path):
+    """str_replace updates the file when the old string appears exactly once and reports success."""
+    tool = EditTool()
+    path = tmp_path / "file.txt"
+    path.write_text("hello world")
+    result = tool.str_replace(path, "world", "there")
+    assert "hello there" in path.read_text()
+    assert "edited" in result.output
+
+
+def test_str_replace_rejects_missing_string(tmp_path):
+    """str_replace raises ToolError when the old string is not found verbatim in the file."""
+    tool = EditTool()
+    path = tmp_path / "file.txt"
+    path.write_text("hello")
+    with pytest.raises(ToolError, match="did not appear verbatim"):
+        tool.str_replace(path, "missing", "x")
+
+
+def test_str_replace_rejects_multiple_matches(tmp_path):
+    """str_replace raises ToolError on multiple matches to prevent ambiguous or unintended bulk replacements."""
+    tool = EditTool()
+    path = tmp_path / "file.txt"
+    path.write_text("aa\naa")
+    with pytest.raises(ToolError, match="Multiple occurrences"):
+        tool.str_replace(path, "aa", "b")
+
+
+def test_insert_adds_lines_at_position(tmp_path):
+    """insert inserts new text at the given zero-based line index without disturbing surrounding lines."""
+    tool = EditTool()
+    path = tmp_path / "file.txt"
+    path.write_text("line1\nline3")
+    result = tool.insert(path, 1, "line2")
+    assert path.read_text().splitlines() == ["line1", "line2", "line3"]
+    assert "edited" in result.output
+
+
+def test_undo_edit_restores_previous_content(tmp_path):
+    """undo_edit reverts the file to its content before the most recent edit using the edit history."""
+    tool = EditTool()
+    path = tmp_path / "file.txt"
+    path.write_text("original")
+    tool.str_replace(path, "original", "changed")
+    result = tool.undo_edit(path)
+    assert path.read_text() == "original"
+    assert "undone successfully" in result.output
+
+
+def test_make_output_includes_line_numbers():
+    """_make_output formats file content with tab-separated line numbers so the model can reference specific lines."""
+    tool = EditTool()
+    output = tool._make_output("alpha\nbeta", "/tmp/demo.txt", init_line=1)
+    assert "alpha" in output
+    assert "beta" in output
+    assert "1\t" in output

--- a/tests/computer_use/tools/test_run.py
+++ b/tests/computer_use/tools/test_run.py
@@ -1,0 +1,71 @@
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+_tools = Path(__file__).resolve().parents[3] / "interpreter/computer_use/tools"
+
+spec = importlib.util.spec_from_file_location(
+    "interpreter.computer_use.tools.run", _tools / "run.py"
+)
+_run = importlib.util.module_from_spec(spec)
+sys.modules["interpreter.computer_use.tools.run"] = _run
+spec.loader.exec_module(_run)
+
+TRUNCATED_MESSAGE = _run.TRUNCATED_MESSAGE
+maybe_truncate = _run.maybe_truncate
+run = _run.run
+
+
+def test_maybe_truncate_leaves_short_content():
+    """maybe_truncate returns content unchanged when it is within the length limit."""
+    assert maybe_truncate("hello", truncate_after=10) == "hello"
+
+
+def test_maybe_truncate_clips_long_content():
+    """maybe_truncate shortens content that exceeds the limit and appends TRUNCATED_MESSAGE so callers know output was clipped."""
+    content = "x" * 20
+    result = maybe_truncate(content, truncate_after=10)
+    assert result.startswith("x" * 10)
+    assert result.endswith(TRUNCATED_MESSAGE)
+
+
+def test_run_returns_stdout_stderr():
+    """run returns the process exit code and decoded stdout/stderr after the subprocess completes."""
+    async def fake_communicate():
+        return (b"out", b"err")
+
+    mock_process = mock.Mock()
+    mock_process.communicate = fake_communicate
+    mock_process.returncode = 0
+
+    with mock.patch.object(
+        _run.asyncio, "create_subprocess_shell", return_value=mock_process
+    ):
+        code, stdout, stderr = asyncio.run(run("echo hi"))
+    assert code == 0
+    assert stdout == "out"
+    assert stderr == "err"
+
+
+def test_run_raises_timeout_error():
+    """run kills the subprocess and raises TimeoutError when execution exceeds the configured timeout."""
+    # communicate is a plain Mock (not async) because wait_for is patched to
+    # raise TimeoutError before it ever tries to await the communicate()
+    # result. Using a plain Mock avoids an unawaited-coroutine RuntimeWarning
+    # that AsyncMock would trigger when wait_for discards it.
+    mock_process = mock.Mock()
+    mock_process.communicate = mock.Mock(return_value=None)
+    mock_process.kill = mock.Mock()
+
+    with mock.patch.object(
+        _run.asyncio, "create_subprocess_shell", return_value=mock_process
+    ):
+        with mock.patch.object(
+            _run.asyncio, "wait_for", side_effect=asyncio.TimeoutError
+        ):
+            with pytest.raises(TimeoutError, match="timed out"):
+                asyncio.run(run("sleep 999", timeout=0.1))

--- a/tests/core/computer/ai/test_ai_helpers.py
+++ b/tests/core/computer/ai/test_ai_helpers.py
@@ -1,0 +1,41 @@
+from interpreter.core.computer.ai.ai import chunk_responses, split_into_chunks
+
+
+def test_split_into_chunks_with_tiktoken():
+    """split_into_chunks splits long text into overlapping token-sized windows."""
+    llm = type("Llm", (), {"model": "gpt-4"})()  # tiktoken encoding name, not API model
+    text = "word " * 100
+    chunks = split_into_chunks(text, tokens=20, llm=llm, overlap=5)
+    assert len(chunks) > 1
+    joined = " ".join(chunks)
+    assert joined[:20] == text[:20]
+    assert joined[-20:] == text[-20:]
+
+
+def test_split_into_chunks_fallback_without_tiktoken():
+    """Invalid model name forces character-based fallback when tiktoken fails."""
+    llm = type("Llm", (), {"model": "totally-invalid-model-name-xyz"})()
+    text = "abcdefghij" * 50
+    chunks = split_into_chunks(text, tokens=10, llm=llm, overlap=2)
+    assert len(chunks) >= 2
+    assert chunks[0].startswith("abcd")
+
+
+def test_chunk_responses_respects_token_limit():
+    """Multiple responses under the token budget merge into one list element.
+
+    Both strings together are well under 100 tokens, so chunk_responses joins
+    them with a blank line separator. Happy path — no splitting required.
+    """
+    llm = type("Llm", (), {"model": "gpt-4"})()
+    responses = ["short", "another short response"]
+    result = chunk_responses(responses, tokens=100, llm=llm)
+    assert result == ["short\n\nanother short response"]
+
+
+def test_chunk_responses_oversized_single_response():
+    """A single response larger than the token budget is returned unsplit."""
+    llm = type("Llm", (), {"model": "gpt-4"})()
+    big = "x" * 5000
+    result = chunk_responses([big], tokens=50, llm=llm)
+    assert result == [big]

--- a/tests/core/computer/calendar/test_calendar.py
+++ b/tests/core/computer/calendar/test_calendar.py
@@ -1,0 +1,45 @@
+import datetime
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.computer.calendar.calendar import Calendar
+
+
+def test_get_events_non_macos():
+    """get_events() returns an unsupported-platform message on non-macOS systems."""
+    cal = Calendar(computer=SimpleNamespace())
+    with mock.patch(
+        "interpreter.core.computer.calendar.calendar.platform.system",
+        return_value="Linux",
+    ):
+        assert cal.get_events() == "This method is only supported on MacOS"
+
+
+def test_get_events_macos_runs_applescript():
+    """On macOS, get_events() returns the output from run_applescript_capture."""
+    cal = Calendar(computer=SimpleNamespace())
+    with mock.patch(
+        "interpreter.core.computer.calendar.calendar.platform.system",
+        return_value="Darwin",
+    ):
+        with mock.patch(
+            "interpreter.core.computer.calendar.calendar.run_applescript_capture",
+            return_value=("Meeting at 3pm", ""),
+        ):
+            result = cal.get_events()
+    assert result == "Meeting at 3pm"
+
+
+def test_create_event_non_macos():
+    """create_event() reports MacOS-only support when called on non-macOS platforms."""
+    cal = Calendar(computer=SimpleNamespace())
+    with mock.patch(
+        "interpreter.core.computer.calendar.calendar.platform.system",
+        return_value="Linux",
+    ):
+        result = cal.create_event(
+            "Title",
+            datetime.datetime(2024, 1, 1, 9, 0),
+            datetime.datetime(2024, 1, 1, 10, 0),
+        )
+    assert "MacOS" in result

--- a/tests/core/computer/contacts/test_contacts.py
+++ b/tests/core/computer/contacts/test_contacts.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from interpreter.core.computer.contacts.contacts import Contacts
+
+
+def test_get_phone_number_non_macos():
+    """get_phone_number() returns an unsupported-platform message on non-macOS systems."""
+    contacts = Contacts(computer=SimpleNamespace())
+    with mock.patch(
+        "interpreter.core.computer.contacts.contacts.platform.system",
+        return_value="Linux",
+    ):
+        assert contacts.get_phone_number("Alice") == "This method is only supported on MacOS"
+
+
+def test_get_phone_number_success():
+    """On macOS, get_phone_number() returns the trimmed AppleScript lookup result."""
+    contacts = Contacts(computer=SimpleNamespace())
+    with mock.patch(
+        "interpreter.core.computer.contacts.contacts.platform.system",
+        return_value="Darwin",
+    ):
+        with mock.patch(
+            "interpreter.core.computer.contacts.contacts.run_applescript_capture",
+            return_value=("555-1234\n", ""),
+        ):
+            assert contacts.get_phone_number("Alice") == "555-1234"
+
+
+def test_get_phone_number_suggests_similar_contacts():
+    """When lookup fails, get_phone_number() raises with similar contact suggestions."""
+    contacts = Contacts(computer=SimpleNamespace())
+    with mock.patch(
+        "interpreter.core.computer.contacts.contacts.platform.system",
+        return_value="Darwin",
+    ):
+        with mock.patch(
+            "interpreter.core.computer.contacts.contacts.run_applescript_capture",
+            side_effect=[("", "Can't get person"), ("Alice Smith", "")],
+        ):
+            with mock.patch.object(
+                contacts, "get_full_names_from_first_name", return_value="Alice Smith"
+            ):
+                with pytest.raises(Exception, match="similar contacts"):
+                    contacts.get_phone_number("Ali")

--- a/tests/core/computer/files/test_files.py
+++ b/tests/core/computer/files/test_files.py
@@ -10,6 +10,7 @@ class TestFiles(unittest.TestCase):
 
     @mock.patch("interpreter.core.computer.files.files.aifs")
     def test_search(self, mock_aifs):
+        """Files.search() delegates args and kwargs to aifs.search."""
         # Arrange
         mock_args = ["foo", "bar"]
         mock_kwargs = {"foo": "bar"}
@@ -21,6 +22,7 @@ class TestFiles(unittest.TestCase):
         mock_aifs.search.assert_called_once_with(mock_args, mock_kwargs)
 
     def test_edit_original_text_in_filedata(self):
+        """Files.edit() replaces original text in a file and writes the updated content."""
         # Arrange
         mock_open = mock.mock_open(read_data="foobar")
         mock_write = mock_open.return_value.write
@@ -35,6 +37,7 @@ class TestFiles(unittest.TestCase):
         mock_write.assert_called_once_with("foobarbaz")
 
     def test_edit_original_text_not_in_filedata(self):
+        """Files.edit() raises ValueError with close-match hints when text is not found."""
         # Arrange
         mock_open = mock.mock_open(read_data="foobar")
 

--- a/tests/core/computer/files/test_get_close_matches.py
+++ b/tests/core/computer/files/test_get_close_matches.py
@@ -1,0 +1,28 @@
+from interpreter.core.computer.files.files import get_close_matches_in_text
+
+
+def test_exact_phrase_ranked_first():
+    """An exact phrase match is ranked first among close matches."""
+    filedata = "The quick brown fox jumps over the lazy dog"
+    matches = get_close_matches_in_text("quick brown fox", filedata)
+    assert matches[0] == "quick brown fox"
+
+
+def test_typo_returns_closest_phrases():
+    """A typo query returns up to three closest phrases from the file text."""
+    filedata = "foobar baz qux foobar"
+    matches = get_close_matches_in_text("foobaz", filedata)
+    assert len(matches) <= 3
+    assert any("foobar" in match for match in matches)
+
+
+def test_respects_n_limit():
+    """get_close_matches_in_text honors the n parameter for result count."""
+    filedata = "one two three four five six seven eight"
+    matches = get_close_matches_in_text("one two", filedata, n=1)
+    assert len(matches) == 1
+
+
+def test_empty_filedata_returns_empty():
+    """Empty file text yields no close matches regardless of the query."""
+    assert get_close_matches_in_text("anything", "") == []

--- a/tests/core/computer/mail/test_mail.py
+++ b/tests/core/computer/mail/test_mail.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.computer.mail.mail import Mail
+
+
+def test_mail_get_non_macos_returns_message():
+    """Mail.get() returns an unsupported-platform message on non-macOS systems."""
+    mail = Mail(computer=SimpleNamespace())
+    with mock.patch(
+        "interpreter.core.computer.mail.mail.platform.system", return_value="Linux"
+    ):
+        assert mail.get() == "This method is only supported on MacOS"
+
+
+def test_mail_get_on_macos_runs_applescript():
+    """On macOS, Mail.get() runs AppleScript limited to the requested message count."""
+    mail = Mail(computer=SimpleNamespace())
+    with mock.patch(
+        "interpreter.core.computer.mail.mail.platform.system", return_value="Darwin"
+    ):
+        with mock.patch(
+            "interpreter.core.computer.mail.mail.run_applescript_capture",
+            return_value=("inbox data", ""),
+        ) as capture:
+            result = mail.get(number=2)
+    capture.assert_called_once()
+    script = capture.call_args[0][0]
+    assert "repeat with i from 1 to 2" in script
+    assert result == "inbox data"

--- a/tests/core/computer/os/test_os.py
+++ b/tests/core/computer/os/test_os.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.computer.os.os import Os
+
+
+def test_get_selected_text_uses_clipboard():
+    """get_selected_text copies selection via clipboard and restores prior contents."""
+    clipboard = SimpleNamespace(
+        view=mock.Mock(side_effect=["previous", "selected text"]),
+        copy=mock.Mock(),
+    )
+    os_module = Os(SimpleNamespace(clipboard=clipboard))
+    assert os_module.get_selected_text() == "selected text"
+    clipboard.copy.assert_any_call()
+    clipboard.copy.assert_any_call("previous")
+    assert clipboard.copy.call_count == 2
+
+
+def test_notify_truncates_long_text_on_linux():
+    """Notifications longer than 200 chars are shortened before plyer.notify."""
+    import sys
+
+    os_module = Os(SimpleNamespace(verbose=False))
+    plyer = mock.Mock()
+    with mock.patch("interpreter.core.computer.os.os.platform.system", return_value="Linux"):
+        with mock.patch.dict(sys.modules, {"plyer": plyer}):
+            os_module.notify("x" * 300)
+    plyer.notification.notify.assert_called_once()
+    message = plyer.notification.notify.call_args.kwargs["message"]
+    assert len(message) <= 203  # 200 chars + "..."
+    assert message.endswith("...")
+
+
+def test_notify_macos_runs_osascript():
+    """On macOS, notify() runs osascript with a display notification script."""
+    os_module = Os(SimpleNamespace(verbose=False))
+    with mock.patch(
+        "interpreter.core.computer.os.os.platform.system", return_value="Darwin"
+    ):
+        with mock.patch(
+            "interpreter.core.computer.os.os.subprocess.run"
+        ) as run:
+            os_module.notify('Say "hello"')
+    run.assert_called_once_with(["osascript", "-e", mock.ANY])
+    script = run.call_args[0][0][2]
+    assert "display notification" in script

--- a/tests/core/computer/skills/test_skills.py
+++ b/tests/core/computer/skills/test_skills.py
@@ -1,15 +1,18 @@
-"""Regression tests for issue #3: lazy pynput import masking AttributeError."""
-
 import importlib
 import importlib.abc
 import importlib.util
 import sys
+from types import SimpleNamespace
+from unittest import mock
 
 import pytest
+
+from interpreter.core.computer.skills.skills import Skills
 
 SKILLS_MODULE = "interpreter.core.computer.skills.skills"
 
 
+# 3 regression tests for issue #3: lazy pynput import masking AttributeError.
 def _install_headless_lazy_module(module_name):
     """Register a PEP 562 lazy module that fails like pynput on headless SSH."""
 
@@ -91,3 +94,58 @@ def test_attribute_error_unmasked_when_skills_does_not_preload_pynput():
     finally:
         for name, mod in saved.items():
             sys.modules[name] = mod
+
+
+# Other tests
+
+def test_list_returns_empty_when_skills_disabled(capsys):
+    """Skills.list() returns an empty list when import_skills is disabled."""
+    computer = SimpleNamespace(import_skills=False, _has_imported_skills=False)
+    skills = Skills(computer)
+    assert skills.list() == []
+
+
+def test_list_returns_skill_names(tmp_path):
+    """Skills.list() returns callable signatures for each .py file in the skills directory."""
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "demo_skill.py").write_text("def demo_skill(): pass")
+    computer = SimpleNamespace(
+        import_skills=True,
+        _has_imported_skills=True,
+        save_skills=True,
+        interpreter=SimpleNamespace(debug=False),
+        run=mock.Mock(return_value=[]),
+    )
+    skills = Skills(computer)
+    skills.path = str(skills_dir)
+    result = skills.list()
+    assert result == ["demo_skill()"]
+
+
+def test_import_skills_runs_python_files(tmp_path):
+    """import_skills() executes each skill file via computer.run and enables save_skills."""
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill_file = skills_dir / "skill_a.py"
+    skill_file.write_text("x = 1")
+    computer = SimpleNamespace(
+        import_skills=True,
+        save_skills=True,
+        interpreter=SimpleNamespace(debug=False),
+        run=mock.Mock(return_value=[]),
+    )
+    skills = Skills(computer)
+    skills.path = str(skills_dir)
+    skills.import_skills()
+    computer.run.assert_called_once_with("python",
+                                         skill_file.read_text() + "\n")
+    assert computer.save_skills is True
+
+
+def test_import_skills_skips_when_disabled():
+    """import_skills() does nothing when import_skills is False on the computer."""
+    computer = SimpleNamespace(import_skills=False, run=mock.Mock())
+    skills = Skills(computer)
+    skills.import_skills()
+    computer.run.assert_not_called()

--- a/tests/core/computer/sms/test_sms.py
+++ b/tests/core/computer/sms/test_sms.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import interpreter.core.computer.sms.sms as sms_module
+from interpreter.core.computer.sms.sms import SMS
+from tests.helpers import patch_expanduser
+
+
+def test_send_non_macos_prints_message(capsys):
+    """SMS.send() prints a Mac-only notice and returns None on non-macOS platforms."""
+    with mock.patch("sys.platform", "linux"):
+        sms = SMS(computer=SimpleNamespace())
+        assert sms.send("+1", "hi") is None
+    assert "Only supported on Mac" in capsys.readouterr().out
+
+
+def test_resolve_database_path(monkeypatch, tmp_path):
+    """On macOS, chat.db lives under expanduser('~')/Library/Messages."""
+    patch_expanduser(monkeypatch, sms_module, tmp_path)
+    with mock.patch("sys.platform", "darwin"):
+        sms = SMS(computer=SimpleNamespace())
+    assert Path(sms.database_path) == (tmp_path / "Library" / "Messages" /
+                                       "chat.db")
+
+
+def test_get_non_macos(capsys):
+    """SMS.get() prints a Mac-only notice and returns None on non-macOS platforms."""
+    with mock.patch("sys.platform", "linux"):
+        sms = SMS(computer=SimpleNamespace())
+        assert sms.get() is None
+    assert "Only supported on Mac" in capsys.readouterr().out

--- a/tests/core/computer/terminal/languages/test_applescript.py
+++ b/tests/core/computer/terminal/languages/test_applescript.py
@@ -1,0 +1,30 @@
+from interpreter.core.computer.terminal.languages.applescript import AppleScript
+
+
+def test_applescript_add_active_line_indicators():
+    """AppleScript add_active_line_indicators() inserts log markers before each line."""
+    script = AppleScript()
+    result = script.add_active_line_indicators('say "hi"\n')
+    assert 'log "##active_line1##"' in result
+
+
+def test_applescript_preprocess_code_wraps_for_osascript():
+    """User script is escaped and wrapped for osascript -e with execution markers."""
+    script = AppleScript()
+    result = script.preprocess_code('say "hello"')
+    assert result.startswith("osascript -e ")
+    assert "##end_of_execution##" in result
+    assert '\\"hello\\"' in result
+
+
+def test_applescript_detect_active_line():
+    """AppleScript detect_active_line() parses the line number from ##active_lineN## markers."""
+    script = AppleScript()
+    assert script.detect_active_line("##active_line4##") == 4
+
+
+def test_applescript_detect_end_of_execution():
+    """AppleScript detect_end_of_execution() recognizes end markers but not running output."""
+    script = AppleScript()
+    assert script.detect_end_of_execution("##end_of_execution##") is True
+    assert script.detect_end_of_execution("still running") is False

--- a/tests/core/computer/terminal/languages/test_html.py
+++ b/tests/core/computer/terminal/languages/test_html.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from interpreter.core.computer.terminal.languages.html import HTML
+
+
+def test_html_run_yields_console_code_and_image():
+    """HTML.run() yields console, code, and base64 PNG image chunks in order."""
+    html = HTML()
+    with mock.patch(
+        "interpreter.core.computer.terminal.languages.html.html_to_png_base64",
+        return_value="base64data",
+    ):
+        chunks = list(html.run("<html><body>Hi</body></html>"))
+
+    assert chunks[0]["type"] == "console"
+    assert chunks[1]["type"] == "code"
+    assert chunks[2]["type"] == "image"
+    assert chunks[2]["format"] == "base64.png"
+    assert chunks[2]["content"] == "base64data"

--- a/tests/core/computer/terminal/languages/test_java.py
+++ b/tests/core/computer/terminal/languages/test_java.py
@@ -1,0 +1,116 @@
+from unittest import mock
+
+from interpreter.core.computer.terminal.languages.java import Java, preprocess_java
+
+_VALID_CLASS = "class Hello { public static void main(String[] args) {} }"
+
+
+def test_preprocess_java_adds_markers():
+    """preprocess_java() injects active-line and end-of-execution markers into Java code."""
+    code = preprocess_java("System.out.println(1);")
+    assert "##active_line1##" in code
+    assert "##end_of_execution##" in code
+
+
+def test_java_run_without_class_yields_error():
+    """Java.run() reports missing class definition when source has no class."""
+    java = Java()
+    chunks = list(java.run("not a class"))
+    assert "No class definition found" in chunks[0]["content"]
+
+
+def test_java_run_compilation_error_cleans_up_java_file(tmp_path, monkeypatch):
+    """Java.run() removes the .java source file after a compilation failure."""
+    monkeypatch.chdir(tmp_path)
+    java = Java()
+
+    compile_proc = mock.Mock()
+    compile_proc.communicate.return_value = ("", "syntax error")
+    compile_proc.returncode = 1
+
+    with mock.patch(
+        "interpreter.core.computer.terminal.languages.java.subprocess.Popen",
+        return_value=compile_proc,
+    ):
+        chunks = list(java.run(_VALID_CLASS))
+
+    assert "Compilation Error" in chunks[0]["content"]
+    assert not (tmp_path / "Hello.java").exists()
+
+
+def test_java_run_finally_removes_java_and_class_files(tmp_path, monkeypatch):
+    """Java.run() finally block removes both .java and .class files after compile errors."""
+    monkeypatch.chdir(tmp_path)
+    java = Java()
+
+    compile_proc = mock.Mock()
+    compile_proc.returncode = 1
+
+    def fail_compile_and_touch_class():
+        (tmp_path / "Hello.class").write_bytes(b"fake")
+        return ("", "syntax error")
+
+    compile_proc.communicate.side_effect = fail_compile_and_touch_class
+
+    with mock.patch(
+        "interpreter.core.computer.terminal.languages.java.subprocess.Popen",
+        return_value=compile_proc,
+    ):
+        list(java.run(_VALID_CLASS))
+
+    assert not (tmp_path / "Hello.java").exists()
+    assert not (tmp_path / "Hello.class").exists()
+
+
+def test_java_run_success_cleans_up_after_execution(tmp_path, monkeypatch):
+    """Java.run() deletes generated .java and .class files after successful execution."""
+    import queue
+    import threading
+
+    monkeypatch.chdir(tmp_path)
+    java = Java()
+    java.output_queue = queue.Queue()
+    java.done = threading.Event()
+    java.done.set()
+
+    compile_proc = mock.Mock()
+    compile_proc.communicate.return_value = ("", "")
+    compile_proc.returncode = 0
+
+    run_proc = mock.Mock()
+    run_proc.stdout = mock.Mock()
+    run_proc.stderr = mock.Mock()
+    run_proc.wait.return_value = None
+
+    def popen_side_effect(cmd, **kwargs):
+        if cmd[0] == "javac":
+            (tmp_path / "Hello.class").write_bytes(b"fake")
+            return compile_proc
+        return run_proc
+
+    with mock.patch(
+        "interpreter.core.computer.terminal.languages.java.subprocess.Popen",
+        side_effect=popen_side_effect,
+    ):
+        with mock.patch(
+            "interpreter.core.computer.terminal.languages.java.threading.Thread"
+        ) as thread_cls:
+            thread_cls.return_value.start = mock.Mock()
+            thread_cls.return_value.join = mock.Mock()
+            list(java.run(_VALID_CLASS))
+
+    assert not (tmp_path / "Hello.java").exists()
+    assert not (tmp_path / "Hello.class").exists()
+
+
+def test_java_line_postprocessor_strips_whitespace():
+    """Java line_postprocessor trims leading and trailing whitespace from output lines."""
+    java = Java()
+    assert java.line_postprocessor("  output  ") == "output"
+
+
+def test_java_detect_active_line():
+    """Java detect_active_line() parses ##active_lineN## markers and ignores plain text."""
+    java = Java()
+    assert java.detect_active_line("##active_line2##") == 2
+    assert java.detect_active_line("plain") is None

--- a/tests/core/computer/terminal/languages/test_javascript.py
+++ b/tests/core/computer/terminal/languages/test_javascript.py
@@ -1,0 +1,25 @@
+from interpreter.core.computer.terminal.languages.javascript import (
+    JavaScript,
+    preprocess_javascript,
+)
+
+
+def test_preprocess_javascript_adds_end_marker():
+    """preprocess_javascript() wraps code in try/catch and adds an end-of-execution marker."""
+    code = preprocess_javascript("console.log(1)")
+    assert "##end_of_execution##" in code
+    assert "try {" in code
+
+
+def test_preprocess_single_line_adds_active_line_markers():
+    """preprocess_javascript() inserts ##active_lineN## markers before each source line."""
+    code = preprocess_javascript("a()\nb()")
+    assert "##active_line1##" in code
+    assert "##active_line2##" in code
+
+
+def test_line_postprocessor_filters_node_banner():
+    """JavaScript line_postprocessor drops Node.js welcome banners but keeps real output."""
+    js = JavaScript()
+    assert js.line_postprocessor("Welcome to Node.js v20") is None
+    assert js.line_postprocessor("actual output") == "actual output"

--- a/tests/core/computer/terminal/languages/test_jupyter_language.py
+++ b/tests/core/computer/terminal/languages/test_jupyter_language.py
@@ -1,0 +1,89 @@
+import ast
+
+from interpreter.core.computer.terminal.languages.jupyter_language import (
+    AddLinePrints,
+    add_active_line_prints,
+    preprocess_python,
+    string_to_python,
+    wrap_in_try_except,
+)
+
+
+def test_preprocess_python_adds_active_line_markers():
+    """preprocess_python() injects ##active_line markers into executable Python lines."""
+    code = "x = 1\nprint(x)"
+    result = preprocess_python(code)
+    assert "##active_line" in result
+
+
+def test_preprocess_python_skips_magic_lines():
+    """preprocess_python() leaves IPython magic lines without active-line markers."""
+    code = "%matplotlib inline\nx = 1"
+    result = preprocess_python(code)
+    assert "##active_line" not in result
+
+
+def test_preprocess_python_respects_active_line_detection_env(monkeypatch):
+    """INTERPRETER_ACTIVE_LINE_DETECTION=false disables marker injection."""
+    monkeypatch.setenv("INTERPRETER_ACTIVE_LINE_DETECTION", "false")
+    code = "x = 1"
+    result = preprocess_python(code)
+    assert "##active_line" not in result
+
+
+def test_preprocess_python_strips_blank_lines(monkeypatch):
+    """preprocess_python() removes blank lines when active-line detection is disabled."""
+    monkeypatch.setenv("INTERPRETER_ACTIVE_LINE_DETECTION", "false")
+    code = "x = 1\n\n\ny = 2"
+    result = preprocess_python(code)
+    assert result == "x = 1\ny = 2"
+
+
+def test_add_active_line_prints_inserts_before_executable_lines():
+    """add_active_line_prints() adds markers before each executable Python statement."""
+    code = "a = 1\nprint(a)"
+    result = add_active_line_prints(code)
+    assert result.count("##active_line") >= 2
+
+
+def test_add_active_line_prints_handles_comments():
+    """add_active_line_prints() skips comment-only lines but still processes executable code."""
+    code = "# comment\nx = 1"
+    result = add_active_line_prints(code)
+    assert "x = 1" in result
+
+
+def test_string_to_python_extracts_public_functions():
+    """string_to_python() returns public function definitions with their imports, excluding private names."""
+    code = """
+import os
+
+def hello():
+    \"\"\"Say hi\"\"\"
+    return 1
+
+def _private():
+    pass
+"""
+    functions = string_to_python(code)
+    assert "hello" in functions
+    assert "_private" not in functions
+    assert "def hello():" in functions["hello"]
+    assert "import os" in functions["hello"]
+
+
+def test_wrap_in_try_except_wraps_code():
+    """wrap_in_try_except() wraps user code in try/except with traceback printing."""
+    code = "x = 1"
+    result = wrap_in_try_except(code)
+    assert "try:" in result
+    assert "traceback.print_exc" in result
+
+
+def test_add_line_prints_transformer_inserts_prints():
+    """AddLinePrints AST transformer injects ##active_line print statements into parsed code."""
+    tree = ast.parse("x = 1")
+    transformer = AddLinePrints()
+    new_tree = transformer.visit(tree)
+    unparsed = ast.unparse(new_tree)
+    assert "##active_line" in unparsed

--- a/tests/core/computer/terminal/languages/test_powershell.py
+++ b/tests/core/computer/terminal/languages/test_powershell.py
@@ -1,0 +1,16 @@
+from interpreter.core.computer.terminal.languages.powershell import (
+    PowerShell,
+    preprocess_powershell,
+)
+
+
+def test_preprocess_powershell_adds_end_marker():
+    """preprocess_powershell() appends an ##end_of_execution## marker to PowerShell code."""
+    code = preprocess_powershell("Write-Host hi")
+    assert "##end_of_execution##" in code
+
+
+def test_powershell_detect_active_line():
+    """PowerShell detect_active_line() parses ##active_lineN## markers from echoed output."""
+    ps = PowerShell()
+    assert ps.detect_active_line('echo "##active_line4##"') == 4

--- a/tests/core/computer/terminal/languages/test_r.py
+++ b/tests/core/computer/terminal/languages/test_r.py
@@ -1,0 +1,52 @@
+from interpreter.core.computer.terminal.languages.r import R
+
+
+def test_r_preprocess_code_wraps_in_trycatch():
+    """R code is wrapped in tryCatch with active-line and end-of-execution markers."""
+    r_lang = R()
+    result = r_lang.preprocess_code("x <- 1")
+    assert "tryCatch" in result
+    assert "##end_of_execution##" in result
+    assert "##active_line1##" in result
+
+
+def test_r_line_postprocessor_skips_echoed_code():
+    """R line_postprocessor returns None while still within the submitted code line count."""
+    r_lang = R()
+    r_lang.preprocess_code("x <- 1")
+    assert r_lang.line_postprocessor("ignored") is None
+
+
+def test_r_line_postprocessor_strips_string_output():
+    """R line_postprocessor strips the [1] prefix and quotes from string output."""
+    r_lang = R()
+    r_lang.code_line_count = 0
+    assert r_lang.line_postprocessor('[1] "hello"') == "hello"
+
+
+def test_r_line_postprocessor_strips_numeric_prefix():
+    """R line_postprocessor strips the [1] prefix from numeric output."""
+    r_lang = R()
+    r_lang.code_line_count = 0
+    assert r_lang.line_postprocessor("[1] 42") == "42"
+
+
+def test_r_line_postprocessor_filters_prompt_lines():
+    """R line_postprocessor drops bare R prompt lines from output."""
+    r_lang = R()
+    r_lang.code_line_count = 0
+    assert r_lang.line_postprocessor("> ") is None
+
+
+def test_r_detect_active_line():
+    """R detect_active_line() parses the line number from ##active_lineN## markers."""
+    r_lang = R()
+    assert r_lang.detect_active_line("##active_line2##") == 2
+
+
+def test_r_detect_end_of_execution():
+    """R detect_end_of_execution() recognizes end and error markers but not normal output."""
+    r_lang = R()
+    assert r_lang.detect_end_of_execution("##end_of_execution##") is True
+    assert r_lang.detect_end_of_execution("##execution_error##") is True
+    assert r_lang.detect_end_of_execution("still running") is False

--- a/tests/core/computer/terminal/languages/test_react.py
+++ b/tests/core/computer/terminal/languages/test_react.py
@@ -1,0 +1,35 @@
+from unittest import mock
+
+from interpreter.core.computer.terminal.languages.react import React, is_incompatible
+
+
+def test_is_incompatible_detects_import():
+    """is_incompatible() flags React code that uses ES module import syntax."""
+    assert is_incompatible("import React from 'react'\nexport default App")
+
+
+def test_is_incompatible_allows_simple_jsx():
+    """is_incompatible() allows self-contained JSX without import statements."""
+    assert is_incompatible("function App() { return <div />; }") is False
+
+
+def test_react_incompatible_yields_error():
+    """React.run() yields a console error when the source uses unsupported imports."""
+    react = React()
+    chunks = list(react.run("import X from 'x'"))
+    assert chunks[0]["type"] == "console"
+    assert "not supported" in chunks[0]["content"].lower()
+
+
+def test_react_compatible_yields_image_chunk():
+    """React.run() renders compatible JSX to a base64 PNG image chunk."""
+    react = React()
+    with mock.patch(
+        "interpreter.core.computer.terminal.languages.react.html_to_png_base64",
+        return_value="imgdata",
+    ):
+        chunks = list(react.run("function App(){return <div/>}"))
+    image_chunks = [c for c in chunks if c["type"] == "image"]
+    assert len(image_chunks) == 1
+    assert image_chunks[0]["format"] == "base64.png"
+    assert image_chunks[0]["content"] == "imgdata"

--- a/tests/core/computer/terminal/languages/test_ruby.py
+++ b/tests/core/computer/terminal/languages/test_ruby.py
@@ -1,0 +1,39 @@
+from interpreter.core.computer.terminal.languages.ruby import Ruby
+
+
+def test_ruby_preprocess_code_wraps_in_begin_rescue():
+    """Ruby code is wrapped in begin/rescue with active-line and end-of-execution markers."""
+    ruby = Ruby()
+    result = ruby.preprocess_code("puts 1")
+    assert "begin" in result
+    assert "##end_of_execution##" in result
+    assert "##active_line1##" in result
+
+
+def test_ruby_line_postprocessor_skips_echoed_code():
+    """Ruby line_postprocessor returns None while still within the submitted code line count."""
+    ruby = Ruby()
+    ruby.preprocess_code("puts 1")
+    assert ruby.line_postprocessor("ignored") is None
+
+
+def test_ruby_line_postprocessor_filters_nil():
+    """Ruby line_postprocessor drops => nil result lines from output."""
+    ruby = Ruby()
+    ruby.code_line_count = 0
+    assert ruby.line_postprocessor("=> nil") is None
+
+
+def test_ruby_detect_active_line():
+    """Ruby detect_active_line() parses ##active_lineN## markers and ignores plain text."""
+    ruby = Ruby()
+    assert ruby.detect_active_line("##active_line3##") == 3
+    assert ruby.detect_active_line("hello") is None
+
+
+def test_ruby_detect_end_of_execution():
+    """Ruby detect_end_of_execution() recognizes end and error markers but not normal output."""
+    ruby = Ruby()
+    assert ruby.detect_end_of_execution("##end_of_execution##") is True
+    assert ruby.detect_end_of_execution("##execution_error##") is True
+    assert ruby.detect_end_of_execution("running") is False

--- a/tests/core/computer/terminal/languages/test_subprocess_language.py
+++ b/tests/core/computer/terminal/languages/test_subprocess_language.py
@@ -1,0 +1,80 @@
+from io import StringIO
+from unittest import mock
+
+from interpreter.core.computer.terminal.languages.subprocess_language import (
+    SubprocessLanguage,
+)
+
+
+class EchoLanguage(SubprocessLanguage):
+    file_extension = "txt"
+    name = "Echo"
+
+    def __init__(self):
+        super().__init__()
+        self.start_cmd = ["cat"]
+
+    def detect_end_of_execution(self, line):
+        return "##done##" in line
+
+
+def test_handle_stream_output_puts_console_chunks():
+    """handle_stream_output() enqueues console output and signals completion at end markers."""
+    lang = EchoLanguage()
+    stream = StringIO("hello\n##done##\n")
+    lang.handle_stream_output(stream, is_error_stream=False)
+    assert lang.output_queue.get()["content"] == "hello\n"
+    assert lang.done.is_set()
+
+
+def test_handle_stream_output_active_line():
+    """handle_stream_output() emits active_line chunks when detect_active_line matches."""
+    lang = EchoLanguage()
+
+    def detect(line):
+        if "##active_line2##" in line:
+            return 2
+        return None
+
+    lang.detect_active_line = detect
+    stream = StringIO("prefix ##active_line2## suffix\n")
+    lang.handle_stream_output(stream, is_error_stream=False)
+    active = lang.output_queue.get()
+    assert active["format"] == "active_line"
+    assert active["content"] == 2
+    output = lang.output_queue.get()
+    assert "suffix" in output["content"]
+
+
+def test_handle_stream_output_keyboard_interrupt_on_stderr():
+    """handle_stream_output() treats KeyboardInterrupt on stderr as output and ends execution."""
+    lang = EchoLanguage()
+    stream = StringIO("KeyboardInterrupt\n")
+    lang.handle_stream_output(stream, is_error_stream=True)
+    assert lang.output_queue.get()["content"] == "KeyboardInterrupt"
+    assert lang.done.is_set()
+
+
+def test_run_yields_queue_output():
+    """SubprocessLanguage.run() writes code to stdin and yields queued console chunks."""
+    lang = EchoLanguage()
+    mock_process = mock.Mock()
+    mock_process.stdin = mock.Mock()
+    mock_process.stdout = StringIO("")
+    mock_process.stderr = StringIO("")
+    lang.process = mock_process
+
+    lang.output_queue.put(
+        {"type": "console", "format": "output", "content": "result"}
+    )
+    lang.done.set()
+
+    with mock.patch.object(lang, "start_process"):
+        with mock.patch("interpreter.core.computer.terminal.languages.subprocess_language.time.sleep"):
+            chunks = []
+            for chunk in lang.run("echo hi"):
+                chunks.append(chunk)
+                break
+    mock_process.stdin.write.assert_called_once_with("echo hi\n")
+    mock_process.stdin.flush.assert_called_once()
+    assert chunks[0]["content"] == "result"

--- a/tests/core/computer/terminal/test_terminal.py
+++ b/tests/core/computer/terminal/test_terminal.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.computer.terminal.terminal import Terminal
+
+
+def test_get_language_by_name():
+    """Terminal.get_language() resolves known language names and returns None for unknown ones."""
+    terminal = Terminal(computer=SimpleNamespace())
+    assert terminal.get_language("python").name == "Python"
+    assert terminal.get_language("bash").name == "Shell"
+    assert terminal.get_language("unknown_xyz") is None
+
+
+def test_get_language_by_alias():
+    """Terminal.get_language() resolves shell aliases such as 'sh' to Shell."""
+    terminal = Terminal(computer=SimpleNamespace())
+    assert terminal.get_language("sh").name == "Shell"
+
+
+def test_run_non_streaming_merges_output_chunks():
+    """Terminal.run(stream=False) concatenates consecutive console output chunks."""
+    computer = SimpleNamespace(
+        import_computer_api=False,
+        import_skills=False,
+        _has_imported_computer_api=False,
+        _has_imported_skills=False,
+        verbose=False,
+        skills=SimpleNamespace(import_skills=mock.Mock()),
+    )
+    terminal = Terminal(computer=computer)
+
+    def fake_streaming_run(language, code, display=False):
+        yield {"type": "console", "format": "output", "content": "part1"}
+        yield {"type": "console", "format": "output", "content": "part2"}
+
+    with mock.patch.object(terminal, "_streaming_run", side_effect=fake_streaming_run):
+        output = terminal.run("fake", "code", stream=False)
+    assert output == [
+        {"type": "console", "format": "output", "content": "part1part2"}
+    ]
+
+
+def test_apt_install_delegates_to_sudo_install():
+    """Shell 'apt install' commands route through sudo_install with the package name."""
+    computer = SimpleNamespace(
+        import_computer_api=False,
+        import_skills=False,
+        _has_imported_computer_api=False,
+        _has_imported_skills=False,
+        verbose=False,
+        skills=SimpleNamespace(import_skills=mock.Mock()),
+    )
+    terminal = Terminal(computer=computer)
+    with mock.patch.object(terminal, "sudo_install", return_value=True) as sudo_install:
+        output = terminal.run("shell", "apt install cowsay", stream=False)
+    sudo_install.assert_called_once_with("cowsay")
+    assert "installed successfully" in output[0]["content"]
+
+
+def test_streaming_run_parses_recipient_markers():
+    """_streaming_run() splits @@@RECIPIENT/CONTENT markers into chunk fields."""
+    computer = SimpleNamespace(
+        import_computer_api=False,
+        import_skills=False,
+        _has_imported_computer_api=False,
+        _has_imported_skills=False,
+        verbose=False,
+        skills=SimpleNamespace(import_skills=mock.Mock()),
+    )
+    terminal = Terminal(computer=computer)
+    terminal._active_languages["fake"] = SimpleNamespace(
+        run=lambda code: iter(
+            [
+                {
+                    "type": "console",
+                    "format": "output",
+                    "content": "@@@RECIPIENT:user@@@CONTENT:hello@@@END",
+                }
+            ]
+        )
+    )
+    chunks = list(terminal._streaming_run("fake", "x", display=False))
+    assert chunks[0]["recipient"] == "user"
+    assert chunks[0]["content"] == "hello"
+
+
+def test_streaming_run_strips_hide_traceback_marker():
+    """_streaming_run() removes traceback text before the @@@HIDE_TRACEBACK@@@ marker."""
+    computer = SimpleNamespace(
+        import_computer_api=False,
+        import_skills=False,
+        _has_imported_computer_api=False,
+        _has_imported_skills=False,
+        verbose=False,
+        skills=SimpleNamespace(import_skills=mock.Mock()),
+    )
+    terminal = Terminal(computer=computer)
+    terminal._active_languages["fake"] = SimpleNamespace(
+        run=lambda code: iter(
+            [
+                {
+                    "type": "console",
+                    "format": "output",
+                    "content": "Traceback...\n@@@HIDE_TRACEBACK@@@User-facing error",
+                }
+            ]
+        )
+    )
+    chunks = list(terminal._streaming_run("fake", "x", display=False))
+    assert "Traceback" not in chunks[0]["content"]
+    assert "User-facing error" in chunks[0]["content"]

--- a/tests/core/computer/test_computer.py
+++ b/tests/core/computer/test_computer.py
@@ -1,24 +1,35 @@
 import unittest
 from unittest import mock
+
 from interpreter.core.computer.computer import Computer
+from tests.helpers import COMPUTER_TOOL_SUBSYSTEMS
+
 
 class TestComputer(unittest.TestCase):
     def setUp(self):
         self.computer = Computer(mock.Mock())
 
     def test_get_all_computer_tools_list(self):
+        """_get_all_computer_tools_list returns subsystem objects in declared order."""
         # Act
         tools_list = self.computer._get_all_computer_tools_list()
+        expected = [getattr(self.computer, name)
+                    for name in COMPUTER_TOOL_SUBSYSTEMS]
 
         # Assert
-        self.assertEqual(len(tools_list), 15)
+        self.assertEqual(tools_list, expected)
 
     def test_get_all_computer_tools_signature_and_description(self):
+        """Each subsystem's dot-notation prefix appears in the tools description."""
         # Act
         tools_description = self.computer._get_all_computer_tools_signature_and_description()
+        joined = "\n".join(tools_description)
 
         # Assert
-        self.assertGreater(len(tools_description), 64)
+        self.assertGreater(len(joined), 64)
+        for subsystem in COMPUTER_TOOL_SUBSYSTEMS:
+            self.assertIn(f"computer.{subsystem}.", joined)
+
 
 if __name__ == "__main__":
     testing = TestComputer()

--- a/tests/core/computer/test_keyboard_and_mouse.py
+++ b/tests/core/computer/test_keyboard_and_mouse.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+def test_keyboard_write_short_text_uses_clipboard():
+    """Keyboard.write() copies text to the clipboard and pastes it for short strings."""
+    from interpreter.core.computer.keyboard.keyboard import Keyboard
+
+    clipboard = SimpleNamespace(
+        view=mock.Mock(return_value="history"),
+        copy=mock.Mock(),
+        paste=mock.Mock(),
+    )
+    computer = SimpleNamespace(clipboard=clipboard)
+    keyboard = Keyboard(computer)
+
+    fake_pyautogui = mock.Mock()
+    with mock.patch("interpreter.core.computer.keyboard.keyboard.pyautogui", fake_pyautogui):
+        with mock.patch("interpreter.core.computer.keyboard.keyboard.time.sleep"):
+            keyboard.write("hi")
+
+    clipboard.copy.assert_any_call("hi")
+    clipboard.paste.assert_called()
+
+
+def test_keyboard_press_delegates_to_pyautogui():
+    """Keyboard.press() forwards key presses to pyautogui with default timing."""
+    from interpreter.core.computer.keyboard.keyboard import Keyboard
+
+    computer = SimpleNamespace(clipboard=SimpleNamespace())
+    keyboard = Keyboard(computer)
+    fake_pyautogui = mock.Mock()
+
+    with mock.patch("interpreter.core.computer.keyboard.keyboard.pyautogui", fake_pyautogui):
+        with mock.patch("interpreter.core.computer.keyboard.keyboard.time.sleep"):
+            keyboard.press("enter")
+
+    fake_pyautogui.press.assert_called_once_with(("enter",), presses=1, interval=0.1)
+
+
+def test_mouse_scroll_calls_pyautogui():
+    """Mouse.scroll() delegates the scroll amount to pyautogui.scroll."""
+    from interpreter.core.computer.mouse.mouse import Mouse
+
+    computer = SimpleNamespace(
+        display=SimpleNamespace(),
+        emit_images=False,
+        verbose=False,
+    )
+    mouse = Mouse(computer)
+    fake_pyautogui = mock.Mock()
+
+    with mock.patch("interpreter.core.computer.mouse.mouse.pyautogui", fake_pyautogui):
+        mouse.scroll(3)
+
+    fake_pyautogui.scroll.assert_called_once_with(3)
+
+
+def test_mouse_move_rejects_too_many_positional_args():
+    """Mouse.move() raises ValueError when given more than one positional coordinate."""
+    from interpreter.core.computer.mouse.mouse import Mouse
+
+    mouse = Mouse(SimpleNamespace(display=SimpleNamespace(), emit_images=False))
+    with pytest.raises(ValueError, match="Too many positional arguments"):
+        mouse.move(1, 2)

--- a/tests/core/computer/utils/test_html_to_png_base64.py
+++ b/tests/core/computer/utils/test_html_to_png_base64.py
@@ -1,0 +1,28 @@
+from unittest import mock
+
+from interpreter.core.computer.utils import html_to_png_base64
+
+
+def test_html_to_png_base64_returns_base64(tmp_path, monkeypatch):
+    """html_to_png_base64 renders HTML to PNG and returns base64-encoded bytes."""
+    png_bytes = b"\x89PNG\r\n\x1a\nfake"
+    monkeypatch.setattr(
+        html_to_png_base64, "get_storage_path", lambda: str(tmp_path)
+    )
+
+    mock_hti = mock.Mock()
+    mock_hti.output_path = None
+
+    def fake_screenshot(html_str, save_as, size):
+        (tmp_path / save_as).write_bytes(png_bytes)
+
+    mock_hti.screenshot = fake_screenshot
+
+    with mock.patch.object(html_to_png_base64, "html2image") as lazy:
+        lazy.Html2Image.return_value = mock_hti
+        result = html_to_png_base64.html_to_png_base64("<html></html>")
+
+    import base64
+
+    assert result == base64.b64encode(png_bytes).decode()
+    assert not list(tmp_path.glob("*.png"))

--- a/tests/core/computer/utils/test_recipient_utils.py
+++ b/tests/core/computer/utils/test_recipient_utils.py
@@ -1,0 +1,30 @@
+from interpreter.core.computer.utils.recipient_utils import (
+    format_to_recipient,
+    parse_for_recipient,
+)
+
+
+def test_format_and_parse_round_trip():
+    """format_to_recipient and parse_for_recipient preserve recipient and content."""
+    text = "Hello, user!"
+    recipient = "user"
+    formatted = format_to_recipient(text, recipient)
+    parsed_recipient, parsed_content = parse_for_recipient(formatted)
+    assert parsed_recipient == recipient
+    assert parsed_content == text
+
+
+def test_parse_plain_text_without_markers():
+    """parse_for_recipient leaves plain text unchanged and returns no recipient."""
+    content = "Just a normal message"
+    recipient, parsed = parse_for_recipient(content)
+    assert recipient is None
+    assert parsed == content
+
+
+def test_format_preserves_newlines():
+    """format_to_recipient keeps embedded newlines through a round-trip parse."""
+    text = "Line1\nLine2 without colons"
+    formatted = format_to_recipient(text, "assistant")
+    _, parsed = parse_for_recipient(formatted)
+    assert parsed == text

--- a/tests/core/computer/vision/test_vision.py
+++ b/tests/core/computer/vision/test_vision.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.computer.vision.vision import Vision
+
+
+def test_ocr_from_base64_lmc_uses_easyocr():
+    """Vision.ocr() on a base64 LMC image should decode and run easyocr.readtext.
+
+    We mock easyocr so CI does not download models or need a display. The test
+    checks that the recognized text from readtext is returned unchanged.
+    """
+    import base64
+
+    # Minimal valid 1x1 PNG (content does not matter; easyocr is mocked).
+    png = base64.b64encode(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+        b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc``\x00\x00\x00\x02\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+    ).decode()
+    vision = Vision(computer=SimpleNamespace(debug=False))
+    lmc = {"format": "base64.png", "content": png}
+
+    fake_reader = mock.Mock()
+    fake_reader.readtext.return_value = [(None, "OCR TEXT", None)]
+
+    with mock.patch.object(vision, "load"):
+        vision.easyocr = fake_reader
+        assert vision.ocr(lmc=lmc) == "OCR TEXT"
+    fake_reader.readtext.assert_called_once()

--- a/tests/core/llm/test_llm.py
+++ b/tests/core/llm/test_llm.py
@@ -1,6 +1,11 @@
+from types import SimpleNamespace
 from unittest import mock
 
+import pytest
+
 from interpreter import OpenInterpreter
+from interpreter.core.llm.llm import Llm, SuppressDebugFilter
+from tests.helpers import TEST_LLM_MODEL
 
 _MESSAGES = [
     {"role": "system", "type": "message", "content": "system"},
@@ -13,7 +18,7 @@ def _capture_llm_params(interpreter, temperature):
     interpreter.llm.supports_functions = True
     interpreter.llm.supports_vision = False
     interpreter.llm._is_loaded = True
-    interpreter.llm.model = "gpt-4o-mini"
+    interpreter.llm.model = TEST_LLM_MODEL
 
     captured = {}
 
@@ -37,5 +42,60 @@ def test_temperature_zero_is_sent_to_llm_api():
 
 
 def test_temperature_none_omitted_from_llm_api():
+    """Unset temperature must not be sent; API should use its own default."""
     params = _capture_llm_params(OpenInterpreter(), None)
     assert "temperature" not in params
+
+
+def test_suppress_debug_filter_blocks_cost_map_messages():
+    """SuppressDebugFilter hides LiteLLM cost-map debug noise from logs."""
+    filt = SuppressDebugFilter()
+    record = mock.Mock()
+    record.getMessage.return_value = "loading cost map data"
+    assert filt.filter(record) is False
+    record.getMessage.return_value = "normal log line"
+    assert filt.filter(record) is True
+
+
+def test_llm_clamps_max_tokens_to_context_window():
+    """max_tokens is capped to context_window // 2 before calling the API."""
+    interpreter = SimpleNamespace(
+        shrink_images=True,
+        display_message=mock.Mock(),
+        computer=SimpleNamespace(vision=SimpleNamespace(query=mock.Mock())),
+        os=False,
+        verbose=False,
+        debug=False,
+    )
+    llm = Llm(interpreter)
+    llm._is_loaded = True
+    llm.context_window = 1000
+    llm.max_tokens = 5000
+    llm.supports_functions = False
+    llm.supports_vision = False
+
+    messages = [{"role": "system", "type": "message", "content": "sys"}]
+
+    with mock.patch.object(llm, "load"):
+        with mock.patch(
+            "interpreter.core.llm.llm.convert_to_openai_messages",
+            return_value=[{"role": "system", "content": "sys"}],
+        ):
+            with mock.patch("interpreter.core.llm.llm.tt.trim", return_value=([], {})):
+                with mock.patch(
+                    "interpreter.core.llm.llm.run_text_llm", return_value=iter([])
+                ):
+                    list(llm.run(messages))
+    assert llm.max_tokens == 200
+
+
+def test_llm_run_requires_system_first():
+    """llm.run rejects message lists that do not start with a system message."""
+    interpreter = SimpleNamespace(
+        shrink_images=True,
+        display_message=mock.Mock(),
+        computer=SimpleNamespace(vision=SimpleNamespace(query=mock.Mock())),
+    )
+    llm = Llm(interpreter)
+    with pytest.raises(AssertionError, match="system"):
+        list(llm.run([{"role": "user", "type": "message", "content": "hi"}]))

--- a/tests/core/llm/test_run_function_calling_llm.py
+++ b/tests/core/llm/test_run_function_calling_llm.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+from interpreter.core.llm.run_function_calling_llm import run_function_calling_llm
+
+
+class FakeLanguage:
+    name = "Python"
+
+
+def _make_llm(chunks):
+    def completions(**params):
+        for chunk in chunks:
+            yield chunk
+
+    terminal = SimpleNamespace(languages=[FakeLanguage()])
+    computer = SimpleNamespace(terminal=terminal)
+    return SimpleNamespace(
+        completions=completions,
+        interpreter=SimpleNamespace(computer=computer, verbose=False),
+    )
+
+
+def test_message_content_yielded():
+    """Plain text content in streaming deltas is yielded as message-type chunks."""
+    llm = _make_llm([{"choices": [{"delta": {"content": "Hi there"}}]}])
+    result = list(run_function_calling_llm(llm, {"messages": []}))
+    assert result == [{"type": "message", "content": "Hi there"}]
+
+
+def test_streaming_function_call_yields_code():
+    """A streamed execute function_call is reassembled across deltas into a single code chunk."""
+    chunks = [
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "function_call": {
+                            "name": "execute",
+                            "arguments": '{"language": "python", "code": "print(',
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "choices": [
+                {"delta": {"function_call": {"arguments": '1)"'}}}
+            ]
+        },
+    ]
+    llm = _make_llm(chunks)
+    result = list(run_function_calling_llm(llm, {"messages": []}))
+    code_chunks = [r for r in result if r["type"] == "code"]
+    assert code_chunks
+    assert code_chunks[0]["format"] == "python"
+    assert "".join(c["content"] for c in code_chunks) == "print(1)"
+
+
+def test_hallucinated_python_name_yields_code():
+    """When the model names the function 'python' instead of 'execute', the arguments are still treated as code."""
+    chunks = [
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "function_call": {
+                            "name": "python",
+                            "arguments": "print(2)",
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+    llm = _make_llm(chunks)
+    result = list(run_function_calling_llm(llm, {"messages": []}))
+    assert result == [{"type": "code",
+                       "format": "python",
+                       "content": "print(2)"}]

--- a/tests/core/llm/test_run_text_llm.py
+++ b/tests/core/llm/test_run_text_llm.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+from interpreter.core.llm.run_text_llm import run_text_llm
+
+
+def _make_llm(chunks, execution_instructions=None):
+    def completions(**params):
+        for chunk in chunks:
+            yield chunk
+
+    return SimpleNamespace(
+        completions=completions,
+        execution_instructions=execution_instructions,
+        interpreter=SimpleNamespace(verbose=False, os=False),
+    )
+
+
+def test_plain_text_yields_messages():
+    """Streaming text deltas from the LLM are yielded as assistant message chunks."""
+    llm = _make_llm(
+        [
+            {"choices": [{"delta": {"content": "Hello"}}]},
+            {"choices": [{"delta": {"content": " world"}}]},
+        ]
+    )
+    result = list(run_text_llm(llm, {"messages": [{"content": "system"}]}))
+    assert result == [
+        {"type": "message", "content": "Hello"},
+        {"type": "message", "content": " world"},
+    ]
+
+
+def test_code_block_yields_code_chunks():
+    """Markdown fenced code blocks in the stream are parsed into typed code chunks with language format."""
+    llm = _make_llm(
+        [
+            {"choices": [{"delta": {"content": "```python\n"}}]},
+            {"choices": [{"delta": {"content": "print(1)\n"}}]},
+            {"choices": [{"delta": {"content": "```"}}]},
+        ]
+    )
+    result = list(run_text_llm(llm, {"messages": [{"content": "system"}]}))
+    assert any(r["type"] == "code" and r["format"] == "python" for r in result)
+
+
+def test_execution_instructions_appended():
+    """When set, execution_instructions are appended to the system message before the API call."""
+    llm = _make_llm([], execution_instructions="Run safely.")
+    params = {"messages": [{"content": "base"}]}
+    list(run_text_llm(llm, params))
+    assert params["messages"][0]["content"] == "base\nRun safely."

--- a/tests/core/llm/test_run_tool_calling_llm.py
+++ b/tests/core/llm/test_run_tool_calling_llm.py
@@ -1,0 +1,49 @@
+from interpreter.core.llm.run_tool_calling_llm import process_messages
+
+
+def test_function_call_converted_to_tool_calls():
+    """Legacy function_call/function messages are rewritten as assistant tool_calls plus tool responses."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "function_call": {"name": "execute", "arguments": "{}"},
+        },
+        {"role": "function", "name": "execute", "content": "output"},
+    ]
+    result = process_messages(messages)
+    assert result[0]["tool_calls"][0]["id"] == "toolu_1"
+    assert result[1]["role"] == "tool"
+    assert result[1]["tool_call_id"] == "toolu_1"
+
+
+def test_function_call_without_response_gets_empty_tool():
+    """An assistant function_call with no following function message gets a synthetic empty tool reply."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "function_call": {"name": "execute", "arguments": "{}"},
+        }
+    ]
+    result = process_messages(messages)
+    assert len(result) == 2
+    assert result[1] == {"role": "tool",
+                         "tool_call_id": "toolu_1",
+                         "content": ""}
+
+
+def test_orphaned_function_response_gets_synthetic_tool_call():
+    """A lone function message is paired with a synthetic assistant tool_call so the API sees a valid pair."""
+    messages = [{"role": "function",
+                 "name": "execute",
+                 "content": "late output"}]
+    result = process_messages(messages)
+    assert result[0]["role"] == "assistant"
+    assert result[1]["role"] == "tool"
+
+
+def test_passthrough_message_unchanged():
+    """Messages that are already in tool-calling format are returned without modification."""
+    messages = [{"role": "user", "content": "hello"}]
+    assert process_messages(messages) == messages

--- a/tests/core/llm/test_run_tool_calling_llm_extended.py
+++ b/tests/core/llm/test_run_tool_calling_llm_extended.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+from interpreter.core.llm.run_tool_calling_llm import run_tool_calling_llm
+
+
+class Lang:
+    name = "Python"
+
+
+def test_tool_calling_llm_sets_language_enum():
+    """The execute tool's language enum lists every terminal language the computer supports."""
+    captured = {}
+
+    def completions(**params):
+        captured.update(params)
+        return iter([])
+
+    llm = SimpleNamespace(
+        completions=completions,
+        interpreter=SimpleNamespace(
+            computer=SimpleNamespace(
+                terminal=SimpleNamespace(languages=[Lang()])
+            ),
+            verbose=False,
+        ),
+    )
+    list(run_tool_calling_llm(llm, {"messages": []}))
+    tool = captured["tools"][0]["function"]
+    assert tool["name"] == "execute"
+    enum = tool["parameters"]["properties"]["language"]["enum"]
+    assert enum == ["python"]

--- a/tests/core/llm/utils/test_convert_to_openai_messages.py
+++ b/tests/core/llm/utils/test_convert_to_openai_messages.py
@@ -1,0 +1,256 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from interpreter.core.llm.utils.convert_to_openai_messages import (
+    convert_to_openai_messages,
+)
+
+
+@pytest.fixture
+def interpreter():
+    return SimpleNamespace(
+        user_message_template="User: {content}",
+        always_apply_user_message_template=False,
+        code_output_template="Output:\n{content}",
+        empty_code_output_template="(no output)",
+        code_output_sender="user",
+        debug=False,
+    )
+
+
+def test_assistant_message_converted(interpreter):
+    """Plain assistant messages pass through as role/content pairs unchanged."""
+    messages = [{"role": "assistant", "type": "message", "content": "Hello"}]
+    result = convert_to_openai_messages(messages, interpreter=interpreter)
+    assert result == [{"role": "assistant", "content": "Hello"}]
+
+
+def test_last_user_message_gets_template(interpreter):
+    """The last user message is wrapped with the interpreter's user_message_template."""
+    messages = [{"role": "user", "type": "message", "content": "Hello"}]
+    result = convert_to_openai_messages(messages, interpreter=interpreter)
+    assert result == [{"role": "user", "content": "User: Hello"}]
+
+
+def test_code_with_function_calling(interpreter):
+    """Code messages become assistant function_call payloads when function_calling is enabled."""
+    messages = [
+        {"role": "assistant", "type": "code", "format": "python", "content": "1+1"}
+    ]
+    result = convert_to_openai_messages(
+        messages, function_calling=True, interpreter=interpreter
+    )
+    assert result[0]["role"] == "assistant"
+    assert result[0]["function_call"]["name"] == "execute"
+    args = json.loads(result[0]["function_call"]["arguments"])
+    assert args == {"language": "python", "code": "1+1"}
+
+
+def test_code_without_function_calling(interpreter):
+    """Code messages become markdown fenced blocks when function_calling is disabled."""
+    messages = [
+        {"role": "assistant", "type": "code", "format": "python", "content": "1+1"}
+    ]
+    result = convert_to_openai_messages(
+        messages, function_calling=False, interpreter=interpreter
+    )
+    assert result[0]["content"] == "```python\n1+1\n```"
+
+
+def test_console_output_function_role(interpreter):
+    """Console output is sent as a function-role execute result when function_calling is enabled."""
+    messages = [
+        {
+            "role": "computer",
+            "type": "console",
+            "format": "output",
+            "content": "42",
+        }
+    ]
+    result = convert_to_openai_messages(
+        messages, function_calling=True, interpreter=interpreter
+    )
+    assert result == [{"role": "function", "name": "execute", "content": "42"}]
+
+
+def test_console_empty_output(interpreter):
+    """Whitespace-only console output is replaced with a 'No output' placeholder for the LLM."""
+    messages = [
+        {
+            "role": "computer",
+            "type": "console",
+            "format": "output",
+            "content": "   ",
+        }
+    ]
+    result = convert_to_openai_messages(
+        messages, function_calling=True, interpreter=interpreter
+    )
+    assert result[0]["content"] == "No output"
+
+
+def test_recipient_not_assistant_skipped(interpreter):
+    """Messages addressed to a non-assistant recipient are omitted from the OpenAI payload."""
+    messages = [
+        {
+            "role": "user",
+            "type": "message",
+            "content": "hidden",
+            "recipient": "user",
+        }
+    ]
+    assert convert_to_openai_messages(messages, interpreter=interpreter) == []
+
+
+def test_image_description_passes_through(interpreter):
+    """Image description text is forwarded as a user message when vision is disabled."""
+    messages = [
+        {
+            "role": "user",
+            "type": "image",
+            "format": "description",
+            "content": "A gradient image",
+        }
+    ]
+    result = convert_to_openai_messages(messages, vision=False, interpreter=interpreter)
+    assert result == [{"role": "user", "content": "A gradient image"}]
+
+
+def test_file_message(interpreter):
+    """File messages are converted to user messages containing the file path."""
+    messages = [{"role": "user", "type": "file", "content": "/path/to/file.txt"}]
+    result = convert_to_openai_messages(messages, interpreter=interpreter)
+    assert result == [{"role": "user", "content": "/path/to/file.txt"}]
+
+
+def test_unknown_type_raises(interpreter):
+    """An unrecognized message type raises so conversion bugs surface instead of silently dropping data."""
+    with pytest.raises(Exception, match="Unable to convert"):
+        convert_to_openai_messages(
+            [{"role": "user", "type": "unknown", "content": "x"}],
+            interpreter=interpreter,
+        )
+
+
+def test_console_output_assistant_sender(interpreter):
+    """When code_output_sender is assistant, console output is formatted as assistant text, not function role."""
+    interpreter.code_output_sender = "assistant"
+    messages = [
+        {
+            "role": "computer",
+            "type": "console",
+            "format": "output",
+            "content": "result",
+        }
+    ]
+    result = convert_to_openai_messages(
+        messages, function_calling=False, interpreter=interpreter
+    )
+    assert result[0]["role"] == "assistant"
+    assert "result" in result[0]["content"]
+
+
+def test_vision_false_skips_base64_image(interpreter):
+    """Base64 images are omitted entirely from the payload when vision support is disabled."""
+    import base64
+
+    png = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode()
+    messages = [
+        {
+            "role": "user",
+            "type": "image",
+            "format": "base64.png",
+            "content": png,
+        }
+    ]
+    assert (
+        convert_to_openai_messages(messages, vision=False, interpreter=interpreter) == []
+    )
+
+
+def test_image_path_with_vision(tmp_path, interpreter):
+    """Image path messages are read from disk and encoded as image_url parts when vision is enabled."""
+    img = tmp_path / "shot.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01")
+    messages = [
+        {
+            "role": "user",
+            "type": "image",
+            "format": "path",
+            "content": str(img),
+        }
+    ]
+    result = convert_to_openai_messages(
+        messages, vision=True, shrink_images=False, interpreter=interpreter
+    )
+    assert result[0]["content"][0]["type"] == "image_url"
+    text_parts = [c for c in result[0]["content"] if c.get("type") == "text"]
+    assert any("path" in part["text"] for part in text_parts)
+
+
+def test_computer_image_adds_followup_text(interpreter):
+    """Computer-origin images include explanatory text so the model knows the image is tool output."""
+    import base64
+
+    png = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode()
+    messages = [
+        {
+            "role": "computer",
+            "type": "image",
+            "format": "base64.png",
+            "content": png,
+        }
+    ]
+    result = convert_to_openai_messages(
+        messages, vision=True, shrink_images=False, interpreter=interpreter
+    )
+    text_parts = [c for c in result[0]["content"] if c.get("type") == "text"]
+    assert any("tool output" in part["text"] for part in text_parts)
+
+
+def test_error_type_ignored(interpreter):
+    """Error-type messages are dropped so they do not pollute the LLM conversation history."""
+    messages = [
+        {"role": "user", "type": "error", "content": "oops"},
+        {"role": "user", "type": "message", "content": "hi"},
+    ]
+    result = convert_to_openai_messages(messages, interpreter=interpreter)
+    assert result == [{"role": "user", "content": "User: hi"}]
+
+
+def test_always_apply_user_message_template(interpreter):
+    """When always_apply_user_message_template is set, every user message gets the template, not just the last."""
+    interpreter.always_apply_user_message_template = True
+    messages = [
+        {"role": "user", "type": "message", "content": "first"},
+        {"role": "user", "type": "message", "content": "second"},
+    ]
+    result = convert_to_openai_messages(messages, interpreter=interpreter)
+    assert result[0]["content"] == "User: first"
+    assert result[1]["content"] == "User: second"
+
+
+def test_function_calling_false_merges_same_role(interpreter):
+    """Without function calling, consecutive same-role messages are merged into one content string."""
+    messages = [
+        {"role": "assistant", "type": "message", "content": "part one"},
+        {"role": "assistant", "type": "message", "content": "part two"},
+    ]
+    result = convert_to_openai_messages(
+        messages, function_calling=False, interpreter=interpreter
+    )
+    assert len(result) == 1
+    assert "part one" in result[0]["content"]
+    assert "part two" in result[0]["content"]
+
+
+def test_image_missing_format_raises(interpreter):
+    """Image messages without a format field raise because the encoder cannot choose an encoding."""
+    with pytest.raises(Exception, match="format"):
+        convert_to_openai_messages(
+            [{"role": "user", "type": "image", "content": "data"}],
+            vision=True,
+            interpreter=interpreter,
+        )

--- a/tests/core/llm/utils/test_convert_to_openai_messages_images.py
+++ b/tests/core/llm/utils/test_convert_to_openai_messages_images.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import pytest
+
+from interpreter.core.llm.utils.convert_to_openai_messages import (
+    convert_to_openai_messages,
+)
+
+
+@pytest.fixture
+def interpreter():
+    return SimpleNamespace(
+        user_message_template="{content}",
+        always_apply_user_message_template=False,
+        code_output_template="Output:\n{content}",
+        empty_code_output_template="(no output)",
+        code_output_sender="assistant",
+        debug=False,
+    )
+
+
+def test_image_base64_with_vision(interpreter):
+    """Base64 PNG images are converted to OpenAI image_url parts when vision is enabled."""
+    import base64
+
+    png = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode()
+    messages = [
+        {
+            "role": "user",
+            "type": "image",
+            "format": "base64.png",
+            "content": png,
+        }
+    ]
+    result = convert_to_openai_messages(
+        messages, vision=True, shrink_images=False, interpreter=interpreter
+    )
+    assert result[0]["content"][0]["type"] == "image_url"
+    assert "data:image/png;base64," in result[0]["content"][0]["image_url"]["url"]

--- a/tests/core/llm/utils/test_merge_deltas.py
+++ b/tests/core/llm/utils/test_merge_deltas.py
@@ -1,0 +1,41 @@
+from interpreter.core.llm.utils.merge_deltas import merge_deltas
+
+
+def test_merge_string_deltas_concatenates():
+    """String values for the same key are concatenated in place on the original delta dict."""
+    original = {"content": "hello"}
+    delta = {"content": " world"}
+    result = merge_deltas(original, delta)
+    assert result is original
+    assert original["content"] == "hello world"
+
+
+def test_merge_adds_new_string_key():
+    """A string key present only in the incoming delta is copied onto the original."""
+    original = {}
+    delta = {"content": "new"}
+    merge_deltas(original, delta)
+    assert original["content"] == "new"
+
+
+def test_merge_skips_none_values():
+    """None values in the delta are ignored so existing string content is not overwritten."""
+    original = {"content": "keep"}
+    merge_deltas(original, {"content": None, "role": "assistant"})
+    assert original == {"content": "keep", "role": "assistant"}
+
+
+def test_merge_nested_dicts():
+    """Nested dict values (e.g. function_call.arguments) are merged recursively across deltas."""
+    original = {"function_call": {"arguments": "{"}}
+    delta = {"function_call": {"arguments": '"code": "x"}'}}
+    merge_deltas(original, delta)
+    assert original["function_call"]["arguments"] == '{"code": "x"}'
+
+
+def test_merge_empty_original():
+    """Merging into an empty original dict populates it with all keys from the delta."""
+    original = {}
+    delta = {"role": "assistant", "content": "hi"}
+    merge_deltas(original, delta)
+    assert original == {"role": "assistant", "content": "hi"}

--- a/tests/core/llm/utils/test_parse_partial_json.py
+++ b/tests/core/llm/utils/test_parse_partial_json.py
@@ -1,0 +1,48 @@
+from interpreter.core.llm.utils.parse_partial_json import parse_partial_json
+
+
+def test_parse_complete_json():
+    """Valid complete JSON objects parse to the expected dict."""
+    assert parse_partial_json('{"language": "python", "code": "print(1)"}') == {
+        "language": "python",
+        "code": "print(1)",
+    }
+
+
+def test_parse_empty_string_returns_none():
+    """An empty input string cannot be parsed and returns None."""
+    assert parse_partial_json("") is None
+
+
+def test_parse_truncated_object_closes_brace():
+    """A truncated object missing its closing brace is repaired and parsed successfully."""
+    result = parse_partial_json('{"language": "python", "code": "print(1)')
+    assert result == {"language": "python", "code": "print(1)"}
+
+
+def test_parse_truncated_string_closes_quote():
+    """A truncated string value missing its closing quote is repaired and parsed successfully."""
+    result = parse_partial_json('{"language": "python", "code": "hello')
+    assert result == {"language": "python", "code": "hello"}
+
+
+def test_parse_unclosed_string_with_newline():
+    """Newlines inside an unclosed string value are preserved when the string is auto-closed."""
+    result = parse_partial_json('{"code": "line1\nline2')
+    assert result == {"code": "line1\nline2"}
+
+
+def test_parse_mismatched_brace_returns_none():
+    """Extra closing braces that cannot be repaired cause parse_partial_json to return None."""
+    assert parse_partial_json('{"a": 1}}') is None
+
+
+def test_parse_unrecoverable_garbage_returns_none():
+    """Input that is not JSON-like at all returns None instead of raising."""
+    assert parse_partial_json("not json at all {{{") is None
+
+
+def test_parse_truncated_array():
+    """A truncated array missing its closing bracket is repaired and parsed successfully."""
+    result = parse_partial_json("[1, 2, 3")
+    assert result == [1, 2, 3]

--- a/tests/core/test_async_core_extended.py
+++ b/tests/core/test_async_core_extended.py
@@ -1,0 +1,45 @@
+import os
+from unittest import mock
+
+import pytest
+
+from interpreter.core.async_core import AsyncInterpreter, authenticate_function
+
+
+def test_authenticate_function_no_env_key_allows_all():
+    """When INTERPRETER_API_KEY is unset, the async server accepts any client key."""
+    with mock.patch.dict(os.environ, {}, clear=True):
+        os.environ.pop("INTERPRETER_API_KEY", None)
+        assert authenticate_function("anything") is True
+
+
+def test_authenticate_function_requires_matching_key():
+    """When INTERPRETER_API_KEY is set, only that exact key is accepted."""
+    with mock.patch.dict(os.environ, {"INTERPRETER_API_KEY": "secret"}):
+        assert authenticate_function("secret") is True
+        assert authenticate_function("wrong") is False
+
+
+def test_accumulate_creates_message_on_start():
+    """Streaming chunks must begin with start=True before content is stored."""
+    async_i = AsyncInterpreter()
+    async_i.messages = []
+    async_i.accumulate({"role": "user", "type": "message", "start": True})
+    async_i.accumulate({"role": "user", "type": "message", "content": "hello"})
+    assert async_i.messages[-1]["content"] == "hello"
+
+
+def test_accumulate_appends_same_type_content():
+    """Consecutive chunks of the same type/format append to one message."""
+    async_i = AsyncInterpreter()
+    async_i.messages = [{"role": "user", "type": "message", "content": "hi"}]
+    async_i.accumulate({"role": "user", "type": "message", "content": " there"})
+    assert async_i.messages[-1]["content"] == "hi there"
+
+
+def test_accumulate_requires_start_before_content():
+    """accumulate() rejects content chunks that arrive before a start=True chunk for that message."""
+    async_i = AsyncInterpreter()
+    async_i.messages = []
+    with pytest.raises(Exception, match="start"):
+        async_i.accumulate({"role": "user", "type": "message", "content": "oops"})

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+from interpreter import OpenInterpreter
+
+
+def test_reset_clears_messages():
+    """reset() terminates the computer session and clears the conversation history."""
+    interpreter = OpenInterpreter()
+    interpreter.messages = [{"role": "user", "content": "hi"}]
+    with mock.patch.object(interpreter.computer, "terminate") as terminate:
+        interpreter.reset()
+        terminate.assert_called_once()
+    assert interpreter.messages == []
+
+
+def test_anonymous_telemetry_property():
+    """anonymous_telemetry is True only when telemetry is enabled and the interpreter is online."""
+    interpreter = OpenInterpreter()
+    interpreter.disable_telemetry = False
+    interpreter.offline = False
+    assert interpreter.anonymous_telemetry is True
+    interpreter.offline = True
+    assert interpreter.anonymous_telemetry is False
+
+
+def test_streaming_chat_string_message_appended():
+    """_streaming_chat with a string appends a user message before invoking _respond_and_store."""
+    interpreter = OpenInterpreter()
+    with mock.patch.object(interpreter, "_respond_and_store", return_value=iter([])):
+        list(interpreter._streaming_chat(message="Hello", display=False))
+    assert interpreter.messages == [
+        {"role": "user", "type": "message", "content": "Hello"}
+    ]
+
+
+def test_streaming_chat_list_replaces_messages():
+    """_streaming_chat with a message list replaces the entire conversation before responding."""
+    interpreter = OpenInterpreter()
+    new_messages = [{"role": "user", "type": "message", "content": "replaced"}]
+    with mock.patch.object(interpreter, "_respond_and_store", return_value=iter([])):
+        list(interpreter._streaming_chat(message=new_messages, display=False))
+    assert interpreter.messages == new_messages

--- a/tests/core/test_render_message.py
+++ b/tests/core/test_render_message.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.render_message import render_message
+
+
+def test_message_without_templates_returned_unchanged():
+    """Messages with no {{...}} template blocks are returned verbatim without running code."""
+    interpreter = SimpleNamespace(
+        computer=SimpleNamespace(save_skills=True, run=mock.Mock()),
+        verbose=False,
+        debug=False,
+    )
+    assert render_message(interpreter, "Plain system message") == "Plain system message"
+
+
+def test_template_replaced_with_code_output():
+    """{{...}} template blocks are executed and replaced with the console output from computer.run."""
+    def fake_run(language, code, display=False):
+        yield {"format": "output", "content": "hi"}
+
+    interpreter = SimpleNamespace(
+        computer=SimpleNamespace(save_skills=True, run=fake_run),
+        verbose=False,
+        debug=False,
+    )
+    result = render_message(interpreter, 'Prefix {{print("hi")}} suffix')
+    assert result == "Prefix hi suffix"
+
+
+def test_save_skills_disabled_during_template_execution():
+    """Template blocks run with save_skills=False so skill side effects are skipped."""
+    save_skills_during_run = []
+
+    def fake_run(language, code, display=False):
+        save_skills_during_run.append(computer.save_skills)
+        yield {"format": "output", "content": "42"}
+
+    computer = SimpleNamespace(save_skills=True, run=fake_run)
+    interpreter = SimpleNamespace(computer=computer, verbose=False, debug=False)
+    result = render_message(interpreter, "Answer: {{1+1}}")
+    assert result == "Answer: 42"
+    assert save_skills_during_run == [False]
+    assert computer.save_skills is True
+
+
+def test_save_skills_restored_after_render_without_templates():
+    """Rendering a message without templates leaves computer.save_skills unchanged."""
+    computer = SimpleNamespace(save_skills=True, run=lambda *a, **k: iter([]))
+    interpreter = SimpleNamespace(computer=computer, verbose=False, debug=False)
+    render_message(interpreter, "no templates")
+    assert computer.save_skills is True

--- a/tests/core/test_respond.py
+++ b/tests/core/test_respond.py
@@ -1,0 +1,114 @@
+import itertools
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from interpreter.core.respond import respond
+
+
+class FakeLanguage:
+    name = "Python"
+    file_extension = "py"
+
+
+def _code_interpreter(*, language="python", code="1+1"):
+    terminal = SimpleNamespace(
+        languages=[FakeLanguage()],
+        get_language=lambda lang: FakeLanguage() if lang == "python" else None,
+    )
+
+    def run(lang, code_to_run, **run_kwargs):
+        yield {"type": "console", "format": "output", "content": "42"}
+
+    computer = SimpleNamespace(
+        terminal=terminal,
+        import_computer_api=False,
+        system_message="",
+        run=run,
+        verbose=False,
+        debug=False,
+        emit_images=False,
+        max_output=2800,
+        save_skills=True,
+        to_dict=lambda: {},
+    )
+
+    return SimpleNamespace(
+        system_message="You are helpful.",
+        custom_instructions="",
+        messages=[
+            {"role": "assistant", "type": "code", "format": language, "content": code}
+        ],
+        computer=computer,
+        llm=SimpleNamespace(run=lambda msgs: iter([]), supports_vision=False),
+        verbose=False,
+        debug=False,
+        auto_run=True,
+        loop=False,
+        loop_message="continue",
+        loop_breakers=[],
+        sync_computer=False,
+        offline=True,
+        os=False,
+        display_message=mock.Mock(),
+        max_budget=0,
+    )
+
+
+def test_unsupported_language_yields_console_output():
+    """Unknown language names produce a console error instead of executing code."""
+    interpreter = _code_interpreter(language="brainfuck", code="++")
+    chunks = list(itertools.islice(respond(interpreter), 3))
+    outputs = [c for c in chunks if c.get("format") == "output"]
+    assert outputs
+    assert "disabled or not supported" in outputs[0]["content"]
+
+
+def test_text_language_converted_to_assistant_message():
+    """Code blocks with language 'text' are stored as plain assistant messages, not executed."""
+    interpreter = _code_interpreter(language="text", code="notes here")
+    list(itertools.islice(respond(interpreter), 1))
+    assert interpreter.messages[-1]["type"] == "message"
+    assert "notes here" in interpreter.messages[-1]["content"]
+
+
+def test_functions_execute_hallucination_parsed():
+    """LLM hallucinations like functions.execute({...}) are parsed into real executable code."""
+    code = 'functions.execute({"language": "python", "code": "7*6"})'
+    interpreter = _code_interpreter(code=code)
+    gen = respond(interpreter)
+    list(itertools.islice(gen, 3))
+    assert interpreter.messages[0]["content"] == "7*6"
+    assert interpreter.messages[0]["format"] == "python"
+
+
+def test_executeexecute_suffix_stripped():
+    """A trailing 'executeexecute' artifact from model output is removed before code runs."""
+    interpreter = _code_interpreter(code="print(1)executeexecute")
+    list(itertools.islice(respond(interpreter), 3))
+    assert interpreter.messages[0]["content"] == "print(1)"
+
+
+def test_json_code_block_parsed():
+    """JSON-shaped code content is parsed to extract language and code fields for execution."""
+    interpreter = _code_interpreter(code='{"language": "python", "code": "8*8"}')
+    list(itertools.islice(respond(interpreter), 3))
+    assert interpreter.messages[0]["content"] == "8*8"
+
+
+def test_llm_run_when_last_message_not_code():
+    """When the last message is not code, respond delegates to llm.run instead of executing."""
+    interpreter = _code_interpreter()
+    interpreter.messages = [{"role": "user", "type": "message", "content": "hi"}]
+    interpreter.llm.run = lambda msgs: iter([{"type": "message", "content": "hello"}])
+    chunks = list(respond(interpreter))
+    assert {"role": "assistant", "type": "message", "content": "hello"} in chunks
+
+
+def test_respond_requires_messages():
+    """respond() raises AssertionError when called with an empty message list."""
+    interpreter = _code_interpreter()
+    interpreter.messages = []
+    with pytest.raises(AssertionError, match="User message was not passed"):
+        next(respond(interpreter))

--- a/tests/core/test_respond_and_store.py
+++ b/tests/core/test_respond_and_store.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+from interpreter import OpenInterpreter
+
+
+def test_respond_and_store_merges_consecutive_chunks():
+    """Consecutive assistant message chunks of the same type are merged into one stored message."""
+    interpreter = OpenInterpreter()
+    interpreter.messages = []
+
+    def fake_respond(_interpreter):
+        yield {"role": "assistant", "type": "message", "content": "Hello "}
+        yield {"role": "assistant", "type": "message", "content": "world"}
+
+    with mock.patch("interpreter.core.core.respond", fake_respond):
+        chunks = list(interpreter._respond_and_store())
+
+    assert interpreter.messages[-1]["content"] == "Hello world"
+    assert chunks[0].get("start") is True
+    assert chunks[0]["role"] == "assistant"
+
+
+def test_respond_and_store_skips_ephemeral_review_chunks():
+    """Review-type chunks are yielded but not persisted to the conversation history."""
+    interpreter = OpenInterpreter()
+    interpreter.messages = []
+
+    def fake_respond(_interpreter):
+        yield {"role": "assistant", "type": "review", "format": "safe", "content": "ok"}
+        yield {"role": "assistant", "type": "message", "content": "done"}
+
+    with mock.patch("interpreter.core.core.respond", fake_respond):
+        list(interpreter._respond_and_store())
+
+    assert len(interpreter.messages) == 1
+
+
+def test_respond_and_store_truncates_console_output():
+    """Console output stored via _respond_and_store is truncated to interpreter.max_output."""
+    interpreter = OpenInterpreter()
+    interpreter.max_output = 100
+    interpreter.messages = []
+
+    def fake_respond(_interpreter):
+        yield {
+            "role": "computer",
+            "type": "console",
+            "format": "output",
+            "content": "x" * 500,
+        }
+
+    with mock.patch("interpreter.core.core.respond", fake_respond):
+        list(interpreter._respond_and_store())
+
+    assert "Output truncated" in interpreter.messages[-1]["content"]

--- a/tests/core/utils/test_lazy_import_and_temporary_file.py
+++ b/tests/core/utils/test_lazy_import_and_temporary_file.py
@@ -1,0 +1,58 @@
+import os
+from unittest import mock
+
+import pytest
+
+from interpreter.core.utils.lazy_import import lazy_import
+from interpreter.core.utils.temporary_file import (
+    cleanup_temporary_file,
+    create_temporary_file,
+)
+
+
+def test_create_temporary_file_writes_contents(tmp_path, monkeypatch):
+    """create_temporary_file writes the given contents and cleanup_temporary_file removes the file."""
+    monkeypatch.chdir(tmp_path)
+    path = create_temporary_file("hello", extension="txt")
+    assert os.path.exists(path)
+    with open(path) as f:
+        assert f.read() == "hello"
+    cleanup_temporary_file(path)
+    assert not os.path.exists(path)
+
+
+def test_create_temporary_file_verbose(capsys, tmp_path, monkeypatch):
+    """verbose=True prints creation and cleanup messages for temporary files."""
+    monkeypatch.chdir(tmp_path)
+    path = create_temporary_file("data", verbose=True)
+    captured = capsys.readouterr()
+    assert "Created temporary file" in captured.out
+    cleanup_temporary_file(path, verbose=True)
+    captured = capsys.readouterr()
+    assert "Cleaning up temporary file" in captured.out
+
+
+def test_cleanup_missing_file_does_not_raise(capsys):
+    """cleanup_temporary_file on a missing path logs a warning instead of raising."""
+    cleanup_temporary_file("/nonexistent/path/file.txt")
+    captured = capsys.readouterr()
+    assert "Could not clean up temporary file" in captured.out
+
+
+def test_lazy_import_returns_existing_module():
+    """lazy_import returns the already-imported module object for a valid module name."""
+    import json as json_module
+
+    assert lazy_import("json") is json_module
+
+
+def test_lazy_import_optional_missing_returns_none():
+    """lazy_import with optional=True returns None when the module cannot be imported."""
+    assert lazy_import("this_module_definitely_does_not_exist_xyz", optional=True) is None
+
+
+def test_lazy_import_required_missing_raises():
+    """lazy_import with optional=False raises ImportError when the module cannot be found."""
+    with pytest.raises(ImportError, match="cannot be found"):
+        lazy_import("this_module_definitely_does_not_exist_xyz",
+                    optional=False)

--- a/tests/core/utils/test_scan_code.py
+++ b/tests/core/utils/test_scan_code.py
@@ -1,0 +1,47 @@
+"""Tests for semgrep-based scan_code without requiring semgrep on PATH."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.utils import scan_code
+
+
+def test_scan_code_runs_and_cleans_up(tmp_path):
+    """scan_code writes code to a temp file, runs semgrep, and always cleans up afterward."""
+    interpreter = SimpleNamespace(
+        verbose=False,
+        safe_mode="auto",
+        computer=SimpleNamespace(
+            terminal=SimpleNamespace(
+                get_language=lambda lang: SimpleNamespace(
+                    file_extension="py", name="Python"
+                )
+            )
+        ),
+    )
+    temp_path = str(tmp_path / "scan.py")
+
+    with mock.patch(
+        "interpreter.core.utils.scan_code.create_temporary_file",
+        return_value=temp_path,
+    ) as create_temp:
+        with mock.patch(
+            "interpreter.core.utils.scan_code.cleanup_temporary_file"
+        ) as cleanup:
+            with mock.patch(
+                "interpreter.core.utils.scan_code.subprocess.run",
+                return_value=mock.Mock(returncode=0),
+            ) as run:
+                mock_spinner = mock.Mock()
+                mock_spinner.__enter__ = mock.Mock(return_value=mock_spinner)
+                mock_spinner.__exit__ = mock.Mock(return_value=False)
+                with mock.patch.object(scan_code, "yaspin", create=True) as yaspin:
+                    yaspin.return_value.green.right.binary = mock_spinner
+                    scan_code.scan_code("print(1)", "python", interpreter)
+
+    create_temp.assert_called_once_with("print(1)", "py", verbose=False)
+    run.assert_called_once()
+    cmd = run.call_args[0][0]
+    assert "semgrep" in cmd
+    assert "scan.py" in cmd
+    cleanup.assert_called_once_with(temp_path, verbose=False)

--- a/tests/core/utils/test_system_debug_info.py
+++ b/tests/core/utils/test_system_debug_info.py
@@ -1,0 +1,72 @@
+import platform
+import re
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.core.utils import system_debug_info
+from tests.helpers import TEST_LLM_MODEL
+
+
+def test_get_python_version_matches_current_interpreter():
+    """get_python_version reports the same version string as the running interpreter."""
+    version = system_debug_info.get_python_version()
+    assert version == platform.python_version()
+
+
+def test_get_os_version_includes_platform_name():
+    """get_os_version includes the platform.system() name (e.g. Linux, Darwin)."""
+    os_version = system_debug_info.get_os_version()
+    assert platform.system() in os_version
+
+
+def test_get_ram_info_format():
+    """get_ram_info returns a human-readable string with GB totals and used/free breakdown."""
+    ram = system_debug_info.get_ram_info()
+    assert "GB" in ram
+    assert "used:" in ram
+    assert "free:" in ram
+
+
+def test_get_pip_version_parses_successful_output():
+    """get_pip_version extracts the version number from a successful pip --version subprocess call."""
+    with mock.patch(
+        "interpreter.core.utils.system_debug_info.subprocess.check_output",
+        return_value=b"pip 24.0 from /usr/local/lib/python3.12/site-packages",
+    ):
+        assert system_debug_info.get_pip_version() == "24.0"
+
+
+def test_get_pip_version_stringifies_errors():
+    """On failure, get_pip_version returns str(exception) instead of raising."""
+    with mock.patch(
+        "interpreter.core.utils.system_debug_info.subprocess.check_output",
+        side_effect=FileNotFoundError("pip not found"),
+    ):
+        assert system_debug_info.get_pip_version() == "pip not found"
+
+
+def test_system_info_runs_without_error(capsys):
+    """system_info prints a debug summary including Python version and model without raising."""
+    interpreter = SimpleNamespace(
+        offline=False,
+        llm=SimpleNamespace(
+            api_base=None,
+            supports_vision=False,
+            model=TEST_LLM_MODEL,
+            supports_functions=True,
+            context_window=8000,
+            max_tokens=1000,
+        ),
+        messages=[],
+        system_message="test",
+        auto_run=True,
+        computer=SimpleNamespace(import_computer_api=False),
+    )
+    with mock.patch(
+        "interpreter.core.utils.system_debug_info.get_package_mismatches",
+        return_value="",
+    ):
+        system_debug_info.system_info(interpreter)
+    captured = capsys.readouterr().out
+    assert "Python Version" in captured
+    assert TEST_LLM_MODEL in captured

--- a/tests/core/utils/test_telemetry.py
+++ b/tests/core/utils/test_telemetry.py
@@ -1,0 +1,38 @@
+import json
+from unittest import mock
+
+from interpreter.core.utils import telemetry
+from tests.helpers import patch_expanduser
+
+
+def test_get_or_create_uuid_reads_existing(tmp_path, monkeypatch):
+    """get_or_create_uuid returns the ID from disk when the cache file already exists."""
+    patch_expanduser(monkeypatch, telemetry, tmp_path)
+    cache_dir = tmp_path / ".cache" / "open-interpreter"
+    cache_dir.mkdir(parents=True)
+    uuid_file = cache_dir / "telemetry_user_id"
+    uuid_file.write_text("existing-id")
+
+    assert telemetry.get_or_create_uuid() == "existing-id"
+
+
+def test_get_or_create_uuid_creates_new(tmp_path, monkeypatch):
+    """get_or_create_uuid generates a new UUID4 and persists it when no cache file exists."""
+    patch_expanduser(monkeypatch, telemetry, tmp_path)
+    new_id = telemetry.get_or_create_uuid()
+    uuid_file = tmp_path / ".cache" / "open-interpreter" / "telemetry_user_id"
+    assert uuid_file.read_text() == new_id
+    # Must be a valid UUID4 (8-4-4-4-12 hex digits separated by dashes)
+    import re
+    assert re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", new_id)
+
+
+def test_send_telemetry_posts_event():
+    """send_telemetry POSTs a JSON payload with the event name, properties, and oi_version."""
+    with mock.patch("interpreter.core.utils.telemetry.requests.post") as post:
+        telemetry.send_telemetry("test_event", {"foo": "bar"})
+    post.assert_called_once()
+    payload = json.loads(post.call_args.kwargs["data"])
+    assert payload["event"] == "test_event"
+    assert payload["properties"]["foo"] == "bar"
+    assert "oi_version" in payload["properties"]

--- a/tests/core/utils/test_truncate_output.py
+++ b/tests/core/utils/test_truncate_output.py
@@ -1,0 +1,45 @@
+from interpreter.core.utils.truncate_output import truncate_output
+
+
+def test_short_output_unchanged():
+    """Output within the character limit is returned verbatim."""
+    data = "hello world"
+    assert truncate_output(data, max_output_chars=2800) == data
+
+
+def test_long_output_truncated_with_marker():
+    """Long output is replaced with head + [...] + tail and a banner."""
+    data = "a" * 5000
+    result = truncate_output(data, max_output_chars=2800)
+    assert result.startswith("Output truncated (5,000 characters total)")
+    assert "[...]" in result
+    assert result.count("a") < len(data)
+
+
+def test_retruncate_keeps_truncated_shape():
+    """A second truncate pass on shortened output should still look truncated.
+
+    truncate_output only strips a prior banner when it matches the newly built
+    banner text (which embeds len(data)). After the first pass the character
+    count changes, so a second banner may appear — we assert the result still
+    has the middle ellipsis and is much shorter than the original input.
+    """
+    data = "x" * 5000
+    first = truncate_output(data, max_output_chars=100)
+    second = truncate_output(first, max_output_chars=100)
+    assert "[...]" in second
+    assert len(second) < len(data)
+    assert "Output truncated" in second
+
+
+def test_add_scrollbars_appends_hint():
+    """add_scrollbars=True appends a get_last_output() hint to the truncation banner."""
+    data = "b" * 5000
+    result = truncate_output(data, max_output_chars=100, add_scrollbars=True)
+    assert "get_last_output()" in result
+
+
+def test_exactly_at_limit_not_truncated():
+    """Output at exactly the character limit is not truncated."""
+    data = "c" * 2800
+    assert truncate_output(data, max_output_chars=2800) == data

--- a/tests/terminal_interface/components/test_components.py
+++ b/tests/terminal_interface/components/test_components.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+from interpreter.terminal_interface.components.code_block import CodeBlock
+from interpreter.terminal_interface.components.message_block import (
+    MessageBlock,
+    textify_markdown_code_blocks,
+)
+
+
+def test_textify_markdown_code_blocks_rewrites_fence_language():
+    """Code fences are rewritten to use the text language tag for display."""
+    text = "Intro\n```python\nprint(1)\n```\nDone"
+    result = textify_markdown_code_blocks(text)
+    assert "```text" in result
+    assert "```python" not in result
+
+
+def test_textify_leaves_non_code_unchanged():
+    """Plain text without code fences passes through unchanged."""
+    text = "No code here"
+    assert textify_markdown_code_blocks(text) == text
+
+
+def test_message_block_refresh_updates_live():
+    """MessageBlock.refresh updates and refreshes the Rich live display."""
+    block = MessageBlock()
+    block.message = "Hello **world**"
+    with mock.patch.object(block, "live") as live:
+        block.refresh(cursor=False)
+        live.update.assert_called_once()
+        live.refresh.assert_called_once()
+
+
+def test_code_block_end_clears_active_line():
+    """CodeBlock.end clears active_line and stops the live display."""
+    block = CodeBlock()
+    block.active_line = 3
+    block.code = "x = 1"
+    with mock.patch.object(block, "refresh"):
+        with mock.patch.object(block.live, "stop"):
+            block.end()
+    assert block.active_line is None

--- a/tests/terminal_interface/test_contributing_conversations.py
+++ b/tests/terminal_interface/test_contributing_conversations.py
@@ -1,0 +1,73 @@
+import json
+from unittest import mock
+
+from interpreter.terminal_interface import contributing_conversations as cc
+
+
+def test_is_list_of_lists():
+    """is_list_of_lists is True only for lists whose elements are all lists."""
+    assert cc.is_list_of_lists([[1], [2]])
+    assert not cc.is_list_of_lists([1, 2])
+    # vacuous truth: all([]) is True in Python
+    assert cc.is_list_of_lists([])
+
+
+def test_get_contribute_cache_contents_creates_default(tmp_path, monkeypatch):
+    """get_contribute_cache_contents creates a default cache file when none exists."""
+    cache_path = tmp_path / "contribute.json"
+    monkeypatch.setattr(cc, "contribute_cache_path", str(cache_path))
+    result = cc.get_contribute_cache_contents()
+    assert result["displayed_contribution_message"] is False
+    assert cache_path.exists()
+
+
+def test_write_to_contribution_cache_round_trip(tmp_path, monkeypatch):
+    """write_to_contribution_cache persists payload that get_contribute_cache_contents can read."""
+    cache_path = tmp_path / "contribute.json"
+    monkeypatch.setattr(cc, "contribute_cache_path", str(cache_path))
+    payload = {
+        "displayed_contribution_message": True,
+        "asked_to_contribute_past": True,
+        "asked_to_contribute_future": False,
+    }
+    cc.write_to_contribution_cache(payload)
+    with open(cache_path) as f:
+        assert json.load(f) == payload
+
+
+def test_get_all_conversations_reads_json_files(tmp_path):
+    """get_all_conversations loads conversation lists from .json files only."""
+    history = tmp_path / "history"
+    history.mkdir()
+    (history / "a.json").write_text(json.dumps([["msg"]]))
+    (history / "b.txt").write_text("skip me")
+
+    interpreter = mock.Mock()
+    interpreter.conversation_history_path = str(history)
+
+    conversations = cc.get_all_conversations(interpreter)
+    assert len(conversations) == 1
+    assert conversations[0] == [["msg"]]
+
+
+def test_contribute_conversations_posts_payload():
+    """contribute_conversations POSTs conversations, feedback, and id to the server."""
+    conversations = [[{"role": "user", "content": "hi"}]]
+    with mock.patch(
+        "interpreter.terminal_interface.contributing_conversations.requests.post"
+    ) as post:
+        cc.contribute_conversations(conversations, feedback="good", conversation_id="abc")
+    post.assert_called_once()
+    payload = post.call_args.kwargs["json"]
+    assert payload["conversation_id"] == "abc"
+    assert payload["feedback"] == "good"
+    assert payload["conversations"] == conversations
+
+
+def test_contribute_conversations_skips_empty():
+    """contribute_conversations does nothing when given an empty conversation list."""
+    with mock.patch(
+        "interpreter.terminal_interface.contributing_conversations.requests.post"
+    ) as post:
+        assert cc.contribute_conversations([]) is None
+        post.assert_not_called()

--- a/tests/terminal_interface/test_conversation_navigator.py
+++ b/tests/terminal_interface/test_conversation_navigator.py
@@ -1,0 +1,81 @@
+import json
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.terminal_interface.conversation_navigator import (
+    conversation_navigator,
+    open_folder,
+)
+
+
+def test_conversation_navigator_missing_dir(tmp_path, capsys):
+    """conversation_navigator prints a notice when the conversations directory is missing."""
+    interpreter = SimpleNamespace(
+        display_message=mock.Mock(),
+        messages=[],
+        chat=mock.Mock(),
+    )
+    with mock.patch(
+        "interpreter.terminal_interface.conversation_navigator.get_storage_path",
+        return_value=str(tmp_path / "missing"),
+    ):
+        conversation_navigator(interpreter)
+    assert "No conversations found" in capsys.readouterr().out
+
+
+def test_conversation_navigator_loads_selected_conversation(tmp_path):
+    """Selecting a saved conversation loads its messages and resumes chat."""
+    conv_dir = tmp_path / "conversations"
+    conv_dir.mkdir()
+    messages = [{"role": "user", "type": "message", "content": "hi"}]
+    (conv_dir / "test_chat__2024.json").write_text(json.dumps(messages))
+
+    interpreter = SimpleNamespace(
+        display_message=mock.Mock(),
+        messages=[],
+        chat=mock.Mock(),
+        conversation_filename=None,
+    )
+
+    with mock.patch(
+        "interpreter.terminal_interface.conversation_navigator.get_storage_path",
+        return_value=str(conv_dir),
+    ):
+        with mock.patch(
+            "interpreter.terminal_interface.conversation_navigator.inquirer.prompt",
+            return_value={"name": "test chat... (2024)"},
+        ):
+            with mock.patch(
+                "interpreter.terminal_interface.conversation_navigator.render_past_conversation"
+            ):
+                conversation_navigator(interpreter)
+
+    assert interpreter.messages == messages
+    interpreter.chat.assert_called_once()
+
+
+def test_open_folder_linux():
+    """open_folder on Linux invokes xdg-open with the folder path."""
+    with mock.patch("platform.system", return_value="Linux"):
+        with mock.patch("subprocess.run") as run:
+            open_folder("/tmp/test")
+    run.assert_called_once_with(["xdg-open", "/tmp/test"])
+
+
+def test_open_folder_darwin():
+    """open_folder on macOS invokes open with the folder path."""
+    with mock.patch("platform.system", return_value="Darwin"):
+        with mock.patch("subprocess.run") as run:
+            open_folder("/tmp/test")
+    run.assert_called_once_with(["open", "/tmp/test"])
+
+
+def test_open_folder_windows():
+    """open_folder on Windows uses os.startfile to open the folder."""
+    with mock.patch("platform.system", return_value="Windows"):
+        with mock.patch(
+            "interpreter.terminal_interface.conversation_navigator.os.startfile",
+            create=True,
+        ) as startfile:
+            open_folder("C:\\conversations")
+    startfile.assert_called_once_with("C:\\conversations")

--- a/tests/terminal_interface/test_magic_commands.py
+++ b/tests/terminal_interface/test_magic_commands.py
@@ -1,0 +1,294 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from interpreter.terminal_interface import magic_commands
+from tests.helpers import TEST_LLM_MODEL
+
+
+def _interpreter(**kwargs):
+    base = {
+        "messages": [],
+        "system_message": "sys",
+        "verbose": False,
+        "debug": False,
+        "auto_run": True,
+        "llm": SimpleNamespace(model=TEST_LLM_MODEL),
+        "display_message": mock.Mock(),
+        "reset": mock.Mock(),
+    }
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def test_handle_undo_removes_messages_after_last_user():
+    """%undo drops the last user turn and every message after it."""
+    interpreter = _interpreter(
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply1"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "reply2"},
+        ]
+    )
+    magic_commands.handle_undo(interpreter, "")
+    assert interpreter.messages == [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "reply1"},
+    ]
+
+
+def test_handle_undo_noop_on_empty_messages():
+    """%undo leaves an empty message list unchanged."""
+    interpreter = _interpreter(messages=[])
+    magic_commands.handle_undo(interpreter, "")
+    assert interpreter.messages == []
+
+
+def test_handle_reset_calls_reset():
+    """%reset delegates to interpreter.reset()."""
+    interpreter = _interpreter()
+    magic_commands.handle_reset(interpreter, "")
+    interpreter.reset.assert_called_once()
+
+
+def test_handle_verbose_toggles_flag():
+    """%verbose true/false toggles interpreter.verbose."""
+    interpreter = _interpreter(verbose=False)
+    magic_commands.handle_verbose(interpreter, "true")
+    assert interpreter.verbose is True
+    magic_commands.handle_verbose(interpreter, "false")
+    assert interpreter.verbose is False
+
+
+def test_handle_auto_run_toggles_flag():
+    """%auto_run true enables interpreter.auto_run."""
+    interpreter = _interpreter(auto_run=False)
+    magic_commands.handle_auto_run(interpreter, "true")
+    assert interpreter.auto_run is True
+
+
+def test_handle_save_and_load_message_round_trip(tmp_path):
+    """Saved messages can be reloaded from disk with %save_message and %load_message."""
+    interpreter = _interpreter(messages=[{"role": "user", "content": "saved"}])
+    path = tmp_path / "msgs.json"
+    magic_commands.handle_save_message(interpreter, str(path))
+    interpreter.messages = []
+    magic_commands.handle_load_message(interpreter, str(path))
+    assert interpreter.messages == [{"role": "user", "content": "saved"}]
+
+
+def test_get_downloads_path_uses_home_on_posix(monkeypatch, tmp_path):
+    """Non-Windows path uses expanduser('~')/Downloads and creates the folder."""
+    monkeypatch.setattr(magic_commands.os, "name", "posix")
+    monkeypatch.setattr(
+        magic_commands.os.path,
+        "expanduser",
+        lambda path: str(tmp_path) if path == "~" else path,
+    )
+    downloads = magic_commands.get_downloads_path()
+    assert downloads == str(tmp_path / "Downloads")
+    assert (tmp_path / "Downloads").exists()
+
+
+@pytest.mark.windows_ci
+def test_get_downloads_path_windows(monkeypatch, tmp_path):
+    """On Windows, get_downloads_path uses USERPROFILE/Downloads and creates the folder."""
+    monkeypatch.setattr(magic_commands.os, "name", "nt")
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    downloads = magic_commands.get_downloads_path()
+    assert downloads == str(tmp_path / "Downloads")
+
+
+def test_handle_count_tokens_displays_estimate(capsys):
+    """%tokens displays a token estimate for the current conversation."""
+    interpreter = _interpreter(messages=[{"role": "user", "type": "message", "content": "hi"}])
+    with mock.patch(
+        "interpreter.terminal_interface.magic_commands.count_messages_tokens",
+        return_value=(10, 0.001),
+    ):
+        magic_commands.handle_count_tokens(interpreter, "")
+    interpreter.display_message.assert_called()
+    assert "Tokens sent" in interpreter.display_message.call_args[0][0]
+
+
+def test_handle_count_tokens_with_prompt():
+    """%tokens with an argument includes that prompt in the next-request total."""
+    interpreter = _interpreter(messages=[{"role": "user", "type": "message", "content": "hi"}])
+    with mock.patch(
+        "interpreter.terminal_interface.magic_commands.count_messages_tokens",
+        side_effect=[(10, 0.001), (5, 0.0005)],
+    ):
+        magic_commands.handle_count_tokens(interpreter, "extra prompt")
+    text = interpreter.display_message.call_args[0][0]
+    assert "Total tokens for next request" in text
+
+
+def test_handle_help_lists_commands():
+    """%help output lists available magic commands such as %undo and %jupyter."""
+    interpreter = _interpreter()
+    magic_commands.handle_help(interpreter, "")
+    text = interpreter.display_message.call_args[0][0]
+    assert "%undo" in text
+    assert "%jupyter" in text
+
+
+def test_handle_reset_displays_confirmation():
+    """%reset shows a confirmation message after clearing the session."""
+    interpreter = _interpreter()
+    magic_commands.handle_reset(interpreter, "")
+    interpreter.reset.assert_called_once()
+    assert "Reset Done" in interpreter.display_message.call_args[0][0]
+
+
+def test_handle_undo_shows_function_call_preview():
+    """%undo after a function call removes the block and reports the removal."""
+    interpreter = _interpreter(
+        messages=[
+            {"role": "user", "content": "run it"},
+            {"role": "assistant", "function_call": {"name": "execute"}},
+        ]
+    )
+    magic_commands.handle_undo(interpreter, "")
+    assert interpreter.messages == []
+    interpreter.display_message.assert_called_with("**Removed codeblock**")
+
+
+def test_handle_verbose_unknown_argument():
+    """%verbose with an invalid argument shows an unknown-argument error."""
+    interpreter = _interpreter()
+    magic_commands.handle_verbose(interpreter, "maybe")
+    assert "Unknown argument" in interpreter.display_message.call_args[0][0]
+
+
+def test_handle_debug_toggles_flag():
+    """%debug true/false toggles interpreter.debug."""
+    interpreter = _interpreter(debug=False)
+    magic_commands.handle_debug(interpreter, "true")
+    assert interpreter.debug is True
+    magic_commands.handle_debug(interpreter, "false")
+    assert interpreter.debug is False
+
+
+def test_default_handle_shows_help():
+    """Unknown magic commands trigger default_handle, which warns and shows help."""
+    interpreter = _interpreter()
+    magic_commands.default_handle(interpreter, "")
+    calls = [c[0][0] for c in interpreter.display_message.call_args_list]
+    assert any("Unknown command" in c for c in calls)
+    assert any("Available Commands" in c for c in calls)
+
+
+def test_handle_info_delegates_to_system_info():
+    """%info delegates to system_info with the interpreter instance."""
+    interpreter = _interpreter()
+    with mock.patch("interpreter.terminal_interface.magic_commands.system_info") as info:
+        magic_commands.handle_info(interpreter, "")
+    info.assert_called_once_with(interpreter)
+
+
+def test_handle_save_message_adds_json_extension(tmp_path):
+    """%save_message appends .json when the path has no extension."""
+    interpreter = _interpreter(messages=[{"role": "user", "content": "x"}])
+    path = tmp_path / "out"
+    magic_commands.handle_save_message(interpreter, str(path))
+    assert path.with_suffix(".json").exists()
+
+
+def test_handle_magic_command_runs_shell():
+    """%% prefix runs the remainder as a shell command via computer.run."""
+    interpreter = _interpreter()
+    interpreter.computer = SimpleNamespace(run=mock.Mock())
+    magic_commands.handle_magic_command(interpreter, "%% ls -la")
+    interpreter.computer.run.assert_called_once_with(
+        "shell", "ls -la", stream=False, display=True
+    )
+
+
+def test_handle_magic_command_debug_redirects_to_verbose():
+    """%debug is deprecated and redirects to handle_verbose after a short delay."""
+    interpreter = _interpreter(verbose=False)
+    with mock.patch.object(magic_commands.time, "sleep") as sleep:
+        with mock.patch.object(magic_commands, "handle_verbose") as handle_verbose:
+            magic_commands.handle_magic_command(interpreter, "%debug true")
+    sleep.assert_called_once_with(1.5)
+    handle_verbose.assert_called_once_with(interpreter, "true")
+
+
+def test_handle_magic_command_unknown_invokes_default():
+    """Unrecognized % commands fall through to default_handle."""
+    interpreter = _interpreter()
+    with mock.patch.object(magic_commands, "default_handle") as default_handle:
+        magic_commands.handle_magic_command(interpreter, "%nope")
+    default_handle.assert_called_once_with(interpreter, "")
+
+
+def test_markdown_export_empty_messages(capsys):
+    """%markdown with no messages prints a no-messages-to-export notice."""
+    interpreter = _interpreter(messages=[])
+    magic_commands.markdown(interpreter, "")
+    assert "No messages to export" in capsys.readouterr().out
+
+
+def test_markdown_export_delegates(tmp_path):
+    """%markdown with a path delegates to export_to_markdown."""
+    interpreter = _interpreter(
+        messages=[{"role": "user", "content": "hi"}],
+        conversation_filename="chat.json",
+    )
+    export_path = str(tmp_path / "out.md")
+    with mock.patch(
+        "interpreter.terminal_interface.magic_commands.export_to_markdown"
+    ) as export:
+        magic_commands.markdown(interpreter, export_path)
+    export.assert_called_once_with(interpreter.messages, export_path)
+
+
+def test_jupyter_exports_notebook(tmp_path):
+    """%jupyter builds a notebook from messages and writes it to Downloads."""
+    import types
+
+    interpreter = _interpreter(
+        messages=[
+            {"role": "user", "type": "message", "content": "question"},
+            {"role": "assistant", "type": "code", "format": "python", "content": "print(1)"},
+        ]
+    )
+    captured = {}
+
+    v4_module = types.ModuleType("nbformat.v4")
+    v4_module.new_markdown_cell = lambda content: {"cell_type": "markdown", "source": content}
+    v4_module.new_code_cell = lambda content: mock.Mock(metadata={}, source=content)
+    v4_module.new_notebook = lambda: captured.setdefault("nb", {"cells": []})
+
+    nbformat_module = types.ModuleType("nbformat")
+    nbformat_module.write = mock.Mock()
+    nbformat_module.v4 = v4_module
+
+    with mock.patch.object(
+        magic_commands, "install_and_import", return_value=nbformat_module
+    ):
+        with mock.patch.object(
+            magic_commands, "get_downloads_path", return_value=str(tmp_path)
+        ):
+            with mock.patch.dict(
+                "sys.modules",
+                {"nbformat": nbformat_module, "nbformat.v4": v4_module},
+            ):
+                magic_commands.jupyter(interpreter, "")
+
+    cells = captured["nb"]["cells"]
+    assert len(cells) == 2
+    assert cells[0]["source"].startswith("> question")
+    assert cells[1].metadata == {"language": "python"}
+    nbformat_module.write.assert_called_once()
+    interpreter.display_message.assert_called()
+
+
+def test_install_and_import_returns_existing_module():
+    """Already-imported packages are returned without calling pip."""
+    fake = object()
+    with mock.patch.dict("sys.modules", {"already_there": fake}):
+        result = magic_commands.install_and_import("already_there")
+    assert result is fake

--- a/tests/terminal_interface/test_render_past_conversation.py
+++ b/tests/terminal_interface/test_render_past_conversation.py
@@ -1,0 +1,119 @@
+from unittest import mock
+
+from interpreter.terminal_interface.render_past_conversation import (
+    render_past_conversation,
+)
+
+
+def test_render_past_conversation_prints_user_messages(capsys):
+    """User messages are printed with a leading > prefix when replaying history."""
+    messages = [
+        {"role": "user", "type": "message", "content": "Hello"},
+        {"role": "assistant", "type": "message", "content": "Hi"},
+    ]
+    with mock.patch(
+        "interpreter.terminal_interface.render_past_conversation.MessageBlock"
+    ) as mb:
+        mb.return_value = mock.Mock(type="message", message="")
+        render_past_conversation(messages)
+    assert "> Hello" in capsys.readouterr().out
+
+
+def test_render_past_conversation_ends_active_block():
+    """The active message block is ended after the last message is rendered."""
+    fake_block = mock.Mock(type="message", message="")
+    with mock.patch(
+        "interpreter.terminal_interface.render_past_conversation.MessageBlock",
+        return_value=fake_block,
+    ):
+        render_past_conversation(
+            [{"role": "assistant", "type": "message", "content": "done"}]
+        )
+    fake_block.end.assert_called()
+
+
+def test_render_past_conversation_user_message_ends_active_block():
+    """A new user message ends the previous assistant message block before printing."""
+    fake_block = mock.Mock(type="message", message="partial")
+    with mock.patch(
+        "interpreter.terminal_interface.render_past_conversation.MessageBlock",
+        return_value=fake_block,
+    ):
+        render_past_conversation(
+            [
+                {"role": "assistant", "type": "message", "content": "partial"},
+                {"role": "user", "type": "message", "content": "new question"},
+            ]
+        )
+    fake_block.end.assert_called_once()
+
+
+def test_render_past_conversation_code_block_accumulates():
+    """Code messages populate a CodeBlock and refresh it until end is called."""
+    code_block = mock.Mock(type="code", code="", output="", language="", active_line=None)
+    with mock.patch(
+        "interpreter.terminal_interface.render_past_conversation.CodeBlock",
+        return_value=code_block,
+    ):
+        render_past_conversation(
+            [
+                {
+                    "role": "assistant",
+                    "type": "code",
+                    "format": "python",
+                    "content": "x = 1",
+                    "active_line": 1,
+                }
+            ]
+        )
+    assert code_block.language == "python"
+    assert code_block.code == "x = 1"
+    assert code_block.active_line == 1
+    code_block.refresh.assert_called()
+    code_block.end.assert_called()
+
+
+def test_render_past_conversation_console_appends_to_code_output():
+    """Console output messages append to the active code block's output field."""
+    code_block = mock.Mock(type="code", code="x=1", output="", language="python", active_line=None)
+    with mock.patch(
+        "interpreter.terminal_interface.render_past_conversation.CodeBlock",
+        return_value=code_block,
+    ):
+        render_past_conversation(
+            [
+                {"role": "assistant", "type": "code", "format": "python", "content": "x=1"},
+                {
+                    "role": "computer",
+                    "type": "console",
+                    "format": "output",
+                    "content": "1",
+                },
+            ]
+        )
+    assert code_block.output == "1"
+    code_block.end.assert_called()
+
+
+def test_render_past_conversation_switches_message_to_code_block():
+    """Transitioning from message to code ends the message block and starts a code block."""
+    msg_block = mock.Mock(type="message", message="intro")
+    code_block = mock.Mock(type="code", code="", output="", language="", active_line=None)
+
+    with mock.patch(
+        "interpreter.terminal_interface.render_past_conversation.MessageBlock",
+        return_value=msg_block,
+    ):
+        with mock.patch(
+            "interpreter.terminal_interface.render_past_conversation.CodeBlock",
+            return_value=code_block,
+        ):
+            render_past_conversation(
+                [
+                    {"role": "assistant", "type": "message", "content": "intro"},
+                    {"role": "assistant", "type": "code", "format": "python", "content": "1+1"},
+                ]
+            )
+    msg_block.end.assert_called()
+    assert code_block.code == "1+1"
+    code_block.end.assert_called()

--- a/tests/terminal_interface/test_validate_llm_settings.py
+++ b/tests/terminal_interface/test_validate_llm_settings.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from interpreter.terminal_interface.validate_llm_settings import (
+    display_welcome_message_once,
+    validate_llm_settings,
+)
+from tests.helpers import TEST_LLM_MODEL
+
+
+def test_validate_llm_settings_offline_breaks_immediately():
+    """Offline mode skips API key prompts and returns without displaying messages."""
+    interpreter = SimpleNamespace(
+        offline=True,
+        auto_run=False,
+        messages=[],
+        # Model name unused on offline path; only llm.load may be referenced.
+        llm=SimpleNamespace(model=TEST_LLM_MODEL, load=mock.Mock()),
+        display_message=mock.Mock(),
+    )
+    validate_llm_settings(interpreter)
+    interpreter.display_message.assert_not_called()
+
+
+def test_validate_llm_settings_with_env_key_skips_prompt():
+    """When OPENAI_API_KEY is set, validate_llm_settings does not prompt for a key."""
+    # TEST_LLM_MODEL is in validate_llm_settings' OpenAI model list, so missing
+    # keys would normally prompt — unless OPENAI_API_KEY is already set.
+    interpreter = SimpleNamespace(
+        offline=False,
+        auto_run=True,
+        messages=[],
+        llm=SimpleNamespace(
+            model=TEST_LLM_MODEL,
+            api_key=None,
+            api_base=None,
+            load=mock.Mock(),
+        ),
+        display_message=mock.Mock(),
+    )
+    with mock.patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+        validate_llm_settings(interpreter)
+    interpreter.display_message.assert_not_called()
+
+
+def test_display_welcome_message_once_only_first_time():
+    """Welcome message is shown at most once per process."""
+    if hasattr(display_welcome_message_once, "_displayed"):
+        delattr(display_welcome_message_once, "_displayed")
+    interpreter = SimpleNamespace(display_message=mock.Mock())
+    with mock.patch("interpreter.terminal_interface.validate_llm_settings.time.sleep"):
+        display_welcome_message_once(interpreter)
+        display_welcome_message_once(interpreter)
+    assert interpreter.display_message.call_count == 1
+    if hasattr(display_welcome_message_once, "_displayed"):
+        delattr(display_welcome_message_once, "_displayed")

--- a/tests/terminal_interface/utils/test_check_for_package.py
+++ b/tests/terminal_interface/utils/test_check_for_package.py
@@ -1,0 +1,11 @@
+from interpreter.terminal_interface.utils.check_for_package import check_for_package
+
+
+def test_check_for_package_returns_true_for_installed():
+    """check_for_package returns True when the package is importable."""
+    assert check_for_package("json") is True
+
+
+def test_check_for_package_returns_false_for_missing():
+    """check_for_package returns False when the package cannot be imported."""
+    assert check_for_package("definitely_not_a_real_package_xyz") is False

--- a/tests/terminal_interface/utils/test_cli_input.py
+++ b/tests/terminal_interface/utils/test_cli_input.py
@@ -1,0 +1,17 @@
+from unittest import mock
+
+from interpreter.terminal_interface.utils.cli_input import cli_input
+
+
+def test_single_line_input():
+    """cli_input returns a single line when the user does not start a multiline block."""
+    with mock.patch("builtins.input", return_value="hello"):
+        assert cli_input("> ") == "hello"
+
+
+def test_multiline_input():
+    """cli_input collects lines until a closing triple-quote delimiter is entered."""
+    lines = ['start """', "line one", "line two", 'end """']
+    with mock.patch("builtins.input", side_effect=lines):
+        result = cli_input()
+    assert result == 'start """\nline one\nline two\nend """'

--- a/tests/terminal_interface/utils/test_count_tokens.py
+++ b/tests/terminal_interface/utils/test_count_tokens.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+from interpreter.terminal_interface.utils import count_tokens as ct
+
+
+def test_count_tokens_strips_model_prefix():
+    """count_tokens strips provider prefixes (e.g. openai/) before selecting an encoder."""
+    mock_encoder = mock.Mock()
+    mock_encoder.encode.return_value = [1, 2, 3]
+    with mock.patch.object(ct, "tiktoken") as mock_tiktoken:
+        mock_tiktoken.encoding_for_model.return_value = mock_encoder
+        result = ct.count_tokens("hello", model="openai/gpt-4")
+    assert result == 3
+    mock_tiktoken.encoding_for_model.assert_called_with("gpt-4")
+
+
+def test_count_tokens_falls_back_to_gpt4_encoder():
+    """count_tokens falls back to the gpt-4 encoder when the model is unknown."""
+    mock_encoder = mock.Mock()
+    mock_encoder.encode.return_value = [1]
+    with mock.patch.object(ct, "tiktoken") as mock_tiktoken:
+        mock_tiktoken.encoding_for_model.side_effect = [KeyError("unknown"), mock_encoder]
+        result = ct.count_tokens("hello", model="unknown-model")
+    assert result == 1
+
+
+def test_count_tokens_returns_zero_on_failure():
+    """count_tokens returns 0 when tiktoken is unavailable."""
+    with mock.patch.object(ct, "tiktoken", side_effect=ImportError):
+        assert ct.count_tokens("hello") == 0
+
+
+def test_token_cost_rounds_result():
+    """token_cost rounds the computed cost to six decimal places."""
+    with mock.patch.object(ct, "cost_per_token", return_value=(0.1234567, 0)):
+        assert ct.token_cost(tokens=100, model="gpt-4") == 0.123457
+
+
+def test_count_messages_tokens_sums_message_fields():
+    """count_messages_tokens sums tokens across strings and message dict fields."""
+    with mock.patch.object(ct, "count_tokens", side_effect=[2, 3, 4, 5]):
+        with mock.patch.object(ct, "token_cost", return_value=0.01):
+            tokens, cost = ct.count_messages_tokens(
+                messages=[
+                    "plain",
+                    {"message": "msg", "code": "code", "output": "out"},
+                ],
+                model="gpt-4",
+            )
+    assert tokens == 14
+    assert cost == 0.01

--- a/tests/terminal_interface/utils/test_display_output.py
+++ b/tests/terminal_interface/utils/test_display_output.py
@@ -1,0 +1,64 @@
+from unittest import mock
+
+from interpreter.terminal_interface.utils.display_output import (
+    display_output,
+    display_output_cli,
+    open_file,
+)
+
+
+def test_display_output_cli_console(capsys):
+    """Console output is printed directly to stdout."""
+    display_output_cli({"type": "console", "content": "hello"})
+    assert capsys.readouterr().out.strip() == "hello"
+
+
+def test_display_output_cli_html_writes_temp_file():
+    """HTML code output is written to a temp file and opened in the browser."""
+    output = {"type": "code", "format": "html", "content": "<html></html>"}
+    with mock.patch(
+        "interpreter.terminal_interface.utils.display_output.open_file"
+    ) as open_file_mock:
+        display_output_cli(output)
+    open_file_mock.assert_called_once()
+
+
+def test_display_output_jupyter_delegates():
+    """In a Jupyter notebook, display_output skips the CLI path and returns a status string."""
+    with mock.patch(
+        "interpreter.terminal_interface.utils.display_output.in_jupyter_notebook",
+        return_value=True,
+    ):
+        with mock.patch(
+            "interpreter.terminal_interface.utils.display_output.display_output_cli"
+        ) as cli:
+            result = display_output({"type": "console", "content": "x"})
+    cli.assert_not_called()
+    assert result == "Displayed on the user's machine."
+
+
+def test_open_file_linux():
+    """open_file on Linux invokes xdg-open with the file path."""
+    with mock.patch("platform.system", return_value="Linux"):
+        with mock.patch("subprocess.run") as run:
+            open_file("/tmp/x.html")
+    run.assert_called_once_with(["xdg-open", "/tmp/x.html"])
+
+
+def test_open_file_darwin():
+    """open_file on macOS invokes open with the file path."""
+    with mock.patch("platform.system", return_value="Darwin"):
+        with mock.patch("subprocess.run") as run:
+            open_file("/tmp/x.html")
+    run.assert_called_once_with(["open", "/tmp/x.html"])
+
+
+def test_open_file_windows():
+    """open_file on Windows uses os.startfile to open the file."""
+    with mock.patch("platform.system", return_value="Windows"):
+        with mock.patch(
+            "interpreter.terminal_interface.utils.display_output.os.startfile",
+            create=True,
+        ) as startfile:
+            open_file("C:\\x.html")
+    startfile.assert_called_once_with("C:\\x.html")

--- a/tests/terminal_interface/utils/test_export_to_markdown.py
+++ b/tests/terminal_interface/utils/test_export_to_markdown.py
@@ -1,0 +1,29 @@
+from interpreter.terminal_interface.utils.export_to_markdown import (
+    export_to_markdown,
+    messages_to_markdown,
+)
+
+
+def test_user_message_gets_role_header():
+    """User messages are rendered with a ## role header in markdown."""
+    messages = [{"role": "user", "type": "message", "content": "Hello"}]
+    md = messages_to_markdown(messages)
+    assert "## user" in md
+    assert "Hello" in md
+
+
+def test_code_block_rendered():
+    """Assistant code messages are wrapped in a fenced code block with the format language."""
+    messages = [
+        {"role": "assistant", "type": "code", "format": "python", "content": "1+1"}
+    ]
+    md = messages_to_markdown(messages)
+    assert "```python" in md
+
+
+def test_export_to_markdown_writes_file(tmp_path):
+    """export_to_markdown writes the rendered markdown to the given file path."""
+    path = tmp_path / "conversation.md"
+    messages = [{"role": "user", "type": "message", "content": "Test"}]
+    export_to_markdown(messages, str(path))
+    assert path.read_text() == messages_to_markdown(messages)

--- a/tests/terminal_interface/utils/test_find_image_path.py
+++ b/tests/terminal_interface/utils/test_find_image_path.py
@@ -1,0 +1,18 @@
+from interpreter.terminal_interface.utils.find_image_path import find_image_path
+
+
+def test_find_image_path_returns_longest_existing(tmp_path):
+    """When multiple image paths appear in text, the longest existing path wins."""
+    short = tmp_path / "a.png"
+    nested = tmp_path / "nested" / "longer_name.png"
+    nested.parent.mkdir()
+    short.write_bytes(b"x")
+    nested.write_bytes(b"x")
+    text = f"See {short} and {nested}"
+    result = find_image_path(text)
+    assert result == str(nested)
+
+
+def test_find_image_path_none_when_missing():
+    """find_image_path returns None when no referenced image file exists."""
+    assert find_image_path("No images in this text.") is None

--- a/tests/terminal_interface/utils/test_in_jupyter_notebook.py
+++ b/tests/terminal_interface/utils/test_in_jupyter_notebook.py
@@ -1,0 +1,20 @@
+from unittest import mock
+
+from interpreter.terminal_interface.utils.in_jupyter_notebook import in_jupyter_notebook
+
+
+def test_in_jupyter_notebook_false_without_ipython():
+    """in_jupyter_notebook returns False when IPython is not available."""
+    with mock.patch.dict("sys.modules", {"IPython": None}):
+        assert in_jupyter_notebook() is False
+
+
+def test_in_jupyter_notebook_true_with_kernel_app():
+    """in_jupyter_notebook returns True when IPython reports an IPKernelApp config."""
+    fake_ipython = mock.Mock()
+    fake_ipython.return_value.config = {"IPKernelApp": {}}
+    with mock.patch.dict(
+        "sys.modules",
+        {"IPython": mock.Mock(get_ipython=fake_ipython)},
+    ):
+        assert in_jupyter_notebook() is True

--- a/tests/terminal_interface/utils/test_local_storage_path.py
+++ b/tests/terminal_interface/utils/test_local_storage_path.py
@@ -1,0 +1,26 @@
+import os
+from unittest import mock
+
+from interpreter.terminal_interface.utils.local_storage_path import get_storage_path
+
+_CONFIG_DIR = "/home/user/.config/open-interpreter"
+
+
+def test_get_storage_path_default():
+    """get_storage_path with no argument returns the config directory."""
+    with mock.patch(
+        "interpreter.terminal_interface.utils.local_storage_path.config_dir",
+        _CONFIG_DIR,
+    ):
+        assert get_storage_path() == _CONFIG_DIR
+
+
+def test_get_storage_path_subdirectory():
+    """get_storage_path joins the config directory with the requested subdirectory."""
+    with mock.patch(
+        "interpreter.terminal_interface.utils.local_storage_path.config_dir",
+        _CONFIG_DIR,
+    ):
+        path = get_storage_path("profiles")
+    assert path.endswith("profiles")
+    assert path == os.path.join(_CONFIG_DIR, "profiles")

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,37 @@
+import ast
+
+from interpreter.terminal_interface.profiles.profiles import (
+    RemoveInterpreter,
+    apply_profile_to_object,
+)
+
+
+def test_remove_interpreter_strips_import_and_assignment():
+    """Profile AST transform must drop interpreter bootstrap lines, keep user code."""
+    source = (
+        "from interpreter import interpreter\n"
+        "interpreter = OpenInterpreter()\n"
+        "x = 1\n"
+    )
+    tree = ast.parse(source)
+    transformed = RemoveInterpreter().visit(tree)
+    ast.fix_missing_locations(transformed)
+    new_source = ast.unparse(transformed)
+    assert "from interpreter import interpreter" not in new_source
+    assert "OpenInterpreter()" not in new_source
+    assert "x = 1" in new_source
+
+
+def test_apply_profile_to_object_nested():
+    """Nested dict keys in a profile map onto dotted attribute paths."""
+    class Inner:
+        def __init__(self):
+            self.temperature = 0.0
+
+    class Outer:
+        def __init__(self):
+            self.llm = Inner()
+
+    obj = Outer()
+    apply_profile_to_object(obj, {"llm": {"temperature": 0.7}})
+    assert obj.llm.temperature == 0.7


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds ~300 mocked unit tests across computer_use, computer, terminal languages, LLM, core, terminal_interface, and profiles. Rebased onto `main` after #113 merged — duplicate infra/interpreter-hardening commits dropped.

### Commit series (one subsystem each)

1. **test(computer_use): add mocked unit tests for tool modules**
2. **test(computer): add mocked unit tests for computer subsystems**
3. **test(terminal): add mocked unit tests for language handlers**
4. **test(llm): add mocked unit tests for LLM modules**
5. **test(core): add mocked unit tests for respond and utilities**
6. **test(terminal_interface): add mocked unit tests for CLI layer**
7. **test(profiles): add unit tests for profile loading**

### Stacked follow-up

#112 (`cursor/ci-smokes-469a`) adds Linux/Windows/macOS CI smoke tests on top of this branch.

### Notes

- No changes to `conftest.py`, `test_interpreter.py`, CI workflow, or AGENTS.md — those landed via #111/#113 on `main`.
- No `tests/__init__.py` (breaks `from conftest import` in collection).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

