### PR TITLE
ci: add multi-OS matrix and OI_RUN_INTEGRATION integration gating

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -141,6 +141,7 @@ jobs:
       - name: Run integration tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OI_RUN_INTEGRATION: "1"
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[server,dev]"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,8 @@ jobs:
           pip install ruff
           ruff check interpreter tests
 
-  test:
+  test-linux:
+    name: Unit tests (Linux)
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
@@ -49,13 +50,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[server,dev]"
           if [ "${{ matrix.python-version }}" = "3.14" ]; then
-            pytest -m "not integration" \
+            pytest -m "not integration and not windows_ci and not darwin_ci" \
               --cov=interpreter \
               --cov-branch \
               --cov-report=xml \
               --cov-report=term-missing
           else
-            pytest -m "not integration"
+            pytest -m "not integration and not windows_ci and not darwin_ci"
           fi
 
       - name: Upload coverage report
@@ -67,11 +68,11 @@ jobs:
 
   codecov:
     name: Upload to Codecov
-    needs: test
+    needs: test-linux
     if: >-
       github.event_name != 'workflow_dispatch' &&
       !cancelled() &&
-      needs.test.result == 'success'
+      needs.test-linux.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,11 @@ This repo (`endolith/open-interpreter`) is the community-maintained home of OI C
 
 ## Quick commands
 
+- `pytest -m "not integration"` – fast local unit tests (skip LLM calls)
 - `pytest -k "test_name"` – run a single test
 - `ruff check .` – lint
 - `ruff format .` – auto-format
+- `OI_RUN_INTEGRATION=1 pytest -m integration` – integration tests (also needs `OPENAI_API_KEY`; use sparingly locally)
 
 ## Development setup
 
@@ -23,6 +25,7 @@ The build backend is Poetry, but CI installs via pip. The package manager may ch
 - **Always write or update unit tests** when changing code. New functions/methods need tests; bug fixes need regression tests.
 - **Every test function must have a docstring** explaining what behavior it verifies and why. Someone who breaks the test must be able to understand what they broke and what the intended behavior is.
 - **Autonomous agents must monitor CI** after pushing: keep checking the workflow status until it passes, fixing any failures before considering the work complete.
+- **Integration tests** (`@pytest.mark.integration`) call an LLM and auto-execute generated code. Locally they need both `OI_RUN_INTEGRATION=1` and `OPENAI_API_KEY`; without either, pytest skips them. CI sets both in the integration workflow job (see `docs/CONTRIBUTING.md`).
 
 ### Documentation
 
@@ -51,7 +54,7 @@ When changing code, update **all** relevant documentation:
 
 ### Done checklist
 
-- [ ] Local tests pass
+- [ ] Local tests pass (`pytest -m "not integration"`)
 - [ ] CI is green (monitor until it passes)
 - [ ] New logic has a test with a docstring
 - [ ] All affected docs updated (READMEs, `docs/`, docstrings, AGENTS.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,6 +55,24 @@ Once you've forked the code and created a new branch for your work, you can run 
 3. Install dependencies by running `poetry install`.
 4. Run the program with `poetry run interpreter`. Run tests with `poetry run pytest -s -x`.
 
+### Integration tests locally
+
+**Integration tests** (`pytest -m integration`) call an LLM and auto-run generated code. They are skipped unless **both** conditions are met:
+
+1. `OI_RUN_INTEGRATION=1` — explicit opt-in (skipped by default even when `OPENAI_API_KEY` is set)
+2. `OPENAI_API_KEY` is set — skipped when unset, even with `OI_RUN_INTEGRATION=1`
+
+CI sets both in the integration workflow job.
+
+```bash
+# Linux/macOS
+OI_RUN_INTEGRATION=1 pytest -m integration
+
+# Windows
+set OI_RUN_INTEGRATION=1
+pytest -m integration
+```
+
 **Note**: This project uses [`black`](https://black.readthedocs.io/en/stable/index.html) and [`isort`](https://pypi.org/project/isort/) via a [`pre-commit`](https://pre-commit.com/) hook to ensure consistent code style. If you need to bypass it for some reason, you can `git commit` with the `--no-verify` flag.
 
 ### Installing New Dependencies

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,6 +73,17 @@ set OI_RUN_INTEGRATION=1
 pytest -m integration
 ```
 
+### CI test layout
+
+| Job | Runner | What runs |
+| --- | --- | --- |
+| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite (`pytest -m "not integration and not windows_ci and not darwin_ci"`), Python 3.10–3.14 |
+| **Integration** | `ubuntu-latest` | LLM tests (`pytest -m integration`), same-repo PRs and `main` only; sets `OI_RUN_INTEGRATION=1` and `OPENAI_API_KEY` |
+
+Platform-specific tests use `linux_ci`, `windows_ci`, and `darwin_ci` markers. conftest skips each marker on the wrong host so a local Linux run does not fail on Windows-only tests. Dedicated Windows/macOS workflow jobs ship with the smoke tests that use those markers.
+
+Locally: `pytest -m "not integration"` runs the unit suite. `linux_ci` / `windows_ci` / `darwin_ci` tests are skipped automatically on the wrong OS.
+
 **Note**: This project uses [`black`](https://black.readthedocs.io/en/stable/index.html) and [`isort`](https://pypi.org/project/isort/) via a [`pre-commit`](https://pre-commit.com/) hook to ensure consistent code style. If you need to bypass it for some reason, you can `git commit` with the `--no-verify` flag.
 
 ### Installing New Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,9 @@ pythonpath = ["."]
 markers = [
     "integration: calls an LLM, costs money, and executes generated code without approval; requires OI_RUN_INTEGRATION=1 and OPENAI_API_KEY",
     "timeout(duration): fail if the test runs longer than duration seconds (pytest-timeout)",
+    "linux_ci: runs on Linux CI and locally on Linux hosts",
+    "windows_ci: runs on Windows CI and locally on Windows hosts",
+    "darwin_ci: runs on macOS CI and locally on Darwin hosts",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,13 @@ ignore = [
     "F841",
 ]
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+markers = [
+    "integration: calls an LLM, costs money, and executes generated code without approval; requires OI_RUN_INTEGRATION=1 and OPENAI_API_KEY",
+    "timeout(duration): fail if the test runs longer than duration seconds (pytest-timeout)",
+]
+
 [tool.ruff.lint.per-file-ignores]
 "interpreter/core/computer/display/display.py" = ["F821"]
 "interpreter/core/computer/display/point/point.py" = ["F821"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 import pytest
 
@@ -32,3 +33,18 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "integration" in item.keywords:
                 item.add_marker(skip_integration)
+
+    _PLATFORM_MARKERS = {
+        "linux_ci": "Linux",
+        "windows_ci": "Windows",
+        "darwin_ci": "Darwin",
+    }
+    current = platform.system()
+    for item in items:
+        for marker, required_os in _PLATFORM_MARKERS.items():
+            if marker in item.keywords and current != required_os:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=f"{marker} only runs on {required_os} (this host is {current})"
+                    )
+                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,20 +2,33 @@ import os
 
 import pytest
 
+_INTEGRATION_OPT_IN_SKIP = (
+    "integration tests need OI_RUN_INTEGRATION=1 (LLM auto-runs generated code)"
+)
+_INTEGRATION_API_KEY_SKIP = "OPENAI_API_KEY not set; skipping integration tests"
+
+
+def integration_skip_reason() -> str | None:
+    """Return a pytest skip reason when integration tests should not run, else None."""
+    if os.environ.get("OI_RUN_INTEGRATION") != "1":
+        return _INTEGRATION_OPT_IN_SKIP
+    if not os.environ.get("OPENAI_API_KEY"):
+        return _INTEGRATION_API_KEY_SKIP
+    return None
+
 
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "integration: requires an LLM API key (not run in default CI)"
+        "markers",
+        "integration: calls an LLM and may execute generated code; "
+        "requires OI_RUN_INTEGRATION=1 and OPENAI_API_KEY",
     )
 
 
 def pytest_collection_modifyitems(config, items):
-    if os.environ.get("OPENAI_API_KEY"):
-        return
-
-    skip_integration = pytest.mark.skip(
-        reason="OPENAI_API_KEY not set; skipping integration test"
-    )
-    for item in items:
-        if "integration" in item.keywords:
-            item.add_marker(skip_integration)
+    reason = integration_skip_reason()
+    if reason:
+        skip_integration = pytest.mark.skip(reason=reason)
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_integration)

--- a/tests/test_integration_gating.py
+++ b/tests/test_integration_gating.py
@@ -1,0 +1,30 @@
+import os
+from unittest import mock
+
+from conftest import (
+    _INTEGRATION_API_KEY_SKIP,
+    _INTEGRATION_OPT_IN_SKIP,
+    integration_skip_reason,
+)
+
+
+def test_integration_skip_without_opt_in():
+    """Integration tests skip without OI_RUN_INTEGRATION even when OPENAI_API_KEY is set."""
+    with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
+        assert integration_skip_reason() == _INTEGRATION_OPT_IN_SKIP
+
+
+def test_integration_skip_without_api_key():
+    """Integration tests skip when OPENAI_API_KEY is unset even with OI_RUN_INTEGRATION=1."""
+    with mock.patch.dict(os.environ, {"OI_RUN_INTEGRATION": "1"}, clear=True):
+        assert integration_skip_reason() == _INTEGRATION_API_KEY_SKIP
+
+
+def test_integration_allowed_with_opt_in_and_api_key():
+    """Integration tests run only when both OI_RUN_INTEGRATION=1 and OPENAI_API_KEY are set."""
+    with mock.patch.dict(
+        os.environ,
+        {"OI_RUN_INTEGRATION": "1", "OPENAI_API_KEY": "sk-test"},
+        clear=True,
+    ):
+        assert integration_skip_reason() is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Describe the changes you have made:

CI infrastructure only — no new unit tests beyond gating helpers. Three self-contained commits:

1. **Integration opt-in** — integration tests need both `OI_RUN_INTEGRATION=1` and `OPENAI_API_KEY`; missing either skips (not fails). CI integration job sets both explicitly (no `GITHUB_ACTIONS` detection).
2. **Stacked PR CI** — workflow runs on `pull_request` to any branch (not only `main`), unrelated to OS markers.
3. **OS marker infra** — `linux_ci` / `windows_ci` / `darwin_ci` markers, host skips in conftest, Linux job excludes OS markers. Win/Mac workflow jobs intentionally **not** here (they ship with smoke tests in a follow-up PR).

**Part 1 of 4.** Merge order: #111 → #113 → #110 → #112.

### Reference any relevant issues (e.g. "Fixes #000"):

Part of the test-suite work from PR #85.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

