### PR TITLE
test: add Linux/Windows/macOS CI smoke tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -74,6 +74,37 @@ jobs:
           name: coverage-report
           path: coverage.xml
 
+  test-windows:
+    name: Windows CI smoke
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install and run Windows-only tests
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[server,dev]"
+          pytest -m windows_ci -v
+
+  test-macos:
+    name: macOS CI smoke
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install and run macOS-only tests
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[server,dev]"
+          pytest -m darwin_ci -v
+
   codecov:
     name: Upload to Codecov
     needs: test-linux

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,6 +45,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install language runtimes for e2e smokes
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby r-base default-jdk
+      # Google Chrome is pre-installed on ubuntu-latest (actions/runner-images).
+      # HTML/React smokes find it via require_chrome_for_html() — no .deb download.
+      - name: Verify Chrome for HTML/React smokes
+        run: command -v google-chrome || command -v google-chrome-stable
       - name: Install and test
         run: |
           python -m pip install --upgrade pip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ The build backend is Poetry, but CI installs via pip. The package manager may ch
 - **Shared test helpers** live in `tests/helpers.py` (import `from tests.helpers import …`). Do not import from `conftest.py` — it is not a stable import path on all platforms.
 - **Computer subsystem tests** use `COMPUTER_TOOL_SUBSYSTEMS` in `tests/helpers.py` — update when `_get_all_computer_tools_list` changes (until [#101](https://github.com/endolith/open-interpreter/issues/101) lands).
 - Most of the unit tests were written after the fact by AI, with the assumption that the current state of the code was correct (which is likely not true in all cases).  Keep that in mind when a test fails.  Is your code actually wrong, or was the test written to validate incorrect code?
+- **Platform-specific tests** use `linux_ci`, `windows_ci`, or `darwin_ci` markers. Add OS-only coverage to `tests/test_platform_ci.py` (or the appropriate language file) rather than running the full suite on every CI runner.
+- **Manual harness tests** in `tests/test_interpreter.py` (e.g. `@pytest.mark.skip(reason="Mac only")`) are legacy developer smokes — they `assert False`, read private data (SMS), or need a display. **Do not enable them in macOS CI**; write deterministic `darwin_ci` tests in `test_platform_ci.py` instead (AppleScript and shell quoting are already covered there).
 
 ### Documentation
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,12 +79,12 @@ Jobs, Python versions, and pytest commands: `.github/workflows/python-package.ym
 
 | Job | Runner | What runs |
 | --- | --- | --- |
-| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite (`pytest -m "not integration and not windows_ci and not darwin_ci"`), Python 3.10–3.14, plus `linux_ci` language smokes in `tests/test_language_subprocess.py` |
-| **Integration** | `ubuntu-latest` | LLM tests (`pytest -m integration`), same-repo PRs and `main` only; sets `OI_RUN_INTEGRATION=1` and `OPENAI_API_KEY` |
+| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite + `linux_ci` language smokes (`tests/test_language_subprocess.py`) |
+| **Integration** | `ubuntu-latest` | `pytest -m integration` (same-repo PRs and `main` only) |
+| **Windows CI smoke** | `windows-latest` | `pytest -m windows_ci` (`tests/test_platform_ci.py`) |
+| **macOS CI smoke** | `macos-latest` | `pytest -m darwin_ci` (`tests/test_platform_ci.py`) |
 
-Platform-specific tests use `linux_ci`, `windows_ci`, and `darwin_ci` markers. conftest skips each marker on the wrong host so a local Linux run does not fail on Windows-only tests. Dedicated Windows/macOS workflow jobs ship with the smoke tests that use those markers.
-
-Locally: `pytest -m "not integration"` runs the unit suite. `linux_ci` / `windows_ci` / `darwin_ci` tests are skipped automatically on the wrong OS.
+`linux_ci`, `windows_ci`, and `darwin_ci` skip on the wrong host. Plain `pytest` is enough for day-to-day unit testing.
 
 **Note**: This project uses [`black`](https://black.readthedocs.io/en/stable/index.html) and [`isort`](https://pypi.org/project/isort/) via a [`pre-commit`](https://pre-commit.com/) hook to ensure consistent code style. If you need to bypass it for some reason, you can `git commit` with the `--no-verify` flag.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -75,9 +75,11 @@ pytest -m integration
 
 ### CI test layout
 
+Jobs, Python versions, and pytest commands: `.github/workflows/python-package.yml`.
+
 | Job | Runner | What runs |
 | --- | --- | --- |
-| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite (`pytest -m "not integration and not windows_ci and not darwin_ci"`), Python 3.10–3.14 |
+| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite (`pytest -m "not integration and not windows_ci and not darwin_ci"`), Python 3.10–3.14, plus `linux_ci` language smokes in `tests/test_language_subprocess.py` |
 | **Integration** | `ubuntu-latest` | LLM tests (`pytest -m integration`), same-repo PRs and `main` only; sets `OI_RUN_INTEGRATION=1` and `OPENAI_API_KEY` |
 
 Platform-specific tests use `linux_ci`, `windows_ci`, and `darwin_ci` markers. conftest skips each marker on the wrong host so a local Linux run does not fail on Windows-only tests. Dedicated Windows/macOS workflow jobs ship with the smoke tests that use those markers.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -82,6 +82,29 @@ def console_output_text(chunks):
     )
 
 
+# Bash nested-loop quoting smoke shared by linux_ci and darwin_ci jobs.
+# Linux CI excludes darwin_ci markers; macOS CI runs only darwin_ci — so we
+# keep thin per-runner tests that call this helper rather than one dual-marked test.
+BASH_NESTED_LOOP_QUOTING_SNIPPET = (
+    'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
+)
+
+
+def assert_bash_nested_loop_output(output):
+    assert "a_1" in output
+    assert "b_2" in output
+
+
+def run_bash_nested_loop_quoting_smoke(interpreter):
+    """Run nested bash loops through computer.run; fail fast on non-bash $SHELL."""
+
+    require_bash_compatible_shell()
+    chunks = list(
+        interpreter.computer.run("shell", BASH_NESTED_LOOP_QUOTING_SNIPPET)
+    )
+    assert_bash_nested_loop_output(console_output_text(chunks))
+
+
 def patch_expanduser(monkeypatch, module, home):
     """Make expanduser('~') resolve to home (HOME is unreliable on Windows)."""
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -669,7 +669,7 @@ def test_server():
         _stop_server_subprocess(process)
 
 
-@pytest.mark.skip(reason="Mac only")
+@pytest.mark.skip(reason="Mac only — manual harness; use darwin_ci in test_platform_ci.py for CI")
 def test_sms():
     """Manual Mac-only smoke for reading and searching SMS via AppleScript.
 
@@ -688,7 +688,7 @@ def test_sms():
     assert False
 
 
-@pytest.mark.skip(reason="Mac only")
+@pytest.mark.skip(reason="Mac only — manual harness; use darwin_ci in test_platform_ci.py for CI")
 def test_pytes():
     """Manual Mac-only smoke for vision OCR on a Desktop PNG (developer harness).
 
@@ -1185,7 +1185,7 @@ def _rate_limit_openai_after_integration(request):
 
 
 
-@pytest.mark.skip(reason="Mac only + no way to fail test")
+@pytest.mark.skip(reason="Mac only — manual harness; no assertion; not for CI")
 def test_spotlight():
     """Manual Mac smoke: command+space opens Spotlight.
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1184,7 +1184,6 @@ def _rate_limit_openai_after_integration(request):
         time.sleep(4)
 
 
-
 @pytest.mark.skip(reason="Mac only — manual harness; no assertion; not for CI")
 def test_spotlight():
     """Manual Mac smoke: command+space opens Spotlight.
@@ -1349,34 +1348,6 @@ with open('numbers.txt', 'a+') as f:
     # Check if '1' and '5' are in the content
     assert "1" in content
     assert "5" not in content
-
-
-@pytest.mark.linux_ci
-@pytest.mark.timeout(30)
-def test_shell_nested_loop_quoting():
-    """Shell execution must pass nested quotes/variables through unchanged.
-
-    Deterministic: no LLM, no API. The old integration test tried to cover this
-    via LLM-generated nested shell loops, which hung when quoting was malformed.
-
-    Uses bash-style loop syntax fed to subprocess_language, which spawns
-    os.environ["SHELL"]. If SHELL is fish (or other non-bash), fail immediately
-    (see require_bash_compatible_shell) instead of hanging forever.
-
-    Windows cmd.exe variant lives in tests/test_platform_ci.py (``windows_ci``)."""
-
-
-    require_bash_compatible_shell()
-
-    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
-    chunks = interpreter.computer.run("shell", code)
-    output = "".join(
-        chunk.get("content", "")
-        for chunk in chunks
-        if chunk.get("format") == "output"
-    )
-    assert "a_1" in output
-    assert "b_2" in output
 
 
 @pytest.mark.integration

--- a/tests/test_language_subprocess.py
+++ b/tests/test_language_subprocess.py
@@ -1,0 +1,160 @@
+"""Real runtime smokes for all languages exercised on Linux CI.
+
+Unit tests mock preprocess/detect helpers; these catch hangs, missing binaries,
+and marker parsing against a live interpreter process. All snippets are hardcoded
+(not LLM-generated). For tests that call an LLM and execute whatever it returns,
+see ``test_interpreter.py`` integration tests (require OPENAI_API_KEY).
+
+All ten Terminal languages are covered across CI runners:
+
+| Language    | CI runner |
+|-------------|-----------|
+| Python      | Linux     |
+| Shell/bash  | Linux     |
+| JavaScript  | Linux     |
+| Ruby        | Linux     |
+| R           | Linux     |
+| Java        | Linux     |
+| HTML        | Linux     |
+| React       | Linux     |
+| Shell/cmd   | Windows   |
+| PowerShell  | Windows   |
+| AppleScript | macOS     |
+
+To run locally on Linux, install the language runtimes that are missing:
+
+    sudo apt install nodejs ruby r-base default-jdk
+    # For HTML/React (needs headless Chrome). On Ubuntu, chromium from apt is enough:
+    sudo apt install chromium-browser
+    # google-chrome is pre-installed on GitHub-hosted ubuntu-latest runners.
+"""
+
+import shutil
+
+import pytest
+
+from interpreter import OpenInterpreter
+from tests.helpers import (
+    chunks_of_type,
+    console_output_text,
+    require_bash_compatible_shell,
+    require_chrome_for_html,
+)
+
+pytestmark = pytest.mark.linux_ci
+
+_JAVA_SMOKE = """class JavaOk {
+    public static void main(String[] args) {
+        System.out.println("java_ok");
+    }
+}"""
+
+_REACT_SMOKE = """function App() {
+  return <div>react_ok</div>;
+}
+ReactDOM.render(<App />, document.getElementById('root'));"""
+
+
+@pytest.fixture
+def interpreter():
+    oi = OpenInterpreter()
+    oi.conversation_history = False
+    return oi
+
+
+@pytest.mark.timeout(60)
+def test_python_subprocess_smoke(interpreter):
+    """Python code runs through the Jupyter kernel and stdout is captured."""
+    chunks = list(interpreter.computer.run("python", 'print("py_ok")'))
+    assert "py_ok" in console_output_text(chunks)
+
+
+@pytest.mark.timeout(30)
+def test_javascript_subprocess_smoke(interpreter):
+    """JavaScript runs in a node -i subprocess; the banner is filtered out."""
+    if shutil.which("node") is None:
+        pytest.skip("node not installed")
+    chunks = list(interpreter.computer.run("javascript", 'console.log("js_ok")'))
+    assert "js_ok" in console_output_text(chunks)
+
+
+@pytest.mark.timeout(30)
+def test_shell_bash_echo_smoke(interpreter):
+    """Shell uses $SHELL (must be bash-compatible); a basic echo reaches stdout."""
+    require_bash_compatible_shell()
+    chunks = list(interpreter.computer.run("shell", "echo shell_ok"))
+    assert "shell_ok" in console_output_text(chunks)
+
+
+@pytest.mark.timeout(30)
+def test_shell_bash_nested_loop_quoting(interpreter):
+    """Nested bash loops with variable interpolation pass through subprocess unchanged."""
+    require_bash_compatible_shell()
+    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
+    chunks = list(interpreter.computer.run("shell", code))
+    output = console_output_text(chunks)
+    assert "a_1" in output
+    assert "b_2" in output
+
+
+@pytest.mark.timeout(30)
+def test_ruby_subprocess_smoke(interpreter):
+    """Ruby runs in an irb subprocess; puts output reaches the output queue."""
+    if shutil.which("irb") is None:
+        pytest.skip("irb not installed")
+    chunks = list(interpreter.computer.run("ruby", 'puts "ruby_ok"'))
+    assert "ruby_ok" in console_output_text(chunks)
+
+
+@pytest.mark.timeout(30)
+def test_r_subprocess_smoke(interpreter):
+    """R runs in R --vanilla; cat() output is captured after postprocessor filtering."""
+    if shutil.which("R") is None:
+        pytest.skip("R not installed")
+    chunks = list(interpreter.computer.run("r", 'cat("r_ok\\n")'))
+    assert "r_ok" in console_output_text(chunks)
+
+
+@pytest.mark.timeout(60)
+def test_java_subprocess_smoke(interpreter):
+    """Java source is written, compiled with javac, and run; stdout is captured."""
+    if shutil.which("javac") is None or shutil.which("java") is None:
+        pytest.skip("jdk not installed")
+    chunks = list(interpreter.computer.run("java", _JAVA_SMOKE))
+    assert "java_ok" in console_output_text(chunks)
+
+
+@pytest.mark.timeout(90)
+def test_html_runtime_smoke(interpreter):
+    """HTML execution yields console + code + image chunks (via html2image/Chrome)."""
+    require_chrome_for_html()
+    try:
+        chunks = list(
+            interpreter.computer.run(
+                "html", '<html><body style="font-size:32px">html_ok</body></html>'
+            )
+        )
+    except FileNotFoundError as exc:
+        pytest.skip(f"html2image screenshot failed: {exc}")
+    assert chunks_of_type(chunks, "console")
+    assert chunks_of_type(chunks, "code")[0]["format"] == "html"
+    images = chunks_of_type(chunks, "image")
+    assert len(images) == 1
+    assert images[0]["format"] == "base64.png"
+    assert len(images[0]["content"]) > 50
+
+
+@pytest.mark.timeout(120)
+def test_react_runtime_smoke(interpreter):
+    """React code is injected into the CDN-backed HTML template and screenshotted."""
+    require_chrome_for_html()
+    try:
+        chunks = list(interpreter.computer.run("react", _REACT_SMOKE))
+    except FileNotFoundError as exc:
+        pytest.skip(f"html2image screenshot failed: {exc}")
+    assert chunks_of_type(chunks, "console")
+    assert chunks_of_type(chunks, "code")[0]["format"] == "html"
+    images = chunks_of_type(chunks, "image")
+    assert len(images) == 1
+    assert images[0]["format"] == "base64.png"
+    assert len(images[0]["content"]) > 50

--- a/tests/test_language_subprocess.py
+++ b/tests/test_language_subprocess.py
@@ -39,6 +39,7 @@ from tests.helpers import (
     console_output_text,
     require_bash_compatible_shell,
     require_chrome_for_html,
+    run_bash_nested_loop_quoting_smoke,
 )
 
 pytestmark = pytest.mark.linux_ci
@@ -88,13 +89,13 @@ def test_shell_bash_echo_smoke(interpreter):
 
 @pytest.mark.timeout(30)
 def test_shell_bash_nested_loop_quoting(interpreter):
-    """Nested bash loops with variable interpolation pass through subprocess unchanged."""
-    require_bash_compatible_shell()
-    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
-    chunks = list(interpreter.computer.run("shell", code))
-    output = console_output_text(chunks)
-    assert "a_1" in output
-    assert "b_2" in output
+    """Nested bash loops with variable interpolation pass through subprocess unchanged.
+
+    Regression for fish/non-bash $SHELL hangs (require_bash_compatible_shell).
+    macOS CI runs the same snippet under darwin_ci in test_platform_ci.py.
+    Windows cmd.exe variant is in test_platform_ci.py (windows_ci).
+    """
+    run_bash_nested_loop_quoting_smoke(interpreter)
 
 
 @pytest.mark.timeout(30)

--- a/tests/test_platform_ci.py
+++ b/tests/test_platform_ci.py
@@ -12,7 +12,7 @@ import pytest
 
 from interpreter import OpenInterpreter
 from interpreter.core.computer.terminal.languages.shell import Shell
-from tests.helpers import console_output_text
+from tests.helpers import console_output_text, run_bash_nested_loop_quoting_smoke
 
 
 @pytest.fixture
@@ -82,12 +82,8 @@ def test_shell_start_cmd_uses_shell_env():
 @pytest.mark.darwin_ci
 @pytest.mark.timeout(30)
 def test_shell_bash_nested_loop_quoting(interpreter):
-    """Bash nested loops work on macOS (zsh default, but $SHELL may be bash)."""
-    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
-    chunks = list(interpreter.computer.run("shell", code))
-    output = console_output_text(chunks)
-    assert "a_1" in output
-    assert "b_2" in output
+    """Same bash nested-loop snippet as linux_ci in test_language_subprocess.py."""
+    run_bash_nested_loop_quoting_smoke(interpreter)
 
 
 @pytest.mark.darwin_ci

--- a/tests/test_platform_ci.py
+++ b/tests/test_platform_ci.py
@@ -1,0 +1,98 @@
+"""Minimal per-OS CI smokes: real subprocess / path behavior not covered by mocks.
+
+Linux CI runs the full unit suite (see test_language_subprocess.py for language
+e2e). Windows and macOS CI jobs run only tests marked ``windows_ci`` or
+``darwin_ci`` here — cmd.exe, PowerShell, AppleScript, and related quirks from
+cross-platform test development.
+"""
+
+import os
+
+import pytest
+
+from interpreter import OpenInterpreter
+from interpreter.core.computer.terminal.languages.shell import Shell
+from tests.helpers import console_output_text
+
+
+@pytest.fixture
+def interpreter():
+    oi = OpenInterpreter()
+    oi.conversation_history = False
+    return oi
+
+
+# --- Windows (cmd.exe, PowerShell, USERPROFILE paths, test package imports) ---
+
+
+@pytest.mark.windows_ci
+def test_windows_imports_tests_package():
+    """Regression: ``from tests.helpers import ...`` must work (pyproject pythonpath)."""
+
+    from tests.helpers import TEST_LLM_MODEL
+
+    assert TEST_LLM_MODEL
+
+
+@pytest.mark.windows_ci
+def test_shell_start_cmd_uses_cmd_exe():
+    """On Windows, Shell.start_cmd is cmd.exe, not a Unix shell."""
+    shell = Shell()
+    assert shell.start_cmd == ["cmd.exe"]
+
+
+@pytest.mark.windows_ci
+@pytest.mark.timeout(30)
+def test_shell_cmd_echo_smoke(interpreter):
+    """cmd.exe can run a basic echo command end-to-end through computer.run."""
+    chunks = list(interpreter.computer.run("shell", "echo shell_ok"))
+    assert "shell_ok" in console_output_text(chunks)
+
+
+@pytest.mark.windows_ci
+@pytest.mark.timeout(30)
+def test_shell_cmd_nested_loop_quoting(interpreter):
+    """cmd.exe nested ``for`` loops — distinct quoting from bash (Linux CI)."""
+
+    code = "for %i in (a b) do for %j in (1 2) do echo %i_%j"
+    chunks = list(interpreter.computer.run("shell", code))
+    output = console_output_text(chunks)
+    assert "a_1" in output
+    assert "b_2" in output
+
+
+@pytest.mark.windows_ci
+@pytest.mark.timeout(30)
+def test_powershell_subprocess_smoke(interpreter):
+    """PowerShell runs in powershell.exe and Write-Output reaches the output queue."""
+    chunks = list(interpreter.computer.run("powershell", 'Write-Output "ps_ok"'))
+    assert "ps_ok" in console_output_text(chunks)
+
+
+# --- macOS (osascript, Unix $SHELL) ---
+
+
+@pytest.mark.darwin_ci
+def test_shell_start_cmd_uses_shell_env():
+    """On macOS/Linux, Shell.start_cmd reads $SHELL from the environment."""
+    shell = Shell()
+    assert shell.start_cmd == [os.environ.get("SHELL", "bash")]
+
+
+@pytest.mark.darwin_ci
+@pytest.mark.timeout(30)
+def test_shell_bash_nested_loop_quoting(interpreter):
+    """Bash nested loops work on macOS (zsh default, but $SHELL may be bash)."""
+    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
+    chunks = list(interpreter.computer.run("shell", code))
+    output = console_output_text(chunks)
+    assert "a_1" in output
+    assert "b_2" in output
+
+
+@pytest.mark.darwin_ci
+@pytest.mark.timeout(30)
+def test_applescript_subprocess_smoke(interpreter):
+    """AppleScript runs via osascript through the shell; return value is captured."""
+    chunks = list(interpreter.computer.run("applescript", 'return "as_ok"'))
+    assert "as_ok" in console_output_text(chunks)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Linux language-runtime CI smokes, Windows/macOS platform smoke jobs, and DRY shared helpers for bash nested-loop quoting tests.

`docs/CONTRIBUTING.md` is updated incrementally in the commits that add the corresponding CI behavior (no separate docs-only churn commits).

## Commits

1. **test(ci): add Linux language runtime smokes** — `tests/test_language_subprocess.py`, Linux workflow apt packages, CONTRIBUTING yaml pointer + `linux_ci` table row
2. **test(ci): add Windows/macOS platform smokes** — `tests/test_platform_ci.py`, Windows/macOS workflow jobs, AGENTS.md, CONTRIBUTING table rows + lean closing line
3. **test(ci): DRY bash nested-loop smoke** — `tests/helpers.py`, refactor linux/darwin tests, remove duplicate from `test_interpreter.py`

## CONTRIBUTING structure

- **`### Integration tests locally`** — unchanged from `main` (integration opt-in docs)
- **`### CI test layout`** — compact jobs table pointing at `.github/workflows/python-package.yml` for exact commands/versions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

