### PR TITLE
test: shared helpers and legacy interpreter test hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ The build backend is Poetry, but CI installs via pip. The package manager may ch
 - **Autonomous agents must monitor CI** after pushing: keep checking the workflow status until it passes, fixing any failures before considering the work complete.
 - **Integration tests** (`@pytest.mark.integration`) call an LLM and auto-execute generated code. Locally they need both `OI_RUN_INTEGRATION=1` and `OPENAI_API_KEY`; without either, pytest skips them. CI sets both in the integration workflow job (see `docs/CONTRIBUTING.md`).
 - **Optional test gates skip; they do not fail.** Integration tests, OS markers (`linux_ci` / `windows_ci` / `darwin_ci`), and missing external binaries should produce a pytest skip with a clear reason—not a test failure—when prerequisites are absent.
+- **Shell tests on Unix** that feed bash-syntax snippets to `subprocess_language` should call `require_bash_compatible_shell()` from `tests.helpers`: Non-bash `$SHELL` (e.g. fish) hangs instead of failing.
+- **Shared test helpers** live in `tests/helpers.py` (import `from tests.helpers import …`). Do not import from `conftest.py` — it is not a stable import path on all platforms.
+- **Computer subsystem tests** use `COMPUTER_TOOL_SUBSYSTEMS` in `tests/helpers.py` — update when `_get_all_computer_tools_list` changes (until [#101](https://github.com/endolith/open-interpreter/issues/101) lands).
 
 ### Documentation
 

--- a/tests/core/computer/terminal/languages/test_shell.py
+++ b/tests/core/computer/terminal/languages/test_shell.py
@@ -1,0 +1,53 @@
+import platform
+from unittest import mock
+
+import pytest
+from _pytest.outcomes import Failed
+
+from interpreter.core.computer.terminal.languages.shell import (
+    Shell,
+    add_active_line_prints,
+    has_multiline_commands,
+    preprocess_shell,
+)
+from tests.helpers import require_bash_compatible_shell
+
+
+def test_add_active_line_prints():
+    """add_active_line_prints() prefixes shell commands with ##active_lineN## echo markers."""
+    code = "echo one\necho two"
+    result = add_active_line_prints(code)
+    assert 'echo "##active_line1##"' in result
+
+
+def test_preprocess_shell_adds_end_marker():
+    """preprocess_shell() appends an ##end_of_execution## marker to shell code."""
+    result = preprocess_shell("echo hi")
+    assert "##end_of_execution##" in result
+
+
+def test_has_multiline_commands_detects_line_continuation():
+    """has_multiline_commands() detects backslash line continuations in shell scripts."""
+    assert has_multiline_commands("echo hello \\\nworld")
+
+
+def test_shell_start_cmd_uses_shell_env():
+    """Shell subprocess uses os.environ['SHELL'] on Unix; cmd.exe on Windows."""
+    import os
+
+    if platform.system() == "Windows":
+        shell = Shell()
+        assert shell.start_cmd == ["cmd.exe"]
+    else:
+        with mock.patch.dict(os.environ, {"SHELL": "/bin/bash"}):
+            shell = Shell()
+        assert shell.start_cmd == ["/bin/bash"]
+
+
+def test_require_bash_compatible_shell_rejects_fish(monkeypatch):
+    """require_bash_compatible_shell() fails when SHELL points to fish on Unix."""
+    if platform.system() == "Windows":
+        pytest.skip("SHELL guard only applies to Unix")
+    monkeypatch.setenv("SHELL", "/usr/bin/fish")
+    with pytest.raises(Failed, match="fish"):
+        require_bash_compatible_shell()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,92 @@
+"""Shared constants and helpers for unit tests.
+
+Import from here (``from tests.helpers import ...``), not from conftest —
+pytest loads conftest for hooks/fixtures but it is not a stable import path
+on all platforms (notably Windows).
+"""
+
+import os
+import platform
+import shutil
+
+import pytest
+
+# Model id used when a test needs an LLM name for branching (e.g. OpenAI key
+# prompts). Matches tests/config.test.yaml; never hits a real API in unit tests.
+TEST_LLM_MODEL = "gpt-4o-mini"
+
+
+def chunks_of_type(chunks, chunk_type):
+    return [chunk for chunk in chunks if chunk.get("type") == chunk_type]
+
+
+def require_chrome_for_html():
+    """Skip when no Chrome/Chromium binary is available for html2image."""
+
+    for name in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser"):
+        if shutil.which(name):
+            return
+    pytest.skip("google-chrome or chromium not installed (needed for HTML/React e2e)")
+
+
+# Subsystems returned by Computer._get_all_computer_tools_list (order matters).
+COMPUTER_TOOL_SUBSYSTEMS = (
+    "mouse",
+    "keyboard",
+    "display",
+    "clipboard",
+    "mail",
+    "sms",
+    "calendar",
+    "contacts",
+    "browser",
+    "os",
+    "vision",
+    "skills",
+    "docs",
+    "ai",
+    "files",
+)
+
+
+_BASH_COMPATIBLE_SHELL_NAMES = frozenset(
+    {"bash", "sh", "dash", "zsh", "ksh", "ash"}
+)
+
+
+def require_bash_compatible_shell():
+    """Fail immediately if Shell would spawn a non-bash-compatible $SHELL.
+
+    OI feeds bash-syntax snippets to subprocess_language, which uses
+    os.environ["SHELL"] on Unix. Fish and other shells hang waiting for
+    ##end_of_execution## instead of erroring.
+    """
+    if platform.system() == "Windows":
+        return
+    shell = os.environ.get("SHELL", "bash")
+    shell_name = os.path.basename(shell).lower()
+    if shell_name not in _BASH_COMPATIBLE_SHELL_NAMES:
+        pytest.fail(
+            f"SHELL={shell!r} cannot run bash-syntax shell code (Shell uses "
+            f"os.environ['SHELL']). Use bash or wait for explicit bash in develop."
+        )
+
+
+def console_output_text(chunks):
+    """Join console output chunks from ``computer.run`` / ``terminal.run``."""
+
+    return "".join(
+        chunk.get("content", "")
+        for chunk in chunks
+        if chunk.get("format") == "output"
+    )
+
+
+def patch_expanduser(monkeypatch, module, home):
+    """Make expanduser('~') resolve to home (HOME is unreliable on Windows)."""
+
+    monkeypatch.setattr(
+        module.os.path,
+        "expanduser",
+        lambda path: str(home) if path == "~" else path,
+    )

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -134,6 +134,7 @@ def _last_assistant_text(messages):
     return ""
 
 
+@pytest.mark.timeout(120)
 def test_hallucinations():
     """Common LLM code hallucinations are normalized before execution.
 
@@ -1296,6 +1297,7 @@ def test_math():
     assert str(round(test_result, 2)) in messages[-1]["content"]
 
 
+@pytest.mark.timeout(120)
 def test_break_execution():
     """
     Breaking from the generator while it's executing should halt the operation.

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -119,6 +119,18 @@ def _last_assistant_message(messages):
     return ""
 
 
+def _last_assistant_text(messages):
+    """Last assistant message or code block (models often reply with code only)."""
+    for message in reversed(messages):
+        if message.get("role") != "assistant":
+            continue
+        if message.get("type") in ("message", "code"):
+            content = message.get("content")
+            if content:
+                return str(content)
+    return ""
+
+
 def test_hallucinations():
     # We should be resiliant to common hallucinations.
 
@@ -495,8 +507,19 @@ def test_server():
             #### TEST FILE ####
 
             # Send another POST request
+            # auto_run=False: this turn only checks the model's text answer about a file
+            # path (judged via computer.ai.chat). We must not auto-execute shell code here
+            # or the server can hang before WebSocket 'complete' — unrelated to fish/$SHELL.
+            # custom_instructions steers plain-text replies; _last_assistant_text handles
+            # models that still emit a code block instead of a message.
             post_url = "http://127.0.0.1:8000/settings"
-            settings = {"messages": [], "auto_run": True}
+            settings = {
+                "messages": [],
+                "auto_run": False,
+                "custom_instructions": (
+                    "Answer in plain text only. Do not write or run code."
+                ),
+            }
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
 
@@ -542,7 +565,8 @@ def test_server():
             await websocket.send(json.dumps({"role": "user", "end": True}))
             print("WebSocket chunks sent")
 
-            # Wait for response
+            # WebSocket stream may arrive before GET /messages is consistent; keep
+            # accumulated_content as a fallback when picking the assistant reply.
             accumulated_content = await _wait_for_websocket_complete(websocket)
 
             # Get messages
@@ -553,19 +577,23 @@ def test_server():
                 response_json = json.loads(response_json)
             messages = response_json["messages"]
 
-            last_assistant = _last_assistant_message(messages)
-            assert last_assistant, "expected assistant message after file turn"
+            # Prefer structured messages; fall back to the WebSocket stream when the
+            # model replies with a code block or GET /messages lags behind the stream.
+            last_assistant = _last_assistant_text(messages) or accumulated_content
+            assert last_assistant, "expected assistant response after file turn"
             response = interpreter.computer.ai.chat(
                 last_assistant
-                + "\n\nBased on the assistant message above, does the assistant think the file exists? Yes or no? Only reply with one word— 'yes' or 'no'."
+                + "\n\nBased on the assistant response above, does the assistant think the file exists? Yes or no? Only reply with one word— 'yes' or 'no'."
             )
             assert response.strip(" \n.").lower() == "no"
 
             #### TEST IMAGES ####
 
             # Send another POST request
+            # auto_run=False again so vision MCQ is text-only. custom_instructions=""
+            # clears the file-turn "plain text only" prompt for this image turn.
             post_url = "http://127.0.0.1:8000/settings"
-            settings = {"messages": [], "auto_run": True}
+            settings = {"messages": [], "auto_run": False, "custom_instructions": ""}
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
 
@@ -623,8 +651,9 @@ def test_server():
                 response_json = json.loads(response_json)
             messages = response_json["messages"]
 
-            last_assistant = _last_assistant_message(messages)
-            assert last_assistant, "expected assistant message after image turn"
+            # Same message-or-stream fallback as the file MCQ turn above.
+            last_assistant = _last_assistant_text(messages) or accumulated_content
+            assert last_assistant, "expected assistant response after image turn"
             assert re.search(
                 r"\bB\b", last_assistant, re.IGNORECASE
             ), f"expected vision model to answer B (gradient), got: {last_assistant!r}"

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -469,7 +469,8 @@ def test_server():
             assert messages[-1]["type"] == "code"
             assert "18893094989" not in accumulated_content.replace(",", "")
 
-            # Send go message
+            # The math turn used auto_run=False, so the model wrote Python code but did
+            # not execute it. "go" tells the server to run that pending code block now.
             await websocket.send(
                 json.dumps({"role": "user", "type": "command", "start": True})
             )

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -15,6 +15,7 @@ from interpreter.terminal_interface.utils.count_tokens import (
 )
 
 interpreter = OpenInterpreter()
+interpreter.conversation_history = False
 #####
 
 import multiprocessing

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -7,6 +7,8 @@ from random import randint
 
 import pytest
 
+from tests.helpers import require_bash_compatible_shell
+
 #####
 from interpreter import AsyncInterpreter, OpenInterpreter
 from interpreter.terminal_interface.utils.count_tokens import (
@@ -1277,6 +1279,8 @@ with open('numbers.txt', 'a+') as f:
     assert "5" not in content
 
 
+@pytest.mark.linux_ci
+@pytest.mark.timeout(30)
 def test_shell_nested_loop_quoting():
     """Shell execution must pass nested quotes/variables through unchanged.
 
@@ -1284,10 +1288,9 @@ def test_shell_nested_loop_quoting():
     via LLM-generated nested shell loops, which hung when quoting was malformed.
     """
 
-    if platform.system() == "Windows":
-        code = 'for %i in (a b) do for %j in (1 2) do echo %i_%j'
-    else:
-        code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
+    require_bash_compatible_shell()
+
+    code = 'for i in a b; do for j in 1 2; do echo "${i}_${j}"; done; done'
     chunks = interpreter.computer.run("shell", code)
     output = "".join(
         chunk.get("content", "")

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1121,10 +1121,13 @@ def test_long_message():
     assert "A" in interpreter.messages[-1]["content"]
 
 
-# this function will run after each test
-# we're introducing some sleep to help avoid timeout issues with the OpenAI API
-def teardown_function():
-    time.sleep(4)
+# Pause after OpenAI integration tests to reduce API rate-limit errors.
+@pytest.fixture(autouse=True)
+def _rate_limit_openai_after_integration(request):
+    yield
+    if request.node.get_closest_marker("integration"):
+        time.sleep(4)
+
 
 
 @pytest.mark.skip(reason="Mac only + no way to fail test")

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -123,6 +123,7 @@ def _last_assistant_message(messages):
 
 def _last_assistant_text(messages):
     """Last assistant message or code block (models often reply with code only)."""
+
     for message in reversed(messages):
         if message.get("role") != "assistant":
             continue
@@ -134,7 +135,11 @@ def _last_assistant_text(messages):
 
 
 def test_hallucinations():
-    # We should be resiliant to common hallucinations.
+    """Common LLM code hallucinations are normalized before execution.
+
+    Covers executeexecute suffixes, JSON code blocks, functions.execute()
+    wrappers, and loose object literals — each should run and produce the
+    expected numeric or print output."""
 
     code = """10+12executeexecute\n"""
 
@@ -194,11 +199,10 @@ def run_auth_server():
 # @pytest.mark.skip(reason="Requires uvicorn, which we don't require by default")
 @pytest.mark.integration
 def test_authenticated_acknowledging_breaking_server():
-    """
-    Test the server when we have authentication and acknowledging one.
+    """Test the server when we have authentication and acknowledging one.
 
-    I know this is bad, just trying to test quickly!
-    """
+    I know this is bad, just trying to test quickly!"""
+
 
     # Start the server in a new process
 
@@ -332,7 +336,11 @@ def run_server():
 @pytest.mark.integration
 @pytest.mark.timeout(900)
 def test_server():
-    # Start the server in a new process
+    """FastAPI/WebSocket server accepts settings, streams chat, and completes cleanly.
+
+    Spins up AsyncInterpreter in a subprocess (spawn context), posts settings,
+    sends a user message over WebSocket, and verifies poem-style responses
+    arrive without authentication when INTERPRETER_REQUIRE_ACKNOWLEDGE is off."""
 
     process = _start_server_subprocess(run_server)
 
@@ -662,6 +670,10 @@ def test_server():
 
 @pytest.mark.skip(reason="Mac only")
 def test_sms():
+    """Manual Mac-only smoke for reading and searching SMS via AppleScript.
+
+    Not suitable for CI: reads real Messages, needs TCC permission, ends assert False."""
+
     sms = interpreter.computer.sms
 
     # Get the last 5 messages
@@ -677,6 +689,10 @@ def test_sms():
 
 @pytest.mark.skip(reason="Mac only")
 def test_pytes():
+    """Manual Mac-only smoke for vision OCR on a Desktop PNG (developer harness).
+
+    Not suitable for CI: needs a Desktop PNG on a logged-in GUI session, assert False."""
+
     import os
 
     desktop_path = os.path.join(os.path.expanduser("~"), "Desktop")
@@ -696,14 +712,15 @@ def test_pytes():
 
 @pytest.mark.integration
 def test_ai_chat():
+    """Integration smoke: computer.ai.chat returns a response for a simple greeting."""
+
     print(interpreter.computer.ai.chat("hi"))
 
 
 @pytest.mark.integration
 def test_generator():
-    """
-    Sends two messages, makes sure everything is correct with display both on and off.
-    """
+    """Sends two messages, makes sure everything is correct with display both on and off."""
+
 
     interpreter.llm.model = "gpt-4o-mini"
 
@@ -786,6 +803,8 @@ def test_generator():
 
 @pytest.mark.skip(reason="Requires open-interpreter[local]")
 def test_localos():
+    """Manual smoke for local OS view with images disabled then re-enabled."""
+
     interpreter.computer.emit_images = False
     interpreter.computer.view()
     interpreter.computer.emit_images = True
@@ -794,6 +813,8 @@ def test_localos():
 
 @pytest.mark.skip(reason="Requires open-interpreter[local]")
 def test_m_vision():
+    """Manual local-model smoke: chat with a base64 image when supports_vision is off."""
+
     base64png = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAADMElEQVR4nOzVwQnAIBQFQYXff81RUkQCOyDj1YOPnbXWPmeTRef+/3O/OyBjzh3CD95BfqICMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMO0TAAD//2Anhf4QtqobAAAAAElFTkSuQmCC"
     messages = [
         {"role": "user", "type": "message", "content": "describe this image"},
@@ -822,7 +843,8 @@ def test_m_vision():
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_point():
-    # interpreter.computer.debug = True
+    """Manual display smoke: mouse.move finds common macOS icons by description."""
+
     interpreter.computer.mouse.move(icon="gear")
     interpreter.computer.mouse.move(icon="refresh")
     interpreter.computer.mouse.move(icon="play")
@@ -833,6 +855,8 @@ def test_point():
 
 @pytest.mark.skip(reason="Aifs not ready")
 def test_skills():
+    """Manual skills.search integration (Python 3.11 only; skipped on 3.12)."""
+
     import sys
 
     if sys.version_info[:2] == (3, 12):
@@ -884,6 +908,8 @@ def test_skills():
 
 @pytest.mark.skip(reason="Local only")
 def test_browser():
+    """Manual local smoke: browser.search issues a query against a local API base."""
+
     interpreter.computer.api_base = "http://0.0.0.0:80/v0"
     print(
         interpreter.computer.browser.search("When's the next Dune showing in Seattle?")
@@ -893,6 +919,8 @@ def test_browser():
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_display_api():
+    """Manual display smoke: mouse.move locates many on-screen icons/text labels."""
+
     start = time.time()
 
     # interpreter.computer.display.find_text("submit")
@@ -969,7 +997,8 @@ def test_display_api():
 
 @pytest.mark.skip(reason="Server is not a stable feature")
 def test_websocket_server():
-    # Start the server in a new thread
+    """Manual smoke: legacy interpreter.server WebSocket accepts chat messages."""
+
     server_thread = threading.Thread(target=interpreter.server)
     server_thread.start()
 
@@ -1002,6 +1031,8 @@ def test_websocket_server():
 
 @pytest.mark.skip(reason="Server is not a stable feature")
 def test_i():
+    """Manual smoke: HTTP POST to interpreter.server streams a non-empty response."""
+
     import requests
 
     url = "http://127.0.0.1:8000/"
@@ -1032,12 +1063,16 @@ def test_i():
 
 @pytest.mark.integration
 def test_async():
+    """Non-blocking chat returns immediately; wait() collects the final result."""
+
     interpreter.chat("Hello!", blocking=False)
     print(interpreter.wait())
 
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_find_text_api():
+    """Manual display smoke: mouse.move with a long natural-language target string."""
+
     start = time.time()
     interpreter.computer.mouse.move(
         "Left Arrow Left Arrow and a bunch of hallucinated text? or was it..."
@@ -1050,6 +1085,8 @@ def test_find_text_api():
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_getActiveWindow():
+    """Manual smoke: pywinctl reports the currently active window."""
+
     import pywinctl
 
     print(pywinctl.getActiveWindow())
@@ -1058,18 +1095,24 @@ def test_getActiveWindow():
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_notify():
+    """Manual smoke: os.notify shows a desktop notification."""
+
     interpreter.computer.os.notify("Hello")
     assert False
 
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_get_text():
+    """Manual display smoke: get_text_as_list_of_lists OCRs the screen."""
+
     print(interpreter.computer.display.get_text_as_list_of_lists())
     assert False
 
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_keyboard():
+    """Manual smoke: keyboard.write types a long multi-line string."""
+
     time.sleep(2)
     interpreter.computer.keyboard.write("Hello " * 50 + "\n" + "hi" * 50)
     assert False
@@ -1077,6 +1120,8 @@ def test_keyboard():
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_get_selected_text():
+    """Manual smoke: os.get_selected_text reads the current text selection."""
+
     print("Getting selected text")
     time.sleep(1)
     text = interpreter.computer.os.get_selected_text()
@@ -1086,6 +1131,8 @@ def test_get_selected_text():
 
 @pytest.mark.skip(reason="Computer with display only + no way to fail test")
 def test_display_verbose():
+    """Manual verbose smoke: mouse.move logs extra detail when verbose is on."""
+
     interpreter.computer.verbose = True
     interpreter.verbose = True
     interpreter.computer.mouse.move(x=500, y=500)
@@ -1109,6 +1156,11 @@ def setup_function():
     reason="Not working consistently, I think GPT related changes? It worked recently"
 )
 def test_long_message():
+    """Integration: a very long user message is handled within a tiny context window.
+
+    The model should still recall the four repeated characters from the prompt
+    despite aggressive context_window truncation."""
+
     messages = [
         {
             "role": "user",
@@ -1134,11 +1186,17 @@ def _rate_limit_openai_after_integration(request):
 
 @pytest.mark.skip(reason="Mac only + no way to fail test")
 def test_spotlight():
+    """Manual Mac smoke: command+space opens Spotlight.
+
+    Not suitable for CI: drives the GUI with no pass/fail check."""
+
     interpreter.computer.keyboard.hotkey("command", "space")
 
 
 @pytest.mark.integration
 def test_files(tmp_path):
+    """Integration: LLM checks whether a user-attached file path exists on disk."""
+
     require_bash_compatible_shell()
     # Main used a hardcoded /Users/Killian/... path that only existed on one machine.
     # tmp_path creates a real file on any OS so the LLM can answer the existence question.
@@ -1158,6 +1216,8 @@ def test_files(tmp_path):
 
 @pytest.mark.skip(reason="Only 100 vision calls allowed / day!")
 def test_vision():
+    """Manual vision integration: describe a base64 PNG with supports_vision enabled."""
+
     base64png = "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAADMElEQVR4nOzVwQnAIBQFQYXff81RUkQCOyDj1YOPnbXWPmeTRef+/3O/OyBjzh3CD95BfqICMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMK0CMO0TAAD//2Anhf4QtqobAAAAAElFTkSuQmCC"
     messages = [
         {"role": "user", "type": "message", "content": "describe this image"},
@@ -1183,6 +1243,8 @@ def test_vision():
 
 
 def test_multiple_instances():
+    """Each OpenInterpreter instance keeps its own system_message."""
+
     interpreter.system_message = "i"
     agent_1 = OpenInterpreter()
     agent_1.system_message = "<3"
@@ -1196,6 +1258,8 @@ def test_multiple_instances():
 
 @pytest.mark.integration
 def test_hello_world():
+    """Integration: LLM replies with exactly 'Hello, World!' and no code execution."""
+
     hello_world_response = "Hello, World!"
 
     hello_world_message = f"Please reply with just the words {hello_world_response} and nothing else. Do not run code. No confirmation just the text."
@@ -1209,7 +1273,8 @@ def test_hello_world():
 
 @pytest.mark.integration
 def test_math():
-    # we'll generate random integers between this min and max in our math tests
+    """Integration: LLM computes a random order-of-operations expression correctly."""
+
     min_number = randint(1, 99)
     max_number = randint(1001, 9999)
 
@@ -1291,7 +1356,13 @@ def test_shell_nested_loop_quoting():
 
     Deterministic: no LLM, no API. The old integration test tried to cover this
     via LLM-generated nested shell loops, which hung when quoting was malformed.
-    """
+
+    Uses bash-style loop syntax fed to subprocess_language, which spawns
+    os.environ["SHELL"]. If SHELL is fish (or other non-bash), fail immediately
+    (see require_bash_compatible_shell) instead of hanging forever.
+
+    Windows cmd.exe variant lives in tests/test_platform_ci.py (``windows_ci``)."""
+
 
     require_bash_compatible_shell()
 
@@ -1308,6 +1379,8 @@ def test_shell_nested_loop_quoting():
 
 @pytest.mark.integration
 def test_delayed_exec():
+    """Integration: LLM writes and runs code with a delay between print statements."""
+
     require_bash_compatible_shell()
     interpreter.chat(
         """Can you write a single block of code and execute it that prints something, then delays 1 second, then prints something else? No talk just code, execute the code. Thanks!"""
@@ -1320,6 +1393,8 @@ def test_delayed_exec():
 @pytest.mark.integration
 @pytest.mark.timeout(180)
 def test_nested_loops_and_multiple_newlines():
+    """Integration: LLM runs spaced Python loops then a single bash echo line."""
+
     require_bash_compatible_shell()
     messages = interpreter.chat(
         """Can you write a nested for loop in python and run it? Put 1-3 newlines between each line in the python code.
@@ -1336,6 +1411,8 @@ Only generate and execute the code. Execute instantly. No explanations. Thanks!"
 
 @pytest.mark.integration
 def test_write_to_file(monkeypatch, tmp_path):
+    """Integration: LLM writes a file, then reads it back in a follow-up turn."""
+
     require_bash_compatible_shell()
     # Run in a temp directory so the LLM-generated file.txt does not land in the
     # repo root or the developer's home folder. monkeypatch.chdir restores cwd after
@@ -1354,17 +1431,22 @@ def test_write_to_file(monkeypatch, tmp_path):
 
 @pytest.mark.integration
 def test_markdown():
+    """Integration: LLM emits assorted markdown features in a single reply."""
+
     interpreter.chat(
         """Hi, can you test out a bunch of markdown features? Try writing a fenced code block, a table, headers, everything. DO NOT write the markdown inside a markdown code block, just write it raw."""
     )
 
 
 def test_reset():
-    # make sure that interpreter.reset() clears out the messages Array
+    """setup_function leaves messages empty after interpreter.reset()."""
+
     assert interpreter.messages == []
 
 
 def test_token_counter():
+    """count_tokens and count_messages_tokens agree for system and user prompts."""
+
     system_tokens = count_tokens(
         text=interpreter.system_message, model=interpreter.llm.model
     )

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -296,10 +296,11 @@ def test_authenticated_acknowledging_breaking_server():
             print(poem)
             time.sleep(1)
 
-    # Get the current event loop and run the test function
-    loop = asyncio.get_event_loop()
+    # asyncio.get_event_loop() raises RuntimeError on Python 3.12+ when there
+    # is no current event loop (e.g. pytest has not set one up). asyncio.run()
+    # creates a fresh loop, runs the coroutine, and closes it cleanly.
     try:
-        loop.run_until_complete(test_fastapi_server())
+        asyncio.run(test_fastapi_server())
     finally:
         _stop_server_subprocess(process)
 
@@ -637,10 +638,11 @@ def test_server():
             response = requests.post(post_url, json=code_data, timeout=30)
             print("POST request sent, response:", response.json())
 
-    # Get the current event loop and run the test function
-    loop = asyncio.get_event_loop()
+    # asyncio.get_event_loop() raises RuntimeError on Python 3.12+ when there
+    # is no current event loop (e.g. pytest has not set one up). asyncio.run()
+    # creates a fresh loop, runs the coroutine, and closes it cleanly.
     try:
-        loop.run_until_complete(test_fastapi_server())
+        asyncio.run(test_fastapi_server())
     finally:
         _stop_server_subprocess(process)
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1139,6 +1139,7 @@ def test_spotlight():
 
 @pytest.mark.integration
 def test_files():
+    require_bash_compatible_shell()
     messages = [
         {"role": "user", "type": "message", "content": "Does this file exist?"},
         {
@@ -1303,6 +1304,7 @@ def test_shell_nested_loop_quoting():
 
 @pytest.mark.integration
 def test_delayed_exec():
+    require_bash_compatible_shell()
     interpreter.chat(
         """Can you write a single block of code and execute it that prints something, then delays 1 second, then prints something else? No talk just code, execute the code. Thanks!"""
     )
@@ -1314,6 +1316,7 @@ def test_delayed_exec():
 @pytest.mark.integration
 @pytest.mark.timeout(180)
 def test_nested_loops_and_multiple_newlines():
+    require_bash_compatible_shell()
     messages = interpreter.chat(
         """Can you write a nested for loop in python and run it? Put 1-3 newlines between each line in the python code.
 
@@ -1329,6 +1332,7 @@ Only generate and execute the code. Execute instantly. No explanations. Thanks!"
 
 @pytest.mark.integration
 def test_write_to_file():
+    require_bash_compatible_shell()
     interpreter.chat(
         """Write the word 'Washington' to a .txt file called file.txt. Instantly run the code! Save the file!"""
     )

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1138,15 +1138,19 @@ def test_spotlight():
 
 
 @pytest.mark.integration
-def test_files():
+def test_files(tmp_path):
     require_bash_compatible_shell()
+    # Main used a hardcoded /Users/Killian/... path that only existed on one machine.
+    # tmp_path creates a real file on any OS so the LLM can answer the existence question.
+    image_file = tmp_path / "image.png"
+    image_file.write_bytes(b"fake png content")
     messages = [
         {"role": "user", "type": "message", "content": "Does this file exist?"},
         {
             "role": "user",
             "type": "file",
             "format": "path",
-            "content": "/Users/Killian/image.png",
+            "content": str(image_file),
         },
     ]
     interpreter.chat(messages)
@@ -1331,12 +1335,16 @@ Only generate and execute the code. Execute instantly. No explanations. Thanks!"
 
 
 @pytest.mark.integration
-def test_write_to_file():
+def test_write_to_file(monkeypatch, tmp_path):
     require_bash_compatible_shell()
+    # Run in a temp directory so the LLM-generated file.txt does not land in the
+    # repo root or the developer's home folder. monkeypatch.chdir restores cwd after
+    # the test regardless of pass/fail.
+    monkeypatch.chdir(tmp_path)
     interpreter.chat(
         """Write the word 'Washington' to a .txt file called file.txt. Instantly run the code! Save the file!"""
     )
-    assert os.path.exists("file.txt")
+    assert (tmp_path / "file.txt").exists()
     interpreter.messages = []  # Just reset message history, nothing else for this test
     messages = interpreter.chat(
         """Read file.txt in the current directory and tell me what's in it."""

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -523,45 +523,26 @@ def test_server():
             response = requests.post(post_url, json=settings)
             print("POST request sent, response:", response.json())
 
+            user_start = {"role": "user", "start": True}
+            file_question = {
+                "role": "user",
+                "type": "message",
+                "content": "Does this file exist?",
+            }
+            file_path = {
+                "role": "user",
+                "type": "file",
+                "format": "path",
+                "content": "/something.txt",
+            }
+
             # Sending messages via WebSocket
-            await websocket.send(json.dumps({"role": "user", "start": True}))
-            print("sent", json.dumps({"role": "user", "start": True}))
-            await websocket.send(
-                json.dumps(
-                    {
-                        "role": "user",
-                        "type": "message",
-                        "content": "Does this file exist?",
-                    }
-                )
-            )
-            print(
-                "sent",
-                {
-                    "role": "user",
-                    "type": "message",
-                    "content": "Does this file exist?",
-                },
-            )
-            await websocket.send(
-                json.dumps(
-                    {
-                        "role": "user",
-                        "type": "file",
-                        "format": "path",
-                        "content": "/something.txt",
-                    }
-                )
-            )
-            print(
-                "sent",
-                {
-                    "role": "user",
-                    "type": "file",
-                    "format": "path",
-                    "content": "/something.txt",
-                },
-            )
+            await websocket.send(json.dumps(user_start))
+            print("sent", user_start)
+            await websocket.send(json.dumps(file_question))
+            print("sent", file_question)
+            await websocket.send(json.dumps(file_path))
+            print("sent", file_path)
             await websocket.send(json.dumps({"role": "user", "end": True}))
             print("WebSocket chunks sent")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebases shared test helpers and legacy `test_interpreter.py` hardening onto `main` (post-#111/#115), with **atomic commits** per AGENTS.md.

### Commit series (one idea each)

1. **test(infra): add shared helpers and shell guard regression test** — `tests/helpers.py`, fish-guard unit test, AGENTS.md
2. **test(interpreter): disable conversation_history on module fixture**
3. **test(interpreter): use asyncio.run in server integration tests**
4. **test(interpreter): document go command in test_server math turn**
5. **test(interpreter): stabilize test_server file and image MCQ turns** — `_last_assistant_text` + `auto_run=False` / `custom_instructions` + `or accumulated_content` fallback comments
6. **test(interpreter): DRY test_server file-turn WebSocket debug payloads**
7. **test(interpreter): scope rate-limit sleep to integration tests**
8. **test(interpreter): add linux_ci smoke for shell nested-loop quoting**
9. **test(interpreter): guard integration shell tests with require_bash_compatible_shell**
10. **test(interpreter): use tmp_path for file attachment integration tests** (includes inline comments)
11. **test(interpreter): add docstrings to legacy test_interpreter tests** (docstrings only)
12. **test(interpreter): add pytest timeouts to slow legacy unit tests** (`test_hallucinations`, `test_break_execution` only)

### Notes

- `_last_assistant_text` lives in the MCQ stabilization commit with its usage and the comment explaining `last_assistant = _last_assistant_text(messages) or accumulated_content`.
- Docstrings and `@pytest.mark.timeout(120)` are split into separate commits.
- MCQ stream/message fallback comments are preserved (not removed during docstring pass).

Stacked PRs #110 / #112 remain out of scope here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

