### PR TITLE
Document os mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Run shell commands with -y so the user doesn't have to confirm them.
 print(interpreter.system_message)
 ```
 
+### OS control (experimental)
+
+To control the desktop (mouse, keyboard, screenshots), use **`interpreter --profile os`**—the maintained Classic path (`execute` tool + Python `computer.*` module). The separate **`interpreter --os`** flag runs an older Anthropic computer-use demo with a legacy beta API; see [`docs/guides/os-mode.mdx`](docs/guides/os-mode.mdx).
+
 ### Change your Language Model
 
 Open Interpreter uses [LiteLLM](https://docs.litellm.ai/docs/providers/) to connect to hosted language models.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ print(interpreter.system_message)
 
 ### OS control (experimental)
 
-To control the desktop (mouse, keyboard, screenshots), use **`interpreter --profile os`**—the maintained Classic path (`execute` tool + Python `computer.*` module). The separate **`interpreter --os`** flag runs an older Anthropic computer-use demo with a legacy beta API; see [`docs/guides/os-mode.mdx`](docs/guides/os-mode.mdx).
+Use **`interpreter --profile os`** for desktop control (provider-agnostic, LiteLLM + `computer.*`); the separate `interpreter --os` flag runs a deprecated Anthropic demo. See [OS Mode](docs/guides/os-mode.mdx) for both paths.
 
 ### Change your Language Model
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,7 +53,7 @@ We will review PRs when possible and work with you to integrate your contributio
 Classic has two desktop-control paths—see [OS Mode](guides/os-mode.mdx) for full detail:
 
 - **`interpreter --profile os`** (recommended): normal Classic loop; `execute` tool + Python `computer.*` + terminal `Shell` for bash/cmd. Works with LiteLLM providers.
-- **`interpreter --os`**: separate entry in `interpreter/__init__.py` → `interpreter/computer_use/loop.py`; Anthropic SDK only, legacy beta `computer-use-2024-10-22` / `computer_20241022`. Likely broken on current Claude models until updated.
+- **`interpreter --os`**: separate entry in `interpreter/__init__.py` → `interpreter/computer_use/loop.py`; Anthropic SDK only, deprecated beta `computer-use-2024-10-22` / `computer_20241022`. Broken with current Claude models until updated.
 
 Once you've forked the code and created a new branch for your work, you can run the fork in CLI mode by following these steps:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -48,6 +48,13 @@ We will review PRs when possible and work with you to integrate your contributio
 
 **Note: for anyone testing the new `--local`, `--os`, and `--local --os` modes: a plain `pip install -e .` installs only the base dependencies, so executing those modes can fail when they import an omitted optional dependency. Install the extras for the modes you test with `pip install -e ".[local]"`, `pip install -e ".[os]"`, or `pip install -e ".[local,os]"`. You can edit the system messages for these modes in `interpreter/terminal_interface/profiles/defaults`.**
 
+### OS control on Classic (`main`)
+
+Classic has two desktop-control paths—see [OS Mode](guides/os-mode.mdx) for full detail:
+
+- **`interpreter --profile os`** (recommended): normal Classic loop; `execute` tool + Python `computer.*` + terminal `Shell` for bash/cmd. Works with LiteLLM providers.
+- **`interpreter --os`**: separate entry in `interpreter/__init__.py` → `interpreter/computer_use/loop.py`; Anthropic SDK only, legacy beta `computer-use-2024-10-22` / `computer_20241022`. Likely broken on current Claude models until updated.
+
 Once you've forked the code and created a new branch for your work, you can run the fork in CLI mode by following these steps:
 
 1. CD into the project folder by running `cd open-interpreter`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -48,12 +48,9 @@ We will review PRs when possible and work with you to integrate your contributio
 
 **Note: for anyone testing the new `--local`, `--os`, and `--local --os` modes: a plain `pip install -e .` installs only the base dependencies, so executing those modes can fail when they import an omitted optional dependency. Install the extras for the modes you test with `pip install -e ".[local]"`, `pip install -e ".[os]"`, or `pip install -e ".[local,os]"`. You can edit the system messages for these modes in `interpreter/terminal_interface/profiles/defaults`.**
 
-### OS control on Classic (`main`)
+### OS control
 
-Classic has two desktop-control paths—see [OS Mode](guides/os-mode.mdx) for full detail:
-
-- **`interpreter --profile os`** (recommended): normal Classic loop; `execute` tool + Python `computer.*` + terminal `Shell` for bash/cmd. Works with LiteLLM providers.
-- **`interpreter --os`**: separate entry in `interpreter/__init__.py` → `interpreter/computer_use/loop.py`; Anthropic SDK only, deprecated beta `computer-use-2024-10-22` / `computer_20241022`. Broken with current Claude models until updated.
+Two desktop-control paths exist — see [OS Mode](guides/os-mode.mdx) for full detail: `interpreter --profile os` (maintained, provider-agnostic) and `interpreter --os` (separate deprecated Anthropic demo).
 
 Once you've forked the code and created a new branch for your work, you can run the fork in CLI mode by following these steps:
 

--- a/docs/guides/os-mode.mdx
+++ b/docs/guides/os-mode.mdx
@@ -36,7 +36,7 @@ This path:
 
 ### Legacy API status
 
-The `2024-10-22` beta stack is **legacy**: it is still shipped in this repo, but Anthropic has deprecated it. Current Anthropic models expect newer beta headers (for example `computer-use-2025-01-24` or `computer-use-2025-11-24`) and matching tool types (`computer_20250124`, `bash_20250124`, etc.). **`interpreter --os` may fail or behave unpredictably with current Claude models** until this code is updated.
+The `2024-10-22` beta stack is **legacy**: it is still shipped in this repo, but Anthropic no longer accepts it. Their [current docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) list only `computer-use-2025-01-24` and `computer-use-2025-11-24` beta headers (with matching `computer_20250124`/`computer_20251124` tool types); the `2024-10-22` beta and `computer_20241022` tool type are gone. Sending them with a current model is rejected by the API, so **`interpreter --os` fails with current Claude models** until this code is updated to a supported beta.
 
 See [Anthropic's computer use documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) for supported beta headers and tool types.
 

--- a/docs/guides/os-mode.mdx
+++ b/docs/guides/os-mode.mdx
@@ -2,7 +2,7 @@
 title: OS Mode
 ---
 
-Open Interpreter on Classic (`main`) has **two separate ways** to control the desktop. They use different code and APIs.
+Open Interpreter (the Python edition) has **two separate ways** to control the desktop. They use different code and APIs.
 
 ## Recommended: profile-based OS control
 
@@ -18,7 +18,7 @@ This is the normal Classic interpreter loop (`respond.py`):
 - GUI actions use the Python **`computer.*` module** (PyAutoGUI, screenshots, etc.), as described in `interpreter/terminal_interface/profiles/defaults/os.py`.
 - Shell commands run through **`interpreter/core/computer/terminal/`** (a persistent `Shell` subprocess). This is the same execution path as everyday Classic use—not Anthropic's computer-use beta API.
 
-This path works with LiteLLM-supported models (tool calling or markdown code blocks). Profiles set `interpreter.os = True` and `auto_run = True`.
+This path works with any model LiteLLM supports — OpenAI, Anthropic, local, and others — using tool calling or markdown code blocks. Profiles set `interpreter.os = True` and `auto_run = True`.
 
 ## Experimental: `interpreter --os` (Anthropic computer-use demo)
 
@@ -36,7 +36,7 @@ This path:
 
 ### Legacy API status
 
-The `2024-10-22` beta stack is **legacy**. Current Anthropic models expect newer beta headers (for example `computer-use-2025-01-24` or `computer-use-2025-11-24`) and matching tool types (`computer_20250124`, `bash_20250124`, etc.). **`interpreter --os` may fail or behave unpredictably with current Claude models** until this code is updated.
+The `2024-10-22` beta stack is **legacy**: it is still shipped in this repo, but Anthropic has deprecated it. Current Anthropic models expect newer beta headers (for example `computer-use-2025-01-24` or `computer-use-2025-11-24`) and matching tool types (`computer_20250124`, `bash_20250124`, etc.). **`interpreter --os` may fail or behave unpredictably with current Claude models** until this code is updated.
 
 See [Anthropic's computer use documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) for supported beta headers and tool types.
 

--- a/docs/guides/os-mode.mdx
+++ b/docs/guides/os-mode.mdx
@@ -2,16 +2,48 @@
 title: OS Mode
 ---
 
-OS mode is a highly experimental mode that allows Open Interpreter to control the operating system visually through the mouse and keyboard. It provides a multimodal LLM like GPT-4V with the necessary tools to capture screenshots of the display and interact with on-screen elements such as text and icons. It will try to use the most direct method to achieve the goal, like using spotlight on Mac to open applications, and using query parameters in the URL to open websites with additional information.
+Open Interpreter on Classic (`main`) has **two separate ways** to control the desktop. They use different code and APIs.
 
-OS mode is a work in progress, if you have any suggestions or experience issues, please reach out on our [Discord](https://discord.com/invite/6p3fD6rBVm).
+## Recommended: profile-based OS control
 
-To enable OS Mode, run the interpreter with the `--os` flag:
+```bash
+interpreter --profile os
+```
+
+Related profiles include `local-os`, `codestral-os`, and `llama3-os` (combined with `--local`, `--codestral`, or `--llama3`).
+
+This is the normal Classic interpreter loop (`respond.py`):
+
+- The model uses the **`execute` tool** (or markdown code blocks) with languages such as `python` or `shell`.
+- GUI actions use the Python **`computer.*` module** (PyAutoGUI, screenshots, etc.), as described in `interpreter/terminal_interface/profiles/defaults/os.py`.
+- Shell commands run through **`interpreter/core/computer/terminal/`** (a persistent `Shell` subprocess). This is the same execution path as everyday Classic use—not Anthropic's computer-use beta API.
+
+This path works with LiteLLM-supported models (tool calling or markdown code blocks). Profiles set `interpreter.os = True` and `auto_run = True`.
+
+## Experimental: `interpreter --os` (Anthropic computer-use demo)
 
 ```bash
 interpreter --os
 ```
 
-Please note that screen recording permissions must be enabled for your terminal application for OS mode to work properly to work.
+Importing the package with `--os` in `sys.argv` exits early into **`interpreter/computer_use/loop.py`**—a port of [Anthropic's computer-use quickstart](https://github.com/anthropics/anthropic-quickstarts/tree/main/computer-use-demo)—**before** the normal CLI or `--profile os` runs.
 
-OS mode does not currently support multiple displays.
+This path:
+
+- Calls the **Anthropic SDK directly** (not LiteLLM).
+- Requires an **Anthropic API key**.
+- Sends the beta header **`computer-use-2024-10-22`** and registers **`ComputerTool`** (`computer_20241022`) only. **`BashTool`** (`bash_20241022`) and **`EditTool`** exist under `interpreter/computer_use/tools/` but are **commented out** in `loop.py`.
+
+### Legacy API status
+
+The `2024-10-22` beta stack is **legacy**. Current Anthropic models expect newer beta headers (for example `computer-use-2025-01-24` or `computer-use-2025-11-24`) and matching tool types (`computer_20250124`, `bash_20250124`, etc.). **`interpreter --os` may fail or behave unpredictably with current Claude models** until this code is updated.
+
+See [Anthropic's computer use documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) for supported beta headers and tool types.
+
+### Requirements
+
+Screen recording permissions must be enabled for your terminal application. Neither path currently supports multiple displays.
+
+---
+
+OS control is experimental. For suggestions or issues, reach out on [Discord](https://discord.com/invite/6p3fD6rBVm).

--- a/docs/guides/os-mode.mdx
+++ b/docs/guides/os-mode.mdx
@@ -36,7 +36,14 @@ This path:
 
 ### Legacy API status
 
-The `2024-10-22` beta stack is **legacy**: it is still shipped in this repo, but Anthropic no longer accepts it. Their [current docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) list only `computer-use-2025-01-24` and `computer-use-2025-11-24` beta headers (with matching `computer_20250124`/`computer_20251124` tool types); the `2024-10-22` beta and `computer_20241022` tool type are gone. Sending them with a current model is rejected by the API, so **`interpreter --os` fails with current Claude models** until this code is updated to a supported beta.
+The `2024-10-22` beta stack is **legacy**: it is still shipped in this repo, but Anthropic no longer accepts it. Their [current docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) list only `computer-use-2025-01-24` and `computer-use-2025-11-24` beta headers with the matching [tool types](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference):
+
+| Beta header | Computer tool | Bash tool |
+| ----------- | ------------- | --------- |
+| `computer-use-2025-01-24` | `computer_20250124` | `bash_20250124` |
+| `computer-use-2025-11-24` | `computer_20251124` | `bash_20250124` |
+
+Sending the removed `2024-10-22` beta with a current model is rejected by the API, so **`interpreter --os` fails with current Claude models**. Updating to a 2025 beta is not just a header change: the pinned `anthropic` SDK (`>=0.37.1,<0.38`) only exposes the `2024-10-22` types, so the 2025 mappings require an SDK and implementation update.
 
 See [Anthropic's computer use documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) for supported beta headers and tool types.
 

--- a/docs/guides/os-mode.mdx
+++ b/docs/guides/os-mode.mdx
@@ -40,6 +40,19 @@ The `2024-10-22` beta stack is **legacy**: it is still shipped in this repo, but
 
 See [Anthropic's computer use documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) for supported beta headers and tool types.
 
+### `--os` vs `--profile os` (naming collision)
+
+Both desktop-control paths share the "os" name, and the CLI makes it worse: the help text for `--os` describes it as a *shortcut for `--profile os`*, but `--os` is intercepted in `interpreter/__init__.py` **before** the CLI runs and routes to the Anthropic loop instead. So `--os` and `--profile os` are different commands:
+
+- `interpreter --os` → Anthropic computer-use demo (broken with current models).
+- `interpreter --profile os` → provider-agnostic OS control via LiteLLM + the `computer.*` module.
+
+Historically, "OS mode" referred to the Anthropic `--os` path; the provider-agnostic `--profile os` is the maintained one.
+
+### Future direction
+
+The Anthropic-specific `--os` path is slated for removal. Desktop control should stay provider-agnostic via `--profile os`; the underlying automation stack (currently PyAutoGUI pixel-matching) is a candidate for revisiting with OS-native accessibility/UI-tree automation.
+
 ### Requirements
 
 Screen recording permissions must be enabled for your terminal application. Neither path currently supports multiple displays.

--- a/docs/guides/os-mode.mdx
+++ b/docs/guides/os-mode.mdx
@@ -36,7 +36,7 @@ This path:
 
 ### Legacy API status
 
-The `2024-10-22` beta stack is **legacy**: it is still shipped in this repo, but Anthropic no longer accepts it. Their [current docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) list only `computer-use-2025-01-24` and `computer-use-2025-11-24` beta headers with the matching [tool types](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference):
+The `2024-10-22` beta stack is **deprecated**: it is still shipped in this repo, but Anthropic no longer accepts it. Their [current docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool) list only `computer-use-2025-01-24` and `computer-use-2025-11-24` beta headers with the matching [tool types](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference):
 
 | Beta header | Computer tool | Bash tool |
 | ----------- | ------------- | --------- |

--- a/docs/settings/all-settings.mdx
+++ b/docs/settings/all-settings.mdx
@@ -319,7 +319,7 @@ llm:
 
 ### OS Mode
 
-Enables profile-based OS control (Python `computer.*` module, vision, `auto_run`) via the `os` profile. See [OS Mode](/guides/os-mode).
+`os: true` sets `interpreter.os = True`, enabling the provider-agnostic desktop-control path (Python `computer.*` module, vision, `auto_run`) — this is what the `os` profile does. See [OS Mode](/guides/os-mode).
 
 <CodeGroup>
 
@@ -333,7 +333,7 @@ os: true
 
 </CodeGroup>
 
-Note: `interpreter --os` is **not** equivalent to `os: true`. The `--os` flag runs a separate legacy Anthropic computer-use demo (broken with current models); the `os` profile setting is what enables the provider-agnostic desktop control above.
+Note: `interpreter --os` is **not** equivalent to `os: true`. The `--os` flag runs a separate deprecated Anthropic computer-use demo (broken with current models); `os: true` is the profile setting that enables the provider-agnostic desktop control above.
 
 ### Version
 

--- a/docs/settings/all-settings.mdx
+++ b/docs/settings/all-settings.mdx
@@ -319,7 +319,7 @@ llm:
 
 ### OS Mode
 
-`os: true` sets `interpreter.os = True`, enabling the provider-agnostic desktop-control path (Python `computer.*` module, vision, `auto_run`) — this is what the `os` profile does. See [OS Mode](/guides/os-mode).
+`os: true` sets `interpreter.os = True`, enabling the provider-agnostic desktop-control path (Python `computer.*` module, vision, `auto_run`) — this is what the `os` profile does. The separate `interpreter --os` flag is a deprecated Anthropic demo, not the same thing. See [OS Mode](/guides/os-mode).
 
 <CodeGroup>
 
@@ -332,8 +332,6 @@ os: true
 ```
 
 </CodeGroup>
-
-Note: `interpreter --os` is **not** equivalent to `os: true`. The `--os` flag runs a separate deprecated Anthropic computer-use demo (broken with current models); `os: true` is the profile setting that enables the provider-agnostic desktop control above.
 
 ### Version
 

--- a/docs/settings/all-settings.mdx
+++ b/docs/settings/all-settings.mdx
@@ -319,7 +319,7 @@ llm:
 
 ### OS Mode
 
-Enables OS mode for multimodal models. Currently not available in Python. Check out more information on OS mode [here](/guides/os-mode).
+Enables profile-based OS control (Python `computer.*` module, vision, `auto_run`). For the separate Anthropic computer-use demo, use the `--os` CLI flag instead. See [OS Mode](/guides/os-mode).
 
 <CodeGroup>
 

--- a/docs/settings/all-settings.mdx
+++ b/docs/settings/all-settings.mdx
@@ -319,12 +319,12 @@ llm:
 
 ### OS Mode
 
-Enables profile-based OS control (Python `computer.*` module, vision, `auto_run`). For the separate Anthropic computer-use demo, use the `--os` CLI flag instead. See [OS Mode](/guides/os-mode).
+Enables profile-based OS control (Python `computer.*` module, vision, `auto_run`) via the `os` profile. See [OS Mode](/guides/os-mode).
 
 <CodeGroup>
 
 ```bash Terminal
-interpreter --os
+interpreter --profile os
 ```
 
 ```yaml Profile
@@ -332,6 +332,8 @@ os: true
 ```
 
 </CodeGroup>
+
+Note: `interpreter --os` is **not** equivalent to `os: true`. The `--os` flag runs a separate legacy Anthropic computer-use demo (broken with current models); the `os` profile setting is what enables the provider-agnostic desktop control above.
 
 ### Version
 

--- a/docs/usage/terminal/arguments.mdx
+++ b/docs/usage/terminal/arguments.mdx
@@ -43,25 +43,11 @@ vision: true
 
 #### `--os` or `-o`
 
-Starts the **Anthropic computer-use demo** in `interpreter/computer_use/` (legacy beta API; requires an Anthropic API key). This is **not** the same as profile-based OS control.
+Runs the deprecated **Anthropic computer-use demo** (`interpreter/computer_use/`; requires an Anthropic API key) — **not** the same as profile-based OS control. For the maintained provider-agnostic path, use `--profile os`. See [OS Mode](/guides/os-mode).
 
-For the maintained Classic path (LiteLLM, `execute` tool, Python `computer.*` module), use **`--profile os`** instead. See [OS Mode](/guides/os-mode).
-
-<CodeGroup>
-
-    ```bash Terminal
-    interpreter --os
-    ```
-
-    ```yaml Config
-    os: true
-    ```
-
-</CodeGroup>
-
-<Info>
-Setting `os: true` in a YAML profile enables the **profile-based** OS loop, not the `--os` Anthropic demo. The `--os` CLI flag is intercepted in `interpreter/__init__.py` before the normal CLI runs.
-</Info>
+```bash Terminal
+interpreter --os
+```
 
 ---
 

--- a/docs/usage/terminal/arguments.mdx
+++ b/docs/usage/terminal/arguments.mdx
@@ -43,7 +43,9 @@ vision: true
 
 #### `--os` or `-o`
 
-Enables OS mode for multimodal models. Defaults to GPT-4-turbo.
+Starts the **Anthropic computer-use demo** in `interpreter/computer_use/` (legacy beta API; requires an Anthropic API key). This is **not** the same as profile-based OS control.
+
+For the maintained Classic path (LiteLLM, `execute` tool, Python `computer.*` module), use **`--profile os`** instead. See [OS Mode](/guides/os-mode).
 
 <CodeGroup>
 
@@ -56,6 +58,10 @@ Enables OS mode for multimodal models. Defaults to GPT-4-turbo.
     ```
 
 </CodeGroup>
+
+<Info>
+Setting `os: true` in a YAML profile enables the **profile-based** OS loop, not the `--os` Anthropic demo. The `--os` CLI flag is intercepted in `interpreter/__init__.py` before the normal CLI runs.
+</Info>
 
 ---
 

--- a/interpreter/computer_use/loop.py
+++ b/interpreter/computer_use/loop.py
@@ -1,4 +1,9 @@
 """
+Anthropic computer-use demo loop (entered via `interpreter --os` in __init__.py).
+
+Not the same as `--profile os`, which uses Classic's execute tool + computer.* APIs.
+Uses legacy beta computer-use-2024-10-22 / computer_20241022; see docs/guides/os-mode.mdx.
+
 Based on Anthropic's computer use example at https://github.com/anthropics/anthropic-quickstarts/blob/main/computer-use-demo/computer_use_demo/loop.py
 """
 


### PR DESCRIPTION
### Describe the changes you have made:

### Reference any relevant issues (e.g. "Fixes #000"):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the distinction between the recommended `--profile os` desktop-control mode and the deprecated Anthropic-only `--os` computer-use demo.
  - Added guidance on commands, provider and model compatibility, configuration, permissions, display limitations, and legacy tooling.
  - Documented YAML `os: true` behavior and clarified CLI handling.
  - Added guidance for choosing the appropriate provider-agnostic desktop-control path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->