### PR TITLE
test: strengthen weak assertions from test-suite audit

### DIFF
--- a/tests/computer_use/tools/test_collection.py
+++ b/tests/computer_use/tools/test_collection.py
@@ -40,6 +40,7 @@ def test_tool_collection_unknown_tool_returns_failure():
     collection = ToolCollection(DummyTool())
     result = asyncio.run(collection.run(name="missing", tool_input={}))
     assert isinstance(result, ToolFailure)
+    assert result.error == "Tool missing is invalid"
 
 
 def test_tool_collection_tool_error_becomes_failure():

--- a/tests/core/computer/ai/test_ai_helpers.py
+++ b/tests/core/computer/ai/test_ai_helpers.py
@@ -3,10 +3,17 @@ from interpreter.core.computer.ai.ai import chunk_responses, split_into_chunks
 
 def test_split_into_chunks_with_tiktoken():
     """split_into_chunks splits long text into overlapping token-sized windows."""
+    import tiktoken
+
     llm = type("Llm", (), {"model": "gpt-4"})()  # tiktoken encoding name, not API model
     text = "word " * 100
-    chunks = split_into_chunks(text, tokens=20, llm=llm, overlap=5)
+    tokens = 20
+    overlap = 5
+    chunks = split_into_chunks(text, tokens=tokens, llm=llm, overlap=overlap)
+    encoding = tiktoken.encoding_for_model(llm.model)
     assert len(chunks) > 1
+    assert all(chunk for chunk in chunks)
+    assert all(len(encoding.encode(chunk)) <= tokens for chunk in chunks)
     joined = " ".join(chunks)
     assert joined[:20] == text[:20]
     assert joined[-20:] == text[-20:]

--- a/tests/core/computer/calendar/test_calendar.py
+++ b/tests/core/computer/calendar/test_calendar.py
@@ -42,4 +42,4 @@ def test_create_event_non_macos():
             datetime.datetime(2024, 1, 1, 9, 0),
             datetime.datetime(2024, 1, 1, 10, 0),
         )
-    assert "MacOS" in result
+    assert result == "This method is only supported on MacOS"

--- a/tests/core/computer/files/test_get_close_matches.py
+++ b/tests/core/computer/files/test_get_close_matches.py
@@ -13,7 +13,7 @@ def test_typo_returns_closest_phrases():
     filedata = "foobar baz qux foobar"
     matches = get_close_matches_in_text("foobaz", filedata)
     assert len(matches) <= 3
-    assert any("foobar" in match for match in matches)
+    assert matches[0] == "foobar"
 
 
 def test_respects_n_limit():

--- a/tests/core/llm/test_run_text_llm.py
+++ b/tests/core/llm/test_run_text_llm.py
@@ -40,7 +40,10 @@ def test_code_block_yields_code_chunks():
         ]
     )
     result = list(run_text_llm(llm, {"messages": [{"content": "system"}]}))
-    assert any(r["type"] == "code" and r["format"] == "python" for r in result)
+    assert result == [
+        {"type": "code", "format": "python", "content": "```\n"},
+        {"type": "code", "format": "python", "content": "print(1)\n"},
+    ]
 
 
 def test_execution_instructions_appended():

--- a/tests/core/llm/test_run_tool_calling_llm.py
+++ b/tests/core/llm/test_run_tool_calling_llm.py
@@ -40,7 +40,13 @@ def test_orphaned_function_response_gets_synthetic_tool_call():
                  "content": "late output"}]
     result = process_messages(messages)
     assert result[0]["role"] == "assistant"
-    assert result[1]["role"] == "tool"
+    assert result[0]["tool_calls"][0]["id"] == "toolu_1"
+    assert result[1] == {
+        "role": "tool",
+        "name": "execute",
+        "content": "late output",
+        "tool_call_id": "toolu_1",
+    }
 
 
 def test_passthrough_message_unchanged():

--- a/tests/core/llm/utils/test_convert_to_openai_messages.py
+++ b/tests/core/llm/utils/test_convert_to_openai_messages.py
@@ -149,7 +149,7 @@ def test_console_output_assistant_sender(interpreter):
         messages, function_calling=False, interpreter=interpreter
     )
     assert result[0]["role"] == "assistant"
-    assert "result" in result[0]["content"]
+    assert result[0]["content"] == "```output\nresult\n```"
 
 
 def test_vision_false_skips_base64_image(interpreter):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited the `tests/` suite (70 `test_*.py` files) against assertion-quality criteria adapted for this repo:

- **Package layout:** implementation in `interpreter/` (not `src/`), tests mirror that tree under `tests/`
- **Markers:** `integration`, `linux_ci`, `windows_ci`, `darwin_ci` gate optional/slow tests
- **Helpers:** shared fixtures in `tests/helpers.py`

Most tests are well-structured (mocked LLM streams, explicit expected dicts, `pytest.raises(..., match=...)`). A handful had assertions loose enough to pass on wrong behavior.

## Findings (not fixed — informational)

| Severity | Count | Examples |
|----------|-------|----------|
| CRITICAL | 0 | No tests compute expected values by re-calling the function under test |
| HIGH | 2 | `test_tool_collection_unknown_tool_returns_failure` (type-only), `test_create_event_non_macos` (substring) |
| MEDIUM | ~15 | Substring/`in` checks on formatted output, `len > N` without value checks, `test_get_ram_info_format` (format keywords only) |

Manual `assert False` stubs in `test_interpreter.py` are intentional local-only smokes, not CI failures.

## Changes in this PR

Strengthened 7 tests where the fix was clear and low-risk:

1. **`test_tool_collection_unknown_tool_returns_failure`** — assert `result.error == "Tool missing is invalid"`
2. **`test_orphaned_function_response_gets_synthetic_tool_call`** — assert full tool message dict including `tool_call_id`
3. **`test_typo_returns_closest_phrases`** — assert `matches[0] == "foobar"` (not just substring)
4. **`test_create_event_non_macos`** — assert full platform message (matches sibling `get_events` test)
5. **`test_console_output_assistant_sender`** — assert exact fenced output string
6. **`test_split_into_chunks_with_tiktoken`** — assert non-empty chunks respect token budget
7. **`test_code_block_yields_code_chunks`** — assert full parsed chunk list instead of `any(...)`

## Testing

- `pytest` on all modified files: 22 passed
- Full `pytest -m "not integration"`: 301 passed (2 unrelated HTML/React subprocess timeouts in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

