### PR TITLE
test: add edge-case coverage from test-suite audit

### DIFF
--- a/tests/core/computer/ai/test_ai_helpers.py
+++ b/tests/core/computer/ai/test_ai_helpers.py
@@ -46,3 +46,24 @@ def test_chunk_responses_oversized_single_response():
     big = "x" * 5000
     result = chunk_responses([big], tokens=50, llm=llm)
     assert result == [big]
+
+
+def test_split_into_chunks_empty_text_returns_empty_list():
+    """Empty input text produces no chunks."""
+    llm = type("Llm", (), {"model": "gpt-4"})()
+    assert split_into_chunks("", tokens=20, llm=llm, overlap=5) == []
+
+
+def test_chunk_responses_empty_list_returns_empty():
+    """An empty responses list produces an empty result list."""
+    llm = type("Llm", (), {"model": "gpt-4"})()
+    assert chunk_responses([], tokens=100, llm=llm) == []
+
+
+def test_split_into_chunks_overlap_greater_than_tokens_returns_empty():
+    """When overlap exceeds tokens the tiktoken step is negative and yields no chunks.
+
+    This documents current behavior; callers should keep overlap < tokens.
+    """
+    llm = type("Llm", (), {"model": "gpt-4"})()
+    assert split_into_chunks("abcdefghij", tokens=5, llm=llm, overlap=6) == []

--- a/tests/core/computer/files/test_get_close_matches.py
+++ b/tests/core/computer/files/test_get_close_matches.py
@@ -26,3 +26,19 @@ def test_respects_n_limit():
 def test_empty_filedata_returns_empty():
     """Empty file text yields no close matches regardless of the query."""
     assert get_close_matches_in_text("anything", "") == []
+
+
+def test_empty_original_text_matches_every_position():
+    """An empty query matches every sliding window (including empty phrases) in file text."""
+    matches = get_close_matches_in_text("", "one two three")
+    assert matches == ["", "", ""]
+
+
+def test_query_longer_than_filedata_returns_empty():
+    """When the query has more words than the file, no phrase window can match."""
+    assert get_close_matches_in_text("one two three four", "one two") == []
+
+
+def test_n_zero_returns_empty():
+    """n=0 requests zero results even when close matches exist."""
+    assert get_close_matches_in_text("one", "one two three", n=0) == []

--- a/tests/core/llm/test_run_tool_calling_llm.py
+++ b/tests/core/llm/test_run_tool_calling_llm.py
@@ -53,3 +53,43 @@ def test_passthrough_message_unchanged():
     """Messages that are already in tool-calling format are returned without modification."""
     messages = [{"role": "user", "content": "hello"}]
     assert process_messages(messages) == messages
+
+
+def test_process_messages_empty_list():
+    """An empty message list is returned unchanged."""
+    assert process_messages([]) == []
+
+
+def test_process_messages_mutates_function_call_in_place():
+    """function_call is popped and replaced with tool_calls on the original message dict."""
+    message = {
+        "role": "assistant",
+        "content": "",
+        "function_call": {"name": "execute", "arguments": "{}"},
+    }
+    process_messages([message])
+    assert "function_call" not in message
+    assert message["tool_calls"][0]["id"] == "toolu_1"
+
+
+def test_sequential_function_calls_get_incrementing_tool_ids():
+    """Each function_call/function pair receives a new toolu_N id in order."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "function_call": {"name": "execute", "arguments": "{}"},
+        },
+        {"role": "function", "name": "execute", "content": "first"},
+        {
+            "role": "assistant",
+            "content": "",
+            "function_call": {"name": "execute", "arguments": "{}"},
+        },
+        {"role": "function", "name": "execute", "content": "second"},
+    ]
+    result = process_messages(messages)
+    assert result[0]["tool_calls"][0]["id"] == "toolu_1"
+    assert result[1]["tool_call_id"] == "toolu_1"
+    assert result[2]["tool_calls"][0]["id"] == "toolu_2"
+    assert result[3]["tool_call_id"] == "toolu_2"

--- a/tests/core/llm/utils/test_parse_partial_json.py
+++ b/tests/core/llm/utils/test_parse_partial_json.py
@@ -54,3 +54,14 @@ def test_parse_none_raises_type_error():
     """None is a caller bug, not incomplete JSON — must raise, not return None."""
     with pytest.raises(TypeError):
         parse_partial_json(None)
+
+
+def test_parse_whitespace_only_returns_none():
+    """Whitespace-only input is not valid JSON and returns None."""
+    assert parse_partial_json("   ") is None
+
+
+def test_parse_truncated_nested_object():
+    """A truncated nested object is repaired by closing inner and outer braces."""
+    result = parse_partial_json('{"a": {"b": 1')
+    assert result == {"a": {"b": 1}}

--- a/tests/core/utils/test_truncate_output.py
+++ b/tests/core/utils/test_truncate_output.py
@@ -66,3 +66,16 @@ def test_non_positive_max_output_chars_rejected():
         truncate_output("hello", max_output_chars=0)
     with pytest.raises(ValueError, match="positive integer"):
         truncate_output("hello", max_output_chars=-1)
+
+
+def test_empty_string_unchanged():
+    """Empty output is returned verbatim without adding a truncation banner."""
+    assert truncate_output("") == ""
+
+
+def test_small_max_chars_truncates_short_output():
+    """Very small max_output_chars still truncates when data exceeds the limit."""
+    data = "abcdefgh"
+    result = truncate_output(data, max_output_chars=4)
+    assert result.startswith("Output truncated (8 characters total)")
+    assert "[...]" in result

--- a/tests/terminal_interface/utils/test_count_tokens.py
+++ b/tests/terminal_interface/utils/test_count_tokens.py
@@ -49,3 +49,18 @@ def test_count_messages_tokens_sums_message_fields():
             )
     assert tokens == 14
     assert cost == 0.01
+
+
+def test_count_tokens_empty_string_returns_zero():
+    """count_tokens returns 0 for empty text when the encoder yields no tokens."""
+    mock_encoder = mock.Mock()
+    mock_encoder.encode.return_value = []
+    with mock.patch.object(ct, "tiktoken") as mock_tiktoken:
+        mock_tiktoken.encoding_for_model.return_value = mock_encoder
+        assert ct.count_tokens("") == 0
+
+
+def test_count_messages_tokens_empty_returns_zero():
+    """count_messages_tokens returns (0, 0) for an empty message list."""
+    with mock.patch.object(ct, "token_cost", return_value=0.0):
+        assert ct.count_messages_tokens(messages=[]) == (0, 0.0)

--- a/tests/terminal_interface/utils/test_export_to_markdown.py
+++ b/tests/terminal_interface/utils/test_export_to_markdown.py
@@ -27,3 +27,22 @@ def test_export_to_markdown_writes_file(tmp_path):
     messages = [{"role": "user", "type": "message", "content": "Test"}]
     export_to_markdown(messages, str(path))
     assert path.read_text() == messages_to_markdown(messages)
+
+
+def test_empty_messages_returns_empty_string():
+    """An empty conversation exports to an empty markdown string."""
+    assert messages_to_markdown([]) == ""
+
+
+def test_console_block_rendered():
+    """Console output messages are wrapped in a fenced block using their format."""
+    messages = [
+        {
+            "role": "assistant",
+            "type": "console",
+            "format": "output",
+            "content": "printed",
+        }
+    ]
+    md = messages_to_markdown(messages)
+    assert md == "## assistant\n\n```output\nprinted\n```\n\n"

--- a/tests/terminal_interface/utils/test_find_image_path.py
+++ b/tests/terminal_interface/utils/test_find_image_path.py
@@ -16,3 +16,8 @@ def test_find_image_path_returns_longest_existing(tmp_path):
 def test_find_image_path_none_when_missing():
     """find_image_path returns None when no referenced image file exists."""
     assert find_image_path("No images in this text.") is None
+
+
+def test_find_image_path_empty_text_returns_none():
+    """find_image_path returns None for empty input."""
+    assert find_image_path("") is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Edge-case coverage audit of `interpreter/` vs `tests/` (116 implementation modules, 70 test files). Findings are in the PR discussion; this PR adds **18 new tests** for the highest-impact gaps in already-tested utility functions.

## Modules covered by new tests

| Module | New edge cases |
|--------|----------------|
| `truncate_output.py` | `data=""`, `max_output_chars=4` on short strings |
| `parse_partial_json.py` | whitespace-only input, truncated nested object |
| `files.get_close_matches_in_text` | empty query, query longer than file, `n=0` |
| `run_tool_calling_llm.process_messages` | `[]`, in-place `function_call` mutation, sequential `toolu_N` IDs |
| `ai.split_into_chunks` / `chunk_responses` | empty inputs, `overlap > tokens` quirk |
| `export_to_markdown.messages_to_markdown` | `messages=[]`, `type="console"` |
| `find_image_path` | `text=""` |
| `count_tokens` | `text=""`, `messages=[]` |

## Not in scope (documented in audit)

- Untested modules: `browser/`, `clipboard/`, `display/`, most `profiles/defaults/`, `terminal_interface.py`
- `calendar.py` datetime edge cases (DST, naive vs aware) — only platform guards tested
- Network/API failure paths in `llm.py` / LiteLLM integration
- `convert_to_openai_messages` shrink_images / missing image path (needs fixture images)

## Testing

- `pytest` on all 8 modified test files: 53 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

