### PR TITLE
fix: reject non-positive max_output values

### DIFF
--- a/interpreter/core/core.py
+++ b/interpreter/core/core.py
@@ -151,6 +151,18 @@ class OpenInterpreter:
         return self.messages[self.last_messages_count :]
 
     @property
+    def max_output(self):
+        return self._max_output
+
+    @max_output.setter
+    def max_output(self, value):
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError(
+                f"max_output must be a positive integer, got {value!r}"
+            )
+        self._max_output = value
+
+    @property
     def anonymous_telemetry(self) -> bool:
         return not self.disable_telemetry and not self.offline
 

--- a/interpreter/core/utils/truncate_output.py
+++ b/interpreter/core/utils/truncate_output.py
@@ -1,4 +1,9 @@
 def truncate_output(data, max_output_chars=2800, add_scrollbars=False):
+    if max_output_chars <= 0:
+        raise ValueError(
+            f"max_output must be a positive integer, got {max_output_chars!r}"
+        )
+
     # if "@@@DO_NOT_TRUNCATE@@@" in data:
     #     return data
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from interpreter import OpenInterpreter
 
 
@@ -40,3 +42,15 @@ def test_streaming_chat_list_replaces_messages():
     with mock.patch.object(interpreter, "_respond_and_store", return_value=iter([])):
         list(interpreter._streaming_chat(message=new_messages, display=False))
     assert interpreter.messages == new_messages
+
+
+def test_max_output_must_be_positive_integer():
+    """max_output rejects zero, negatives, and non-integers at construction and assignment."""
+    with pytest.raises(ValueError, match="positive integer"):
+        OpenInterpreter(max_output=0)
+    with pytest.raises(ValueError, match="positive integer"):
+        OpenInterpreter(max_output=-100)
+
+    interpreter = OpenInterpreter()
+    with pytest.raises(ValueError, match="positive integer"):
+        interpreter.max_output = 0

--- a/tests/core/utils/test_truncate_output.py
+++ b/tests/core/utils/test_truncate_output.py
@@ -1,5 +1,7 @@
 from interpreter.core.utils.truncate_output import truncate_output
 
+import pytest
+
 
 def test_short_output_unchanged():
     """Output within the character limit is returned verbatim."""
@@ -43,3 +45,11 @@ def test_exactly_at_limit_not_truncated():
     """Output at exactly the character limit is not truncated."""
     data = "c" * 2800
     assert truncate_output(data, max_output_chars=2800) == data
+
+
+def test_non_positive_max_output_chars_rejected():
+    """max_output must be positive; zero and negative values raise ValueError."""
+    with pytest.raises(ValueError, match="positive integer"):
+        truncate_output("hello", max_output_chars=0)
+    with pytest.raises(ValueError, match="positive integer"):
+        truncate_output("hello", max_output_chars=-1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`max_output` in profiles / `interpreter.max_output` controls how much code output is kept for the LLM. Setting it to `0` or a negative number produced broken truncation (essentially zero useful output) with no clear error.

## Changes

- `truncate_output()` raises `ValueError` when `max_output_chars <= 0`
- `OpenInterpreter.max_output` is now a property that rejects non-positive integers at construction and assignment

## Note

Unicode/emoji truncation tests are in a separate PR (#128 or new number).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

