### PR TITLE
fix: separate consecutive user messages in %markdown export

### DIFF
--- a/interpreter/terminal_interface/utils/export_to_markdown.py
+++ b/interpreter/terminal_interface/utils/export_to_markdown.py
@@ -11,17 +11,18 @@ def messages_to_markdown(messages: list[dict]) -> str:
     previous_role = None
     for chunk in messages:
         current_role = chunk["role"]
+
+        # User messages always get their own header, even when consecutive.
+        if chunk["role"] == "user":
+            markdown_content += f"## {current_role}\n\n{chunk['content']}\n\n"
+            previous_role = current_role
+            continue
+
         if current_role == previous_role:
             rendered_chunk = ""
         else:
             rendered_chunk = f"## {current_role}\n\n"
             previous_role = current_role
-
-        # User query message
-        if chunk["role"] == "user":
-            rendered_chunk += chunk["content"] + "\n\n"
-            markdown_content += rendered_chunk
-            continue
 
         # Message
         if chunk["type"] == "message":

--- a/tests/terminal_interface/utils/test_export_to_markdown.py
+++ b/tests/terminal_interface/utils/test_export_to_markdown.py
@@ -12,6 +12,16 @@ def test_user_message_gets_role_header():
     assert "Hello" in md
 
 
+def test_consecutive_user_messages_each_get_header():
+    """Two user messages in a row each get their own ## user section in the export."""
+    messages = [
+        {"role": "user", "type": "message", "content": "First"},
+        {"role": "user", "type": "message", "content": "Second"},
+    ]
+    md = messages_to_markdown(messages)
+    assert md == "## user\n\nFirst\n\n## user\n\nSecond\n\n"
+
+
 def test_code_block_rendered():
     """Assistant code messages are wrapped in a fenced code block with the format language."""
     messages = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`%markdown` export merged consecutive user messages into one block because `messages_to_markdown` only printed a `## user` header when the role changed.

## Changes

Each user message now always gets its own `## user` section, even when two user turns appear back-to-back (allowed by some APIs).

## Testing

New test: `test_consecutive_user_messages_each_get_header`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

