### PR TITLE
test: truncate_output handles Unicode and emoji

### DIFF
--- a/tests/core/utils/test_truncate_output.py
+++ b/tests/core/utils/test_truncate_output.py
@@ -51,7 +51,7 @@ def test_unicode_output_unchanged_when_short():
 
 
 def test_unicode_output_truncates_without_error():
-    """Long Unicode output truncates cleanly without breaking surrogate pairs."""
+    """Long emoji output truncates without error; head/tail still contain valid emoji."""
     data = "✅" * 2000
     result = truncate_output(data, max_output_chars=100)
     assert result.startswith("Output truncated")

--- a/tests/core/utils/test_truncate_output.py
+++ b/tests/core/utils/test_truncate_output.py
@@ -43,3 +43,16 @@ def test_exactly_at_limit_not_truncated():
     """Output at exactly the character limit is not truncated."""
     data = "c" * 2800
     assert truncate_output(data, max_output_chars=2800) == data
+
+
+def test_unicode_output_unchanged_when_short():
+    """Emoji and other non-ASCII characters survive unchanged in short output."""
+    assert truncate_output("Done ✅") == "Done ✅"
+
+
+def test_unicode_output_truncates_without_error():
+    """Long Unicode output truncates cleanly without breaking surrogate pairs."""
+    data = "✅" * 2000
+    result = truncate_output(data, max_output_chars=100)
+    assert result.startswith("Output truncated")
+    assert "✅" in result


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Regression tests only: `truncate_output` should handle emoji and other non-ASCII text without error.

- Short Unicode (`Done ✅`) passes through unchanged
- Long Unicode truncates cleanly with banner

Split out from #126 (validation fix) per review feedback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

