### PR TITLE
test: parse_partial_json(None) must raise TypeError

### DIFF
--- a/tests/core/llm/utils/test_parse_partial_json.py
+++ b/tests/core/llm/utils/test_parse_partial_json.py
@@ -1,5 +1,7 @@
 from interpreter.core.llm.utils.parse_partial_json import parse_partial_json
 
+import pytest
+
 
 def test_parse_complete_json():
     """Valid complete JSON objects parse to the expected dict."""
@@ -46,3 +48,9 @@ def test_parse_truncated_array():
     """A truncated array missing its closing bracket is repaired and parsed successfully."""
     result = parse_partial_json("[1, 2, 3")
     assert result == [1, 2, 3]
+
+
+def test_parse_none_raises_type_error():
+    """None is a caller bug, not incomplete JSON — must raise, not return None."""
+    with pytest.raises(TypeError):
+        parse_partial_json(None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`parse_partial_json(None)` already raises `TypeError` today. This adds an explicit regression test so future changes do not silently return `None` for a caller bug.

None means a missing `arguments` value from internal code — not incomplete JSON from the model. It should crash.

Fixes #139
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed60f0fc-e6d6-4973-aa75-34cd106eab92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

