### PR TITLE
test(mock_llm): scenario-based mock server for keyless integration smokes

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Jobs, Python versions, and pytest commands: `.github/workflows/python-package.ym
 
 | Job | Runner | What runs |
 | --- | --- | --- |
-| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite + `linux_ci` language smokes; includes `mock_llm` (local HTTP server, no API key) |
+| **Unit tests (Linux)** | `ubuntu-latest` | Unit suite + `linux_ci` language smokes; includes `mock_llm` (scenario-based local HTTP server, no API key) |
 | **Integration** | `ubuntu-latest` | `pytest -m integration` (same-repo PRs and `main` only) |
 | **Windows CI smoke** | `windows-latest` | `pytest -m windows_ci` (`tests/test_platform_ci.py`) |
 | **macOS CI smoke** | `macos-latest` | `pytest -m darwin_ci` (`tests/test_platform_ci.py`) |

--- a/tests/support/mock_openai_server.py
+++ b/tests/support/mock_openai_server.py
@@ -7,9 +7,99 @@ import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
-class _Handler(BaseHTTPRequestHandler):
-    reply_text = "Hello, World!"
+def _message_text(messages: list) -> str:
+    """Flatten chat message contents into one string for scenario matching."""
+    parts = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+    return "\n".join(parts)
 
+
+def _last_user_text(messages: list) -> str:
+    """Return the content of the most recent user message."""
+    for message in reversed(messages):
+        if message.get("role") == "user":
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+    return ""
+
+
+def pick_reply(body: dict) -> str:
+    """Return a canned assistant reply based on prompt keywords (level-2 scenarios)."""
+    messages = body.get("messages") or []
+    text = _last_user_text(messages).lower()
+    ran_code = any(
+        message.get("role") == "computer" and message.get("type") == "console"
+        for message in messages
+    )
+
+    if ran_code and "read file.txt" not in text:
+        # End the respond() loop after auto_run executes mocked code once.
+        return "The task is done."
+
+    if "code output:" in text:
+        # OI injects console output as a follow-up user turn; stop looping.
+        return "The task is done."
+
+    if "hello, world" in text or "just the words hello, world" in text:
+        return "Hello, World!"
+
+    if "washington" in text and "file.txt" in text and (
+        "write" in text or "save" in text
+    ):
+        return (
+            "```python\n"
+            "with open('file.txt', 'w') as f:\n"
+            "    f.write('Washington')\n"
+            "```"
+        )
+
+    if "read file.txt" in text or (
+        "read" in text and "file.txt" in text and "washington" not in text
+    ):
+        return "Washington"
+
+    if "use python" in text and "print" not in text:
+        # Simple math smoke: integration tests ask the model to compute via Python.
+        return "```python\nprint(42)\n```"
+
+    return "Hello, World!"
+
+
+def stream_reply_chunks(content: str) -> list[str]:
+    """Split assistant text into streaming deltas that run_text_llm can parse.
+
+    run_text_llm defers processing while accumulated text ends with a backtick
+    (waiting for more of a fence). Split the opening fence from the language line
+    so the yielded code body does not include leading ``` markers.
+    """
+    if "```" not in content:
+        return [content]
+
+    before, rest = content.split("```", 1)
+    chunks: list[str] = []
+    if before:
+        chunks.append(before)
+
+    if "\n" in rest:
+        language, code = rest.split("\n", 1)
+        chunks.append("```")
+        if code.endswith("```"):
+            body, _ = code.rsplit("```", 1)
+            chunks.append(f"{language}\n{body}")
+            chunks.append("```")
+        else:
+            chunks.append(f"{language}\n{code}")
+    else:
+        chunks.append(f"```{rest}")
+
+    return [chunk for chunk in chunks if chunk]
+
+
+class _Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):  # noqa: A003
         return
 
@@ -21,16 +111,17 @@ class _Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", 0))
         body = json.loads(self.rfile.read(length)) if length else {}
         stream = body.get("stream", False)
-        content = self.reply_text
+        content = pick_reply(body)
 
         if stream:
             self.send_response(200)
             self.send_header("Content-Type", "text/event-stream")
             self.end_headers()
-            chunk = {
-                "choices": [{"delta": {"content": content}, "finish_reason": None}],
-            }
-            self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+            for piece in stream_reply_chunks(content):
+                chunk = {
+                    "choices": [{"delta": {"content": piece}, "finish_reason": None}],
+                }
+                self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
             done = {"choices": [{"delta": {}, "finish_reason": "stop"}]}
             self.wfile.write(f"data: {json.dumps(done)}\n\n".encode())
             self.wfile.write(b"data: [DONE]\n\n")
@@ -55,10 +146,9 @@ class _Handler(BaseHTTPRequestHandler):
 class MockOpenAIServer:
     """In-process HTTP server that mimics OpenAI chat completions for tests."""
 
-    def __init__(self, reply_text: str = "Hello, World!"):
+    def __init__(self):
         self._httpd: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
-        _Handler.reply_text = reply_text
 
     @property
     def api_base(self) -> str:

--- a/tests/support/test_mock_openai_server.py
+++ b/tests/support/test_mock_openai_server.py
@@ -1,0 +1,46 @@
+from tests.support.mock_openai_server import pick_reply, stream_reply_chunks
+
+
+def test_pick_reply_hello_world():
+    """pick_reply returns a plain greeting for the integration hello-world prompt."""
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "Please reply with just the words Hello, World! and nothing else.",
+            }
+        ]
+    }
+    assert pick_reply(body) == "Hello, World!"
+
+
+def test_pick_reply_write_file_returns_python():
+    """pick_reply returns a Python code block for the write-to-file integration prompt."""
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": "Write the word 'Washington' to a .txt file called file.txt.",
+            }
+        ]
+    }
+    reply = pick_reply(body)
+    assert reply.startswith("```python")
+    assert "file.txt" in reply
+    assert "Washington" in reply
+
+
+def test_pick_reply_read_file_returns_content():
+    """pick_reply returns file contents for a read-file follow-up prompt."""
+    body = {
+        "messages": [
+            {"role": "user", "content": "Read file.txt in the current directory."}
+        ]
+    }
+    assert pick_reply(body) == "Washington"
+
+
+def test_stream_reply_chunks_splits_fenced_code():
+    """stream_reply_chunks emits multiple deltas for fenced code so run_text_llm parses it."""
+    chunks = stream_reply_chunks("```python\nprint(1)\n```")
+    assert chunks == ["```", "python\nprint(1)\n", "```"]

--- a/tests/test_mock_llm.py
+++ b/tests/test_mock_llm.py
@@ -3,13 +3,14 @@ import pytest
 from interpreter import OpenInterpreter
 from tests.support.mock_openai_server import MockOpenAIServer
 
+
 pytestmark = pytest.mark.mock_llm
 
 
 @pytest.fixture
 def mock_llm_server():
-    """Start a local OpenAI-compatible server for the duration of a test."""
-    server = MockOpenAIServer(reply_text="Hello, World!")
+    """Start a scenario-based local OpenAI-compatible server for the duration of a test."""
+    server = MockOpenAIServer()
     server.start()
     try:
         yield server
@@ -17,16 +18,66 @@ def mock_llm_server():
         server.stop()
 
 
-@pytest.mark.timeout(60)
-def test_chat_uses_mock_openai_api(mock_llm_server):
-    """chat() completes against a local OpenAI-compatible server without a real API key."""
+def _mock_interpreter(server: MockOpenAIServer, *, auto_run: bool = False) -> OpenInterpreter:
+    """OpenInterpreter wired to the mock server instead of a real LLM provider."""
     interpreter = OpenInterpreter(disable_telemetry=True)
+    interpreter.auto_run = auto_run
     interpreter.llm.model = "openai/gpt-4o-mini"
-    interpreter.llm.api_base = mock_llm_server.api_base
+    interpreter.llm.api_base = server.api_base
     interpreter.llm.api_key = "mock-key"
     interpreter.llm.supports_functions = False
     interpreter.llm._is_loaded = False
+    return interpreter
+
+
+@pytest.mark.timeout(60)
+def test_chat_uses_mock_openai_api(mock_llm_server):
+    """chat() completes against a local OpenAI-compatible server without a real API key."""
+    interpreter = _mock_interpreter(mock_llm_server)
 
     messages = interpreter.chat("Say hello.", display=False, stream=False, blocking=True)
 
     assert messages[-1]["content"] == "Hello, World!"
+
+
+@pytest.mark.timeout(60)
+def test_mock_llm_hello_world(mock_llm_server):
+    """Scenario mock returns exactly Hello, World! for the integration-style prompt."""
+    interpreter = _mock_interpreter(mock_llm_server)
+    prompt = (
+        "Please reply with just the words Hello, World! and nothing else. "
+        "Do not run code. No confirmation just the text."
+    )
+
+    messages = interpreter.chat(prompt, display=False, stream=False, blocking=True)
+
+    assert messages == [
+        {"role": "assistant", "type": "message", "content": "Hello, World!"}
+    ]
+
+
+@pytest.mark.timeout(60)
+def test_mock_llm_write_to_file(mock_llm_server, monkeypatch, tmp_path):
+    """Scenario mock returns Python that writes a file; chat() auto-runs it without an API key."""
+    monkeypatch.chdir(tmp_path)
+    interpreter = _mock_interpreter(mock_llm_server, auto_run=True)
+
+    interpreter.chat(
+        "Write the word 'Washington' to a .txt file called file.txt. "
+        "Instantly run the code! Save the file!",
+        display=False,
+        stream=False,
+        blocking=True,
+    )
+
+    assert (tmp_path / "file.txt").read_text() == "Washington"
+
+    interpreter.messages = []
+    messages = interpreter.chat(
+        "Read file.txt in the current directory and tell me what's in it.",
+        display=False,
+        stream=False,
+        blocking=True,
+    )
+
+    assert "Washington" in messages[-1]["content"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Merge after #18.**

## Summary

Level-2 extension of the mock OpenAI server: prompt-matched canned responses so fork PRs can run integration-*style* smokes without `OPENAI_API_KEY`.

## Changes

- **`pick_reply()`** — scenario table keyed on the last user message:
  - hello-world prompt → plain text
  - write `Washington` to `file.txt` → fenced Python
  - read `file.txt` → `Washington`
  - post–code-exec follow-up (`Code output:` user turn) → stop loop
- **`stream_reply_chunks()`** — splits fences across multiple SSE deltas so `run_text_llm` parses code blocks (single-chunk fences are silently dropped)
- **Tests** (`pytest -m mock_llm`):
  - `test_mock_llm_hello_world` — mirrors integration `test_hello_world`
  - `test_mock_llm_write_to_file` — mirrors integration `test_write_to_file` (write + read turns)
- Unit tests for `pick_reply` / `stream_reply_chunks` in `tests/support/test_mock_openai_server.py`

## Why

Runs in the Linux unit-test job on **all PRs including forks** — the integration job cannot access secrets for external contributors.

## Not in scope

- `test_server`, `test_math`, tool-calling, OpenRouter params (#19)
- Local inference (Ollama/LM Studio)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

