### PR TITLE
fix(async): bound respond_thread.join() to 30s in server input handler

### DIFF
--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -72,7 +72,7 @@ class AsyncInterpreter(OpenInterpreter):
             # If the user is starting something, the interpreter should stop.
             if self.respond_thread is not None and self.respond_thread.is_alive():
                 self.stop_event.set()
-                self.respond_thread.join()
+                self.respond_thread.join(timeout=30)
             self.accumulate(chunk)
         elif "content" in chunk:
             self.accumulate(chunk)
@@ -89,7 +89,7 @@ class AsyncInterpreter(OpenInterpreter):
                 if command == "stop":
                     # Any start flag would have stopped it a moment ago, but to be sure:
                     self.stop_event.set()
-                    self.respond_thread.join()
+                    self.respond_thread.join(timeout=30)
                     return
                 if command == "go":
                     # This is to approve code.

--- a/tests/core/test_async_core_extended.py
+++ b/tests/core/test_async_core_extended.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from unittest import mock
 
@@ -43,3 +44,28 @@ def test_accumulate_requires_start_before_content():
     async_i.messages = []
     with pytest.raises(Exception, match="start"):
         async_i.accumulate({"role": "user", "type": "message", "content": "oops"})
+
+
+def test_input_joins_alive_respond_thread_with_timeout_on_start():
+    """A new user 'start' chunk must not block forever waiting for respond() to finish."""
+    async_i = AsyncInterpreter()
+    mock_thread = mock.Mock()
+    mock_thread.is_alive.return_value = True
+    async_i.respond_thread = mock_thread
+
+    asyncio.run(async_i.input({"role": "user", "type": "message", "start": True}))
+
+    mock_thread.join.assert_called_once_with(timeout=30)
+    assert async_i.stop_event.is_set()
+
+
+def test_stop_command_joins_respond_thread_with_timeout():
+    """The WebSocket 'stop' command must bound how long input() waits on respond()."""
+    async_i = AsyncInterpreter()
+    mock_thread = mock.Mock()
+    async_i.respond_thread = mock_thread
+    async_i.messages = [{"role": "user", "type": "command", "content": "stop"}]
+
+    asyncio.run(async_i.input({"role": "user", "type": "message", "end": True}))
+
+    mock_thread.join.assert_called_once_with(timeout=30)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background

The FastAPI/WebSocket server uses `AsyncInterpreter` (`interpreter/core/async_core.py`). When a client finishes sending a user message (`end: true` on the WebSocket), the server starts `respond()` on a **background thread** (`respond_thread`) so the async event loop can keep pumping output.

If the user sends a new message (`start: true`) or a **`stop` command** while `respond()` is still running, `input()` must wait for the old thread to finish before starting a new one. It does this with `respond_thread.join()`.

## Problem

`threading.Thread.join()` with **no timeout blocks forever** if `respond()` is stuck — for example because subprocess execution never returned (see subprocess timeout PR), or because the LLM stream never ended.

### Visible symptoms

- WebSocket client sends **stop** or starts a **new message** while the server is still responding; the server **never acknowledges** the new input.
- Server process stays alive but appears **unresponsive** to further WebSocket chunks.
- In integration tests, the test may hang in `websocket.recv()` waiting for `complete` because the server thread is deadlocked on `join()`.

This was part of the bundled fix in **#90**; this PR isolates only the server thread join bound.

## What this PR changes

Two call sites in `AsyncInterpreter.input()`:

1. When a new `start` chunk arrives and `respond_thread` is still alive — `join(timeout=30)` instead of unbounded `join()`.
2. When the user sends the `stop` command — same `join(timeout=30)`.

After 30 seconds, `join` returns even if the thread is still alive (same semantics as today, but the server can proceed instead of blocking forever). This matches the 30s bound chosen in **#90**.

## Tests

- `tests/core/test_async_core_extended.py`:
  - `test_input_joins_alive_respond_thread_with_timeout_on_start` — mocks an alive `respond_thread`, asserts `join(timeout=30)` and `stop_event` set.
  - `test_stop_command_joins_respond_thread_with_timeout` — same for the `stop` command path.

## Relationship to other PRs

This is **PR 3 of 4** replacing **#90**:

| PR | Focus |
|----|-------|
| PR #143 | Bash executor (fixes fish / wrong shell) |
| Subprocess timeout PR | Subprocess `run()` deadline |
| **This PR** | Server `respond_thread.join()` deadline |
| Server test diagnostics PR | Test-only better error messages |

Complements the subprocess timeout PR: even if a subprocess hang is eventually killed, the server must not block forever while stopping the old respond thread.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcadaf0c-df02-4407-9199-ed70dc93469a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

