### PR TITLE
fix(computer_use): make bash tool timeout work on Python 3.9-3.10

### DIFF
--- a/interpreter/computer_use/tools/bash.py
+++ b/interpreter/computer_use/tools/bash.py
@@ -81,19 +81,23 @@ class _BashSession:
         await self._process.stdin.drain()
 
         # read output from the process, until the sentinel is found
+        async def _read_until_sentinel():
+            """Read from the process output until the sentinel is found, returning the output before it."""
+            while True:
+                await asyncio.sleep(self._output_delay)
+                # if we read directly from stdout/stderr, it will wait forever for
+                # EOF. use the StreamReader buffer directly instead.
+                output = (
+                    self._process.stdout._buffer.decode()
+                )  # pyright: ignore[reportAttributeAccessIssue]
+                if self._sentinel in output:
+                    # strip the sentinel and return
+                    return output[: output.index(self._sentinel)]
+
         try:
-            async with asyncio.timeout(self._timeout):
-                while True:
-                    await asyncio.sleep(self._output_delay)
-                    # if we read directly from stdout/stderr, it will wait forever for
-                    # EOF. use the StreamReader buffer directly instead.
-                    output = (
-                        self._process.stdout._buffer.decode()
-                    )  # pyright: ignore[reportAttributeAccessIssue]
-                    if self._sentinel in output:
-                        # strip the sentinel and break
-                        output = output[: output.index(self._sentinel)]
-                        break
+            output = await asyncio.wait_for(
+                _read_until_sentinel(), timeout=self._timeout
+            )
         except asyncio.TimeoutError:
             self._timed_out = True
             raise ToolError(

--- a/tests/computer_use/tools/test_bash.py
+++ b/tests/computer_use/tools/test_bash.py
@@ -171,26 +171,18 @@ def test_bash_session_run_when_process_exited_requires_restart():
     assert "restarted" in result.system
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason="asyncio.timeout requires Python 3.11+",
-)
 def test_bash_session_run_timeout_marks_session_stale():
     """_BashSession.run flags the session as timed out and raises ToolError when the sentinel never arrives."""
     session = _bash._BashSession()
     session._started = True
     session._process = _FakeProcess()
     with mock.patch.object(builtins, "input", return_value="yes"):
-        with mock.patch.object(asyncio, "timeout", side_effect=asyncio.TimeoutError):
+        with mock.patch.object(asyncio, "wait_for", side_effect=asyncio.TimeoutError):
             with pytest.raises(ToolError, match="timed out"):
                 asyncio.run(session.run("sleep 100"))
     assert session._timed_out is True
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason="asyncio.timeout requires Python 3.11+",
-)
 def test_bash_session_run_strips_sentinel_and_trailing_newline():
     """_BashSession.run returns the output up to the sentinel, without the trailing newline, and clears buffers."""
     session = _bash._BashSession()


### PR DESCRIPTION
## Background

`_BashSession.run` in `interpreter/computer_use/tools/bash.py` reads process output until a sentinel using `asyncio.timeout(...)` inside a `try` block.

## Problem

`asyncio.timeout` was added in Python 3.11, but the package declares `python = ">=3.9,<4"` in `pyproject.toml` and CI runs unit tests on Python 3.10. On 3.9/3.10, executing a command through the bash tool crashed with `AttributeError: module 'asyncio' has no attribute 'timeout'` — the run path was completely broken on those supported versions.

## Visible symptoms

- Running the bash tool on Python 3.9 or 3.10 raises `AttributeError` at `bash.py:85` as soon as a command is executed.
- CodeRabbit flagged the version-gated skips added in #172 as hiding this runtime failure.

## What this PR changes

- Replaces `asyncio.timeout` with `asyncio.wait_for` around a small helper coroutine (`_read_until_sentinel`) that reads until the sentinel, matching the timeout pattern already used in `interpreter/computer_use/tools/run.py:29`.
- `asyncio.wait_for` raises `asyncio.TimeoutError` on all supported Python versions (3.9–3.14), so the existing `except asyncio.TimeoutError` path is unchanged in behavior.
- Removes the two `skipif(sys.version_info < (3, 11))` markers added in #172; the timeout test now patches `asyncio.wait_for` instead of `asyncio.timeout`, so the run-path tests execute on every supported version.

## Tests

- `tests/computer_use/tools/test_bash.py`: skips removed, `test_bash_session_run_timeout_marks_session_stale` updated to patch `asyncio.wait_for`; all 14 tests pass locally on Python 3.12.
- Full unit suite (`pytest -m "not integration"`): 408 passed, 31 skipped, 12 deselected, 6 subtests.

## Related work

- Stacked on #172 (`feat/test-computer-use-bash-tool`), which adds the bash tool tests and originally gated the run tests on 3.11+.