### PR TITLE
chore: drop Python 3.9 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Open Interpreter — Python CLI (3.9+) that lets LLMs execute code locally. Uses LiteLLM, ipykernel/jupyter-client, Rich, FastAPI.
+Open Interpreter — Python CLI (3.10+) that lets LLMs execute code locally. Uses LiteLLM, ipykernel/jupyter-client, Rich, FastAPI.
 
 This repo (`endolith/open-interpreter`) is the community-maintained home of OI Classic (Python). Contributions belong here (branches `main` and `classic/develop`). The original home [openinterpreter/openinterpreter](https://github.com/openinterpreter/openinterpreter) is now an unrelated Rust coding agent (Codex fork). Do not treat it as upstream or copy its architecture. OpenInterpreter.com is now dedicated to an unrelated desktop tool.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ sniffio = { version = "^1.3.0", optional = true }
 websockets = { version = "^13.1", optional = true }
 
 # Required dependencies
-python = ">=3.9,<4"
+python = ">=3.10,<4"
 setuptools = "*"
 astor = "^0.8.1"
 git-python = "^1.0.3"


### PR DESCRIPTION
## Background

`pyproject.toml` declares `python = ">=3.9,<4"`, and AGENTS.md describes the project as a Python 3.9+ CLI.

## Problem

Python 3.9 reached end-of-life on 2025-10-31 and no longer receives security updates, but the package still advertises support for it.

## What this PR changes

- Raises the minimum supported Python from 3.9 to 3.10 in `pyproject.toml`.
- Updates the version note in `AGENTS.md`.

No other files reference Python 3.9: CI already only tests 3.10–3.14 (`python-package.yml`), ruff already targets `py310`, and black already targets `py311`.

## Non-goals

- Python 3.10 support is retained for now (3.10 EOLs 2026-10-31).
- This does not touch the `asyncio.timeout` compatibility work in #173, which is needed for 3.10 independent of this change.

## Tests

No code changes; `pytest -m "not integration"` unaffected (408 passed on main).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented Python support requirement to Python 3.10 and later.

* **Chores**
  * Updated project configuration to require Python 3.10+ for installation and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->