### PR TITLE
docs: roadmap step to drop Python 3.10 after tests confirm behavior

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,7 @@ Automation so that pull requests can be reviewed and merged with confidence. Muc
 - [x] [CodeRabbit](https://github.com/apps/coderabbitai) AI code review on pull requests
 - [x] Hundreds of unit tests across `interpreter/` — coverage rose significantly over recent commits
 - [ ] Close the remaining coverage gaps (see [#141](https://github.com/endolith/open-interpreter/issues/141)) and keep every new feature test-backed
+- [ ] Modernize dependencies and bump the Python floor (drop 3.10 — EOL October 2026) — only *after* tests confirm current behavior across the matrix, so the floor change isn't conflated with dependency churn
 
 ### Phase 2: Port features from `classic/develop` into `main`
 


### PR DESCRIPTION
## Background
Python 3.10 reaches end-of-life in October 2026. The repo currently supports `>=3.10,<4` (`pyproject.toml`) and tests a 3.10–3.14 matrix.

## Problem
Dropping the 3.10 floor now would race the dependency-update churn, making it hard to tell whether a failure is a version-floor regression or a dependency change.

## What this PR changes
Docs only: adds a Phase 1 checklist item to `docs/ROADMAP.md` that sequences the dependency modernization + Python floor bump (drop 3.10) *after* the test-coverage work ([#141](https://github.com/endolith/open-interpreter/issues/141)) has confirmed current behavior across the matrix. No code, CI, or support-floor changes.

## Tests
N/A — docs-only change; no test or lint impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 1 roadmap item to modernize dependencies and raise the minimum supported Python version.
  * Notes the planned removal of Python 3.10 support after compatibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->