### PR TITLE
ci: enable CodeRabbit request-changes workflow and assertive review profile

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# CodeRabbit review configuration
+# Docs: https://docs.coderabbit.ai/reference/configuration
+language: "en-US"
+
+reviews:
+  profile: "assertive"        # more thorough feedback (may feel nitpicky)
+  request_changes_workflow: true  # post comments as Request changes; auto-approve once resolved
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary

Adds a `.coderabbit.yaml` config so CodeRabbit acts as a formal reviewer instead of just commenting:

- **`reviews.request_changes_workflow: true`** — CodeRabbit posts its review comments as a **Request changes** review, then automatically **approves** the PR once all its comments are resolved and no pre-merge checks are failing.
- **`reviews.profile: "assertive"`** — more thorough review coverage.
- Keeps the walkthrough summary, auto-review, and incremental re-review on each push enabled.

## Why

Currently CodeRabbit only leaves `COMMENTED` reviews, which do not satisfy the repository's required-approval branch protection. This gives PRs a formal AI review + sign-off (useful as a paper trail), while the human approving review remains the actual merge gate (bot approvals do not count toward GitHub's required-reviews rule).

## Notes

- Single small, self-contained change: one config file, no code touched.
- Docs referenced: https://docs.coderabbit.ai/reference/configuration
- `chat.auto_reply` left enabled for consistency with defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository review settings for English-language, assertive feedback.
  * Enabled automatic and incremental reviews, high-level summaries, and chat responses.
  * Configured review requests to use a change-request workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->