### PR TITLE
fix(ai): return fast_llm response after the finally block

### DIFF
--- a/interpreter/core/computer/ai/ai.py
+++ b/interpreter/core/computer/ai/ai.py
@@ -87,7 +87,7 @@ def fast_llm(llm, system_message, user_message):
     finally:
         llm.interpreter.messages = old_messages
         llm.interpreter.system_message = old_system_message
-        return response[-1].get("content")
+    return response[-1].get("content")
 
 
 def query_map_chunks(chunks, llm, query):

--- a/tests/core/computer/ai/test_fast_llm.py
+++ b/tests/core/computer/ai/test_fast_llm.py
@@ -1,0 +1,47 @@
+"""Tests for ``interpreter.core.computer.ai.ai.fast_llm``.
+
+``fast_llm`` temporarily swaps the interpreter's messages/system message, calls
+the LLM, and restores the prior state. These tests pin both the happy path and
+the failure path: an exception from the LLM must propagate (not be replaced by
+an ``UnboundLocalError``) and the state must be restored either way.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from interpreter.core.computer.ai.ai import fast_llm
+
+
+def _interpreter(chat):
+    return SimpleNamespace(messages=["old"], system_message="old_sys", chat=chat)
+
+
+def test_fast_llm_returns_content_and_restores_state():
+    """fast_llm() returns the last message's content and restores the
+    interpreter's messages/system message afterwards."""
+    interpreter = _interpreter(lambda message: [{"content": "answer"}])
+    llm = SimpleNamespace(interpreter=interpreter)
+
+    result = fast_llm(llm, "sys", "user")
+
+    assert result == "answer"
+    assert interpreter.messages == ["old"]
+    assert interpreter.system_message == "old_sys"
+
+
+def test_fast_llm_propagates_chat_exception_and_restores_state():
+    """If chat() raises, fast_llm() re-raises that original exception (rather
+    than an UnboundLocalError from the finally block) and still restores the
+    interpreter's messages/system message."""
+    def chat(message):
+        raise RuntimeError("boom")
+
+    interpreter = _interpreter(chat)
+    llm = SimpleNamespace(interpreter=interpreter)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        fast_llm(llm, "sys", "user")
+
+    assert interpreter.messages == ["old"]
+    assert interpreter.system_message == "old_sys"


### PR DESCRIPTION
## Background
`interpreter/core/computer/ai/ai.py` `fast_llm()` returned from inside its `finally` block:
`return response[-1].get("content")`. If `interpreter.chat()` raised before assigning `response`, the `finally`'s return evaluated the unbound name and raised `UnboundLocalError`, **masking the original exception**.

## Problem
The failure is visible in `computer.ai.query()` / `summarize()`: an LLM error during the map step surfaces as `UnboundLocalError` instead of the real error, hiding the cause. (Found by CodeRabbit reviewing the tripwire tests for this function.)

## What this PR changes
- Move the `return response[-1].get("content")` outside the `finally` block, so exceptions from `chat()` propagate normally after state restoration.
- Add `tests/core/computer/ai/test_fast_llm.py` with:
  - a happy-path test (returns content, restores state), and
  - a regression test asserting the original exception propagates and `messages`/`system_message` are restored. This test fails on the old code.

## Tests
- `pytest tests/core/computer/ai/test_fast_llm.py` → 2 passed; ruff clean.
- The regression test fails against the pre-fix `finally`-return version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving fast AI responses.
  * Interpreter state is now consistently restored before returning results or propagating errors.

* **Tests**
  * Added coverage for successful responses, failures, exception propagation, and state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->