### PR TITLE
fix(cli): correct the misleading --os help text

### DIFF
--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -242,7 +242,7 @@ def start_terminal_interface(interpreter):
         {
             "name": "os",
             "nickname": "os",
-            "help_text": "experimentally let Open Interpreter control your mouse and keyboard (shortcut for `interpreter --profile os`)",
+            "help_text": "deprecated Anthropic computer-use demo (broken with current models); use `interpreter --profile os` for desktop control",
             "type": bool,
         },
         # Special commands


### PR DESCRIPTION
## Problem
`--os` is intercepted in `interpreter/__init__.py` and runs the legacy Anthropic computer-use loop — it never reaches the CLI's `--os` arg handling. But the CLI help text describes `--os` as a "shortcut for \`interpreter --profile os\`", which is wrong and sends users down the broken Anthropic path.

## What this PR changes
Update the `--os` help text to point at `--profile os` (the maintained provider-agnostic desktop-control path) and note the legacy path is broken with current models.

## Tests
Ruff clean; help-text string change only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `--os` option help text to indicate that the Anthropic computer-use demo is deprecated and incompatible with current models.
  * Directed users to the `os` profile for desktop control instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->