### PR TITLE
docs: drop the now-false misleading-help-text claim

### DIFF
--- a/docs/guides/os-mode.mdx
+++ b/docs/guides/os-mode.mdx
@@ -49,9 +49,9 @@ See [Anthropic's computer use documentation](https://platform.claude.com/docs/en
 
 ### `--os` vs `--profile os` (naming collision)
 
-Both desktop-control paths share the "os" name, and the CLI makes it worse: the help text for `--os` describes it as a *shortcut for `--profile os`*, but `--os` is intercepted in `interpreter/__init__.py` **before** the CLI runs and routes to the Anthropic loop instead. So `--os` and `--profile os` are different commands:
+Both desktop-control paths share the "os" name but are different commands. `--os` is intercepted in `interpreter/__init__.py` **before** the CLI runs and routes to the Anthropic loop:
 
-- `interpreter --os` → Anthropic computer-use demo (broken with current models).
+- `interpreter --os` → Anthropic computer-use demo (deprecated, broken with current models).
 - `interpreter --profile os` → provider-agnostic OS control via LiteLLM + the `computer.*` module.
 
 Historically, "OS mode" referred to the Anthropic `--os` path; the provider-agnostic `--profile os` is the maintained one.


### PR DESCRIPTION
## Background
PR #205 corrects the `--os` CLI help text (it now points at `--profile os` and notes the Anthropic demo is deprecated). The merged OS-mode doc still claimed the help text misleadingly describes `--os` as a shortcut for `--profile os`.

## What this PR changes
Docs only: rewrite the 'naming collision' section in `docs/guides/os-mode.mdx` to state the `--os` vs `--profile os` distinction directly, without the now-outdated misleading-help-text claim.

## Tests
Docs-only; no test or lint impact.