### PR TITLE
chore: omit deprecated computer_use from coverage reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,11 @@ profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
 
+[tool.coverage.run]
+# The Anthropic computer-use demo is deprecated and slated for removal
+# (docs/ROADMAP.md); exclude it from coverage until it's deleted.
+omit = ["interpreter/computer_use/*"]
+
 [tool.ruff]
 line-length = 120
 target-version = "py310"


### PR DESCRIPTION
## Background
`interpreter/computer_use/` is the Anthropic computer-use demo: deprecated (removed beta API), broken with current models, and slated for removal (docs/ROADMAP.md).

## What this PR changes
Add `[tool.coverage.run].omit = ["interpreter/computer_use/*"]` to pyproject.toml so the deprecated code stops dragging the coverage numbers down until it's deleted.

## Tests
Verified `pytest --cov=interpreter` no longer reports `computer_use`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage configuration to exclude computer-use implementation files from coverage measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->