### PR TITLE
fix(deps): pin litellm <1.97.0 to keep Python 3.10 tests green

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
     "pyperclip>=1.9.0,<2.0.0",
     "yaspin>=3.0.2,<4.0.0",
     "shortuuid>=1.0.13,<2.0.0",
-    "litellm>=1.41.26,<2.0.0",
+    # litellm 1.97.0 crashes on Python 3.10 (`Message` is not fully defined,
+    # BerriAI/litellm#36384); pin below it until upstream fixes the type forward refs.
+    "litellm>=1.41.26,<1.97.0",
     "orjson>=3.9.0,<4.0.0",
     "starlette>=0.37.2,<0.38.0",
     "html2text>=2024.2.26,<2025.0.0",


### PR DESCRIPTION
## Background
CI unit tests currently pass on Python 3.10–3.14, but the project has no lockfile, so `pyproject.toml` pins are floating (`litellm>=1.41.26,<2.0.0`).

## Problem
litellm **1.97.0** (released 2026-08-16) crashes on Python 3.10: constructing `ModelResponse()` raises `PydanticUserError: Message is not fully defined; you should define ChatCompletionReasoningSummaryTextBlock, then call Message.model_rebuild()`. This fails `tests/test_mock_llm.py` in the 3.10 CI job. The break is Python-3.10-specific (3.12/3.13/3.14 pass with the same pydantic version).

The regression is upstream and unfixed: [BerriAI/litellm#36384](https://github.com/BerriAI/litellm/issues/36384) has been open since Aug 10 with no fix in any stable release (newest is a pre-release rc).

## Visible symptoms
- `Unit tests (Linux) (3.10)` red on every run that resolves litellm >=1.97.0 (main will go red on its next run too).

## What this PR changes
- Pin `litellm>=1.41.26,<1.97.0` in `pyproject.toml` (the last version that passes the 3.10 matrix), with a comment linking the upstream issue.
- Lift the pin once upstream ships a fix.

## Tests
No code changes. `tomllib` parse of `pyproject.toml` verified; CI matrix will re-run with litellm 1.96.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented installation of a dependency version known to cause crashes on Python 3.10.
  * Improved compatibility and stability for supported Python 3.10 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->