### PR TITLE
docs(test): fix stale test_server docstring describing main's actual turns

### DIFF
--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -393,11 +393,12 @@ def run_server():
 @pytest.mark.integration
 @pytest.mark.timeout(900)
 def test_server():
-    """FastAPI/WebSocket server accepts settings, streams chat, and completes cleanly.
+    """Exercise secret-word, math, and file-existence turns over the WebSocket API.
 
     Spins up AsyncInterpreter in a subprocess (spawn context), posts settings,
-    sends a user message over WebSocket, and verifies poem-style responses
-    arrive without authentication when INTERPRETER_REQUIRE_ACKNOWLEDGE is off."""
+    streams each user turn over WebSocket, and verifies the response flow: the
+    math turn writes code without auto-executing it, and the file turn answers
+    in plain text."""
 
     process = _start_server_subprocess(run_server)
 


### PR DESCRIPTION
## Background
`test_server` was rewritten over several PRs (#142 era) to exercise secret-word, math/code-exec, and file-existence turns. The docstring was never updated and still claims it "verifies poem-style responses".

## Problem
The docstring describes a test that no longer exists, which misleads anyone reading or debugging the test.

## What this PR changes
Updates only the `test_server` docstring to describe the turns the test actually runs (secret-word, math with code written but not auto-executed, and file-existence turns answered in plain text).

## Tests
No behavior change; existing CI covers the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test server documentation to describe secret-word, math, and file-existence WebSocket interactions.
  * Clarified deferred math execution and plain-text file responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->