### PR TITLE
ci: make apt runtime install resilient to flaky mirrors

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,36 +50,31 @@ jobs:
           enable-cache: true
           cache-dependency-glob: pyproject.toml
       - name: Install language runtimes for e2e smokes
-        run: |
-          # azure.archive.ubuntu.com (and occasionally archive.ubuntu.com)
-          # stalls mid-download on larger packages (e.g. the 46.5 MB
-          # openjdk-21-jre-headless) or on the noble-updates InRelease metadata,
-          # hanging the job until it is cancelled. Bound each step with a timeout
-          # and retry a few times so a flaky mirror fails fast instead of
-          # blocking CI. --no-install-recommends keeps the install payload to
-          # what the smokes actually need (irb, R, javac/java); node ships on
-          # the runner image and Chrome is verified separately.
-          install_runtimes() {
-            sudo timeout --kill-after=10s 300 apt-get update \
+        # azure.archive.ubuntu.com (and occasionally archive.ubuntu.com) stalls
+        # mid-download on larger packages (e.g. the 46.5 MB openjdk-21-jre-headless)
+        # or on the noble-updates InRelease metadata. apt-get has no timeout, so an
+        # unbounded install hangs the job until it is cancelled (~30 min). This
+        # action bounds each attempt and retries on failure/timeout (killing the
+        # whole process tree, so apt's child processes die too); the && chains
+        # update to install so a failed update can't install from stale indexes.
+        # --no-install-recommends keeps the payload to what the smokes need
+        # (irb, R, javac/java); node ships on the runner image and Chrome is
+        # verified separately.
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: |
+            sudo apt-get update \
               -o Acquire::Retries=5 \
               -o Acquire::http::Timeout=60 \
-              -o Acquire::https::Timeout=60 || return 1
-            sudo timeout --kill-after=10s 300 apt-get install -y --no-install-recommends \
+              -o Acquire::https::Timeout=60 \
+            && sudo apt-get install -y --no-install-recommends \
               -o Acquire::Retries=5 \
               -o Acquire::http::Timeout=60 \
               -o Acquire::https::Timeout=60 \
               ruby irb r-base default-jdk
-          }
-          for i in 1 2 3; do
-            if install_runtimes; then
-              exit 0
-            fi
-            if [ "$i" -lt 3 ]; then
-              echo "::warning::apt runtime install attempt $i failed, retrying"
-              sleep 10
-            fi
-          done
-          exit 1
       # Google Chrome is pre-installed on ubuntu-latest (actions/runner-images).
       # HTML/React smokes find it via require_chrome_for_html() — no .deb download.
       - name: Verify Chrome for HTML/React smokes

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,8 +64,6 @@ jobs:
         uses: nick-fields/retry@v4
         with:
           timeout_minutes: 6
-          max_attempts: 3
-          retry_wait_seconds: 10
           command: |
             timeout --kill-after=10s 300 sudo apt-get update \
             && timeout --kill-after=10s 300 sudo apt-get install -y --no-install-recommends ruby irb r-base default-jdk

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -51,8 +51,35 @@ jobs:
           cache-dependency-glob: pyproject.toml
       - name: Install language runtimes for e2e smokes
         run: |
-          sudo apt-get update
-          sudo apt-get install -y ruby r-base default-jdk
+          # azure.archive.ubuntu.com (and occasionally archive.ubuntu.com)
+          # stalls mid-download on larger packages (e.g. the 46.5 MB
+          # openjdk-21-jre-headless) or on the noble-updates InRelease metadata,
+          # hanging the job until it is cancelled. Bound each step with a timeout
+          # and retry a few times so a flaky mirror fails fast instead of
+          # blocking CI. --no-install-recommends keeps the install payload to
+          # what the smokes actually need (irb, R, javac/java); node ships on
+          # the runner image and Chrome is verified separately.
+          install_runtimes() {
+            sudo timeout --kill-after=10s 300 apt-get update \
+              -o Acquire::Retries=5 \
+              -o Acquire::http::Timeout=60 \
+              -o Acquire::https::Timeout=60 || return 1
+            sudo timeout --kill-after=10s 300 apt-get install -y --no-install-recommends \
+              -o Acquire::Retries=5 \
+              -o Acquire::http::Timeout=60 \
+              -o Acquire::https::Timeout=60 \
+              ruby irb r-base default-jdk
+          }
+          for i in 1 2 3; do
+            if install_runtimes; then
+              exit 0
+            fi
+            if [ "$i" -lt 3 ]; then
+              echo "::warning::apt runtime install attempt $i failed, retrying"
+              sleep 10
+            fi
+          done
+          exit 1
       # Google Chrome is pre-installed on ubuntu-latest (actions/runner-images).
       # HTML/React smokes find it via require_chrome_for_html() — no .deb download.
       - name: Verify Chrome for HTML/React smokes

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -63,19 +63,12 @@ jobs:
         # verified separately.
         uses: nick-fields/retry@v4
         with:
-          timeout_minutes: 5
+          timeout_minutes: 6
           max_attempts: 3
           retry_wait_seconds: 10
           command: |
             timeout --kill-after=10s 300 sudo apt-get update \
-              -o Acquire::Retries=5 \
-              -o Acquire::http::Timeout=60 \
-              -o Acquire::https::Timeout=60 \
-            && timeout --kill-after=10s 300 sudo apt-get install -y --no-install-recommends \
-              -o Acquire::Retries=5 \
-              -o Acquire::http::Timeout=60 \
-              -o Acquire::https::Timeout=60 \
-              ruby irb r-base default-jdk
+            && timeout --kill-after=10s 300 sudo apt-get install -y --no-install-recommends ruby irb r-base default-jdk
       # Google Chrome is pre-installed on ubuntu-latest (actions/runner-images).
       # HTML/React smokes find it via require_chrome_for_html() — no .deb download.
       - name: Verify Chrome for HTML/React smokes

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,11 +54,12 @@ jobs:
         # mid-download on larger packages (e.g. the 46.5 MB openjdk-21-jre-headless)
         # or on the noble-updates InRelease metadata. apt-get has no timeout, so an
         # unbounded install hangs the job until it is cancelled (~30 min). This
-        # action bounds each attempt and retries on failure/timeout (killing the
-        # whole process tree, so apt's child processes die too); the && chains
-        # update to install so a failed update can't install from stale indexes.
-        # --no-install-recommends keeps the payload to what the smokes need
-        # (irb, R, javac/java); node ships on the runner image and Chrome is
+        # action bounds each attempt and retries on failure/timeout; the inner GNU
+        # timeout adds --kill-after so a non-cooperative apt-get or dpkg is
+        # SIGKILLed before the next attempt rather than leaving a stale lock. The
+        # && chain keeps a failed apt-get update from installing from stale
+        # indexes. --no-install-recommends keeps the payload to what the smokes
+        # need (irb, R, javac/java); node ships on the runner image and Chrome is
         # verified separately.
         uses: nick-fields/retry@v4
         with:
@@ -66,11 +67,11 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 10
           command: |
-            sudo apt-get update \
+            timeout --kill-after=10s 300 sudo apt-get update \
               -o Acquire::Retries=5 \
               -o Acquire::http::Timeout=60 \
               -o Acquire::https::Timeout=60 \
-            && sudo apt-get install -y --no-install-recommends \
+            && timeout --kill-after=10s 300 sudo apt-get install -y --no-install-recommends \
               -o Acquire::Retries=5 \
               -o Acquire::http::Timeout=60 \
               -o Acquire::https::Timeout=60 \


### PR DESCRIPTION
## Background
The Linux unit-test job installs `ruby r-base default-jdk` for e2e smokes via `apt-get`. These binaries are only needed by the subprocess smokes in `tests/test_language_subprocess.py`, and those tests skip gracefully when a binary is absent (`shutil.which(...) is None → pytest.skip`).

## Problem
`azure.archive.ubuntu.com` occasionally stalls mid-download on larger packages — observed repeatedly on the 46.5 MB `openjdk-21-jre-headless` (the `Get:6` line, then ~10 minutes of silence). Because `apt-get` has no timeout, the job hangs until it is externally cancelled (~30 min), on a different matrix cell each run (3.12 one run, 3.13 the next). This blocks unrelated PRs' CI.

## What this PR changes
- Wrap each `apt-get install` attempt in `timeout 300` so a stalled mirror fails fast instead of hanging.
- Retry up to 3 times with a 10s backoff; fail loudly (non-zero exit) if all attempts fail rather than silently proceeding without runtimes.
- Add apt-level resilience (`Acquire::Retries=5`, `Acquire::http::Timeout=60`).
- Use `--no-install-recommends` and install only what the smokes need (`ruby irb r-base default-jdk`), shrinking the payload. `R` comes from `r-base-core` (a Depends), `javac`/`java` from `openjdk-21-jdk` (a Depends), and `irb` is installed explicitly. Node ships on the runner image and Chrome is verified separately.

## Tests
CI only — this is a workflow change. The CI run on this PR itself is the test: a stall should now fail fast and retry rather than hang. Smoke coverage is unchanged when mirrors are healthy (same binaries installed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Linux test environment setup with automatic retries for required development tools.
  * Added a five-minute installation timeout and streamlined package setup for more predictable workflow execution.
  * Continued support for Ruby, IRB, R, and Java development tooling in automated environments.
  * Improved the reliability and consistency of automated builds across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->