### PR TITLE
test: cover run_text_llm and run_function_calling_llm generators

### DIFF
--- a/tests/core/llm/test_run_function_calling_llm.py
+++ b/tests/core/llm/test_run_function_calling_llm.py
@@ -7,7 +7,7 @@ class FakeLanguage:
     name = "Python"
 
 
-def _make_llm(chunks):
+def _make_llm(chunks, verbose=False):
     def completions(**params):
         for chunk in chunks:
             yield chunk
@@ -16,8 +16,13 @@ def _make_llm(chunks):
     computer = SimpleNamespace(terminal=terminal)
     return SimpleNamespace(
         completions=completions,
-        interpreter=SimpleNamespace(computer=computer, verbose=False),
+        interpreter=SimpleNamespace(computer=computer, verbose=verbose),
     )
+
+
+def _chunk(delta):
+    """Wrap a delta dict in the OpenAI streaming chunk shape the generator consumes."""
+    return {"choices": [{"delta": delta}]}
 
 
 def test_message_content_yielded():
@@ -77,3 +82,92 @@ def test_hallucinated_python_name_yields_code():
     assert result == [{"type": "code",
                        "format": "python",
                        "content": "print(2)"}]
+
+
+def test_chunks_without_choices_are_skipped():
+    """Chunks with no choices list (or an empty one) are ignored rather than failing."""
+    llm = _make_llm([{"foo": "bar"}, {"choices": []}, _chunk({"content": "hi"})])
+    assert list(run_function_calling_llm(llm, {"messages": []})) == [
+        {"type": "message", "content": "hi"}
+    ]
+
+
+def test_review_layer_yields_safe_review_after_function_call():
+    """Content following a function_call with a <safe> tag is streamed as a safe review."""
+    llm = _make_llm(
+        [
+            _chunk(
+                {
+                    "function_call": {
+                        "name": "execute",
+                        "arguments": '{"language": "python", "code": "print(1)"}',
+                    }
+                }
+            ),
+            _chunk({"content": "<safe>"}),
+            _chunk({"content": "all good"}),
+            _chunk({"content": "</safe>"}),
+        ]
+    )
+    assert list(run_function_calling_llm(llm, {"messages": []})) == [
+        {"type": "code", "format": "python", "content": "print(1)"},
+        {"type": "review", "format": "safe", "content": ""},
+        {"type": "review", "format": "safe", "content": "all good"},
+        {"type": "review", "format": "safe", "content": ""},
+    ]
+
+
+def test_review_layer_yields_unsafe_review_after_function_call():
+    """Content following a function_call with an <unsafe> tag is streamed as an unsafe review."""
+    llm = _make_llm(
+        [
+            _chunk(
+                {
+                    "function_call": {
+                        "name": "execute",
+                        "arguments": '{"language": "python", "code": "print(1)"}',
+                    }
+                }
+            ),
+            _chunk({"content": "<unsafe>DANGER"}),
+        ]
+    )
+    assert list(run_function_calling_llm(llm, {"messages": []})) == [
+        {"type": "code", "format": "python", "content": "print(1)"},
+        {"type": "review", "format": "unsafe", "content": "DANGER"},
+    ]
+
+
+def test_unparseable_arguments_verbose_prints_warning(capsys):
+    """In verbose mode, unparseable function arguments trigger the 'Arguments not a dict.' notice."""
+    llm = _make_llm(
+        [_chunk({"function_call": {"name": "execute", "arguments": "not json"}})],
+        verbose=True,
+    )
+    assert list(run_function_calling_llm(llm, {"messages": []})) == []
+    assert "Arguments not a dict." in capsys.readouterr().out
+
+
+def test_hallucinated_python_name_verbose_prints_notice(capsys):
+    """In verbose mode, a hallucinated 'python' function_call logs 'Got direct python call'."""
+    llm = _make_llm(
+        [_chunk({"function_call": {"name": "python", "arguments": "print(9)"}})],
+        verbose=True,
+    )
+    assert list(run_function_calling_llm(llm, {"messages": []})) == [
+        {"type": "code", "format": "python", "content": "print(9)"}
+    ]
+    assert "Got direct python call" in capsys.readouterr().out
+
+
+def test_unknown_function_name_yields_name_and_stops():
+    """An unrecognized function name is emitted as python code and the stream stops."""
+    llm = _make_llm(
+        [
+            _chunk({"function_call": {"name": "whatever", "arguments": "x"}}),
+            _chunk({"content": "after"}),
+        ]
+    )
+    assert list(run_function_calling_llm(llm, {"messages": []})) == [
+        {"type": "code", "format": "python", "content": "whatever"}
+    ]

--- a/tests/core/llm/test_run_text_llm.py
+++ b/tests/core/llm/test_run_text_llm.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
 
+import pytest
+
 from interpreter.core.llm.run_text_llm import run_text_llm
 
 
-def _make_llm(chunks, execution_instructions=None):
+def _make_llm(chunks, execution_instructions=None, verbose=False, os_mode=False):
     def completions(**params):
         for chunk in chunks:
             yield chunk
@@ -11,7 +13,7 @@ def _make_llm(chunks, execution_instructions=None):
     return SimpleNamespace(
         completions=completions,
         execution_instructions=execution_instructions,
-        interpreter=SimpleNamespace(verbose=False, os=False),
+        interpreter=SimpleNamespace(verbose=verbose, os=os_mode),
     )
 
 
@@ -52,3 +54,74 @@ def test_execution_instructions_appended():
     params = {"messages": [{"content": "base"}]}
     list(run_text_llm(llm, params))
     assert params["messages"][0]["content"] == "base\nRun safely."
+
+
+def test_chunks_without_choices_are_skipped():
+    """Chunks with no choices list (or an empty one) are ignored rather than failing."""
+    llm = _make_llm([{"foo": "bar"}, {"choices": []}, {"choices": [{"delta": {"content": "hi"}}]}])
+    assert list(run_text_llm(llm, {"messages": [{"content": "sys"}]})) == [
+        {"type": "message", "content": "hi"}
+    ]
+
+
+def test_verbose_prints_each_chunk(capsys):
+    """In verbose mode each raw chunk is printed as it streams."""
+    llm = _make_llm(
+        [{"choices": [{"delta": {"content": "hi"}}]}], verbose=True
+    )
+    assert list(run_text_llm(llm, {"messages": [{"content": "sys"}]})) == [
+        {"type": "message", "content": "hi"}
+    ]
+    assert "Chunk in coding_llm" in capsys.readouterr().out
+
+
+def test_code_block_exit_returns():
+    """The stream stops when the closing ``` of a fenced code block is seen."""
+    llm = _make_llm(
+        [
+            {"choices": [{"delta": {"content": "```python\n"}}]},
+            {"choices": [{"delta": {"content": "print(1)\n"}}]},
+            {"choices": [{"delta": {"content": "```\n"}}]},
+        ]
+    )
+    result = list(run_text_llm(llm, {"messages": [{"content": "sys"}]}))
+    assert result == [
+        {"type": "code", "format": "python", "content": "```\n"},
+        {"type": "code", "format": "python", "content": "print(1)\n"},
+    ]
+
+
+def test_empty_language_defaults_to_python():
+    """A code fence with no language label (e.g. '```\\n') defaults to python in text mode."""
+    llm = _make_llm(
+        [
+            {"choices": [{"delta": {"content": "```\n"}}]},
+            {"choices": [{"delta": {"content": "print(1)\n"}}]},
+        ]
+    )
+    result = list(run_text_llm(llm, {"messages": [{"content": "sys"}]}))
+    assert result == [
+        {"type": "code", "format": "python", "content": "```\n"},
+        {"type": "code", "format": "python", "content": "print(1)\n"},
+    ]
+
+
+def test_none_content_chunk_is_skipped():
+    """Chunks whose delta content is None are skipped rather than treated as text."""
+    llm = _make_llm(
+        [
+            {"choices": [{"delta": {"content": None}}]},
+            {"choices": [{"delta": {"content": "hi"}}]},
+        ]
+    )
+    assert list(run_text_llm(llm, {"messages": [{"content": "sys"}]})) == [
+        {"type": "message", "content": "hi"}
+    ]
+
+
+def test_execution_instructions_unappendable_message_reraises(capsys):
+    """A non-string first message with execution_instructions prints context and re-raises the error."""
+    llm = _make_llm([], execution_instructions="careful")
+    with pytest.raises(TypeError):
+        list(run_text_llm(llm, {"messages": [{"content": 123}]}))
+    assert "params[\"messages\"][0]" in capsys.readouterr().out


### PR DESCRIPTION
## Background

`interpreter/core/llm/run_function_calling_llm.py` (68%) and `interpreter/core/llm/run_text_llm.py` (74%) are the two remaining LLM-layer streaming generators with meaningful coverage gaps. Both sit on the CLI code-run path, are rewritten by classic/develop (+13 and +39 lines), and are independent of the server work in PR #200.

Issue #141 lists the LLM layer as priority coverage.

## What this PR changes

Test-only, no source changes.

- **`tests/core/llm/test_run_function_calling_llm.py`** — coverage 68% → 99%:
  - chunks with no/empty choices skipped
  - the judge-layer review stream for `<safe>` / `<unsafe>` tags after a function call
  - verbose "Arguments not a dict." notice for unparseable arguments
  - verbose "Got direct python call" notice for hallucinated `python` names
  - unknown function names emitted as python code with early return
- **`tests/core/llm/test_run_text_llm.py`** — coverage 74% → 98%:
  - chunks with no/empty choices skipped
  - `None` content chunks skipped
  - verbose per-chunk logging
  - code block exit (closing fence) stopping the stream
  - empty language label defaulting to python
  - `execution_instructions` failing to append to a non-string first message (prints context, re-raises)

## Tests

Local verification: `pytest tests/core/llm/` → 91 passed; full `pytest -m "not integration"` → 636 passed, 32 skipped; `ruff check .` → clean.

Remaining uncovered statements are dead code (a duplicate-condition `elif` in `run_text_llm.py`; an unreachable line after an early `return` in `run_function_calling_llm.py`).

Addresses LLM-layer items in #141 (not closing — several modules remain).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for streaming responses, including malformed, empty, and incomplete chunks.
  * Added validation for function-call handling, unknown functions, hallucinated calls, and review-tag safety.
  * Added coverage for verbose-mode warnings and logging.
  * Improved testing of code-fence parsing, missing content, execution errors, and configurable runtime modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->