### PR TITLE
test: cover count_tokens error-fallback branches (79% -> 100%)

### DIFF
--- a/tests/terminal_interface/utils/test_count_tokens.py
+++ b/tests/terminal_interface/utils/test_count_tokens.py
@@ -64,3 +64,53 @@ def test_count_messages_tokens_empty_returns_zero():
     """count_messages_tokens returns (0, 0) for an empty message list."""
     with mock.patch.object(ct, "token_cost", return_value=0.0):
         assert ct.count_messages_tokens(messages=[]) == (0, 0.0)
+
+
+def test_count_tokens_returns_zero_when_encoder_fails():
+    """count_tokens returns 0 when encoding raises, keeping tokenization non-essential."""
+    mock_encoder = mock.Mock()
+    mock_encoder.encode.side_effect = RuntimeError("encode failed")
+    with mock.patch.object(ct, "tiktoken") as mock_tiktoken:
+        mock_tiktoken.encoding_for_model.return_value = mock_encoder
+        assert ct.count_tokens("hello") == 0
+
+
+def test_token_cost_returns_zero_on_failure():
+    """token_cost returns 0 when cost_per_token raises, keeping cost non-essential."""
+    with mock.patch.object(ct, "cost_per_token", side_effect=RuntimeError("boom")):
+        assert ct.token_cost(tokens=100, model="gpt-4") == 0
+
+
+def test_count_messages_tokens_returns_zero_on_bad_message():
+    """count_messages_tokens returns (0, 0) when a message is not a string or dict."""
+    with mock.patch.object(ct, "token_cost", return_value=0.0):
+        assert ct.count_messages_tokens(messages=[42]) == (0, 0.0)
+
+
+def test_module_imports_tolerate_missing_optional_deps(monkeypatch):
+    """The module imports successfully (and functions degrade to 0) when tiktoken
+    or litellm are unavailable."""
+    import builtins
+    import importlib
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in ("tiktoken", "litellm"):
+            raise ImportError(f"No module named {name}")
+        return real_import(name, *args, **kwargs)
+
+    try:
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.delattr(ct, "tiktoken")
+        monkeypatch.delattr(ct, "cost_per_token")
+        reloaded = importlib.reload(ct)
+
+        assert reloaded.count_tokens("hello") == 0
+        assert reloaded.token_cost(tokens=10) == 0
+        assert reloaded.count_messages_tokens(messages=["hi"]) == (0, 0)
+    finally:
+        # Restore the real import hook first so the reload below actually
+        # rebinds the real tiktoken and cost_per_token imports, then reload.
+        builtins.__import__ = real_import
+        importlib.reload(ct)


### PR DESCRIPTION
## Background

`count_tokens.py` was at 79% coverage. The four uncovered lines were all defensive `except:` fallbacks: encoder failure, `cost_per_token` failure, non-string/dict messages, and the import-failure path for `tiktoken`/`litellm`. These are exactly the branches the dependency-bump risk map cares about — the module imports litellm directly.

## What this PR changes

Pure test addition — **no source changes**. Appends 4 tests to `tests/terminal_interface/utils/test_count_tokens.py`:

- `count_tokens` returns 0 when encoding raises
- `token_cost` returns 0 when `cost_per_token` raises
- `count_messages_tokens` returns `(0, 0)` on a non-string/dict message
- module imports successfully and functions degrade to 0 when `tiktoken`/`litellm` are unavailable (via a guarded `importlib.reload` that restores the real imports afterwards)

Coverage: **79% → 100%** on `count_tokens.py`.

## Tests

`pytest tests/terminal_interface/utils/test_count_tokens.py` → 11 passed; full suite `pytest -m "not integration"` → 688 passed, 32 skipped, 12 deselected; `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for graceful fallback behavior when token encoding, cost calculation, message validation, or optional dependencies are unavailable.
  * Verified that affected operations return zero-valued results and recover correctly when reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->