### PR TITLE
test: cover validate_llm_settings interactive branches (63% -> 100%)

### DIFF
--- a/tests/terminal_interface/test_validate_llm_settings.py
+++ b/tests/terminal_interface/test_validate_llm_settings.py
@@ -1,10 +1,13 @@
 from types import SimpleNamespace
 from unittest import mock
 
+import pytest
+
 from interpreter.terminal_interface.validate_llm_settings import (
     display_welcome_message_once,
     validate_llm_settings,
 )
+from interpreter.terminal_interface import validate_llm_settings as vls_module
 from tests.helpers import TEST_LLM_MODEL
 
 
@@ -54,3 +57,92 @@ def test_display_welcome_message_once_only_first_time():
     assert interpreter.display_message.call_count == 1
     if hasattr(display_welcome_message_once, "_displayed"):
         delattr(display_welcome_message_once, "_displayed")
+
+
+def _interpreter(model="gpt-4o-mini", messages=None, api_key=None, api_base=None, **overrides):
+    """Build a minimal interpreter stub with sane defaults for validate_llm_settings."""
+    kwargs = {
+        "offline": False,
+        "auto_run": True,
+        "messages": [] if messages is None else messages,
+        "llm": SimpleNamespace(
+            model=model,
+            api_key=api_key,
+            api_base=api_base,
+            load=mock.Mock(),
+        ),
+        "display_message": mock.Mock(),
+    }
+    kwargs.update(overrides)
+    return SimpleNamespace(**kwargs)
+
+
+def test_validate_llm_settings_prompts_for_missing_key():
+    """When no OpenAI key is available, validate_llm_settings prompts and stores the response."""
+    interpreter = _interpreter()
+    with mock.patch.dict("os.environ", {}, clear=True), mock.patch.object(
+        vls_module, "display_welcome_message_once"
+    ) as welcome, mock.patch.object(vls_module, "prompt", return_value="sk-abc") as prompt, mock.patch.object(
+        vls_module.time, "sleep"
+    ):
+        validate_llm_settings(interpreter)
+    welcome.assert_called_once_with(interpreter)
+    prompt.assert_called_once_with("OpenAI API key: ", is_password=True)
+    assert interpreter.llm.api_key == "sk-abc"
+
+
+def test_validate_llm_settings_exits_on_local_command():
+    """validate_llm_settings exits when the user types `interpreter --local` at the key prompt."""
+    interpreter = _interpreter()
+    with mock.patch.dict("os.environ", {}, clear=True), mock.patch.object(
+        vls_module, "display_welcome_message_once"
+    ), mock.patch.object(vls_module, "prompt", return_value="interpreter --local"), mock.patch.object(
+        vls_module.time, "sleep"
+    ), mock.patch("builtins.exit", side_effect=SystemExit) as exit_mock, mock.patch(
+        "interpreter.terminal_interface.validate_llm_settings.print"
+    ):
+        with pytest.raises(SystemExit):
+            validate_llm_settings(interpreter)
+    exit_mock.assert_called_once_with()
+
+
+def test_validate_llm_settings_uses_api_base_key():
+    """validate_llm_settings does not prompt when an api_base is set (e.g. self-hosted proxy)."""
+    interpreter = _interpreter(api_base="https://proxy.example.com")
+    with mock.patch.dict("os.environ", {}, clear=True):
+        validate_llm_settings(interpreter)
+    assert interpreter.llm.api_key is None
+
+
+def test_validate_llm_settings_uses_llm_api_key():
+    """validate_llm_settings does not prompt when interpreter.llm.api_key is already set."""
+    interpreter = _interpreter(api_key="sk-preset")
+    with mock.patch.dict("os.environ", {}, clear=True):
+        validate_llm_settings(interpreter)
+    assert interpreter.llm.api_key == "sk-preset"
+
+
+def test_validate_llm_settings_displays_model_set():
+    """validate_llm_settings announces the active model for non-auto-run interactive use."""
+    interpreter = _interpreter(
+        model="custom-model", auto_run=False, messages=[{"role": "user"}, {"role": "assistant"}]
+    )
+    with mock.patch.dict("os.environ", {}, clear=True):
+        validate_llm_settings(interpreter)
+    interpreter.display_message.assert_called_with("> Model set to `custom-model`")
+
+
+def test_validate_llm_settings_i_model_note():
+    """validate_llm_settings shows the training-usage note when the model is `i`."""
+    interpreter = _interpreter(model="i")
+    with mock.patch.dict("os.environ", {}, clear=True):
+        validate_llm_settings(interpreter)
+    assert "will be used to train" in interpreter.display_message.call_args.args[0]
+
+
+def test_validate_llm_settings_ollama_loads():
+    """validate_llm_settings calls llm.load() for ollama model names."""
+    interpreter = _interpreter(model="ollama/llama3", messages=[{"role": "user"}])
+    with mock.patch.dict("os.environ", {}, clear=True):
+        validate_llm_settings(interpreter)
+    interpreter.llm.load.assert_called_once()


### PR DESCRIPTION
## Background

`validate_llm_settings.py` was at 63% coverage. It gates interactive startup for every OpenAI-model session: it prompts for a missing API key, exits on `interpreter --local`, announces the active model, and lazily loads ollama models. The uncovered lines were exactly those interactive and post-check branches — the API-key prompt flow and the model-setup display logic.

## What this PR changes

Pure test addition — **no source changes**. Adds 7 tests to `tests/terminal_interface/test_validate_llm_settings.py` (plus a shared `_interpreter` stub helper):

- prompts for a missing OpenAI API key, stores the response, shows the welcome message
- exits when the user types `interpreter --local`
- does not prompt when `llm.api_key` or `llm.api_base` is already set
- announces the active model (`> Model set to ...`) for interactive use
- shows the training-usage note for the `i` model
- calls `llm.load()` for ollama model names

Coverage: **63% → 100%** on `validate_llm_settings.py`.

## Tests

`pytest tests/terminal_interface/test_validate_llm_settings.py` → 10 passed; full suite `pytest -m "not integration"` → 646 passed, 32 skipped, 12 deselected; `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for LLM settings validation.
  * Verified prompts for missing API keys and correct handling of configured API bases and keys.
  * Added checks for local command exits, model information, training notices, and Ollama loading behavior.
  * These tests help ensure more reliable setup validation and clearer feedback when configuring language models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->