### PR TITLE
test(server): fail fast when the server subprocess dies during a WebSocket wait

### DIFF
--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -118,25 +118,64 @@ def _stop_server_subprocess(process):
 
 
 async def _wait_for_websocket_complete(
-    websocket, max_messages=500, recv_timeout=300.0, acknowledge=False
+    websocket,
+    max_messages=500,
+    recv_timeout=300.0,
+    acknowledge=False,
+    phase="unknown",
+    server_process=None,
 ):
     """Read WebSocket chunks until the server sends a 'complete' status.
 
     The old while True loops hung forever when 'complete' never arrived (for example
     on auth failure). Bound both message count and per-recv wait time.
+
+    While awaiting a message, `server_process.is_alive()` is polled so a child
+    that crashes mid-turn (including a port-race socket bind failure from issue
+    #165) aborts with its exit code instead of blocking until the recv timeout
+    expires.
     """
 
     import asyncio
     import json
 
     accumulated_content = ""
+    messages_received = 0
     for _ in range(max_messages):
+        loop = asyncio.get_running_loop()
+        recv_task = asyncio.create_task(websocket.recv())
         try:
-            message = await asyncio.wait_for(websocket.recv(), timeout=recv_timeout)
-        except asyncio.TimeoutError as exc:
-            raise Exception(
-                f"No WebSocket message within {recv_timeout}s waiting for 'complete'"
-            ) from exc
+            deadline = loop.time() + recv_timeout
+            while not recv_task.done():
+                if server_process is not None and not server_process.is_alive():
+                    raise RuntimeError(
+                        f"Server subprocess exited during WebSocket wait (phase: {phase}, "
+                        f"exit code {server_process.exitcode}, port {_server_port})"
+                    )
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise Exception(
+                        f"No WebSocket message within {recv_timeout}s waiting for 'complete' "
+                        f"(phase: {phase}, messages received: {messages_received}, "
+                        f"port {_server_port})"
+                    )
+                await asyncio.wait({recv_task}, timeout=min(remaining, 0.1))
+            try:
+                message = recv_task.result()
+            except asyncio.TimeoutError as exc:
+                raise Exception(
+                    f"No WebSocket message within {recv_timeout}s waiting for 'complete' "
+                    f"(phase: {phase}, messages received: {messages_received}, "
+                    f"port {_server_port})"
+                ) from exc
+        finally:
+            if not recv_task.done():
+                recv_task.cancel()
+                try:
+                    await recv_task
+                except asyncio.CancelledError:
+                    pass
+        messages_received += 1
 
         message_data = json.loads(message)
         if acknowledge and "id" in message_data:
@@ -157,7 +196,129 @@ async def _wait_for_websocket_complete(
             print("Received expected message from server")
             return accumulated_content
 
-    raise Exception(f"Never received 'complete' status after {max_messages} messages")
+    raise Exception(
+        f"Never received 'complete' status after {max_messages} messages "
+        f"(phase: {phase}, port {_server_port})"
+    )
+
+
+def test_wait_for_websocket_complete_dead_server():
+    """A server subprocess that has already exited aborts the wait immediately.
+
+    The health check turns a crashed child into a fast, descriptive failure
+    (phase and exit code) instead of an opaque hang until the recv timeout."""
+
+    import asyncio
+    from unittest.mock import AsyncMock, Mock
+
+    process = Mock()
+    process.is_alive.return_value = False
+    process.exitcode = 1
+    websocket = Mock()
+    websocket.recv = AsyncMock()
+
+    async def scenario():
+        with pytest.raises(
+            RuntimeError,
+            match=r"Server subprocess exited during WebSocket wait \(phase: dead_process, exit code 1",
+        ):
+            await _wait_for_websocket_complete(
+                websocket, phase="dead_process", server_process=process
+            )
+
+    asyncio.run(scenario())
+
+
+def test_wait_for_websocket_complete_process_dies_mid_recv():
+    """A server subprocess that dies during the recv aborts the wait promptly.
+
+    The poll-while-awaiting loop checks is_alive() while the recv is pending, so
+    a child that crashes mid-turn fails fast with its exit code instead of
+    blocking until the recv timeout expires."""
+
+    import asyncio
+    from unittest.mock import Mock
+
+    process = Mock()
+    process.is_alive.side_effect = [True, True, False]
+    process.exitcode = 7
+    websocket = Mock()
+
+    async def never_returns():
+        await asyncio.Event().wait()
+
+    websocket.recv = never_returns
+
+    async def scenario():
+        with pytest.raises(
+            RuntimeError,
+            match=r"Server subprocess exited during WebSocket wait \(phase: mid_recv_death, exit code 7",
+        ):
+            await _wait_for_websocket_complete(
+                websocket, phase="mid_recv_death", server_process=process
+            )
+
+    asyncio.run(scenario())
+
+
+def test_wait_for_websocket_complete_recv_timeout():
+    """A stalled WebSocket recv raises a phase-labeled timeout error.
+
+    The recv_timeout bound guards against a server that stops streaming; the
+    error names the phase and the number of messages already received so CI
+    failures are diagnosable."""
+
+    import asyncio
+    from unittest.mock import Mock
+
+    websocket = Mock()
+
+    # A recv that never resolves (like a server that stops streaming) drives the
+    # poll loop to the deadline branch, where the per-recv timeout is enforced.
+    async def never_returns():
+        await asyncio.Event().wait()
+
+    websocket.recv = never_returns
+
+    async def scenario():
+        with pytest.raises(
+            Exception,
+            match=r"No WebSocket message within .*waiting for 'complete' \(phase: timeout_phase, messages received: 0",
+        ):
+            await _wait_for_websocket_complete(
+                websocket, recv_timeout=0.01, phase="timeout_phase"
+            )
+
+    asyncio.run(scenario())
+
+
+def test_wait_for_websocket_complete_message_limit():
+    """Exhausting max_messages without 'complete' raises a phase-labeled error.
+
+    The message-count bound replaces the old while-True loop so a server that
+    never sends 'complete' fails fast instead of hanging forever."""
+
+    import asyncio
+    import json
+    from unittest.mock import AsyncMock, Mock
+
+    websocket = Mock()
+    websocket.recv = AsyncMock(
+        side_effect=[
+            json.dumps({"role": "assistant", "type": "message", "content": "hi"})
+        ]
+    )
+
+    async def scenario():
+        with pytest.raises(
+            Exception,
+            match=r"Never received 'complete' status after 1 messages \(phase: exhausted_phase",
+        ):
+            await _wait_for_websocket_complete(
+                websocket, max_messages=1, phase="exhausted_phase"
+            )
+
+    asyncio.run(scenario())
 
 
 def _last_assistant_message(messages):
@@ -438,7 +599,12 @@ def test_authenticated_acknowledging_breaking_server():
             # Sending message via WebSocket
             await websocket.send(json.dumps({"auth": "testing"}))
 
-            poem += await _wait_for_websocket_complete(websocket, acknowledge=True)
+            poem += await _wait_for_websocket_complete(
+                websocket,
+                acknowledge=True,
+                phase="auth_server_resume_poem",
+                server_process=process,
+            )
 
             time.sleep(1)
             print("Is this a normal poem?")
@@ -527,7 +693,9 @@ def test_server():
             print("WebSocket chunks sent")
 
             # Wait for a specific response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="secret_word_crunk", server_process=process
+            )
 
             assert "crunk" in accumulated_content
 
@@ -563,7 +731,9 @@ def test_server():
             print("WebSocket chunks sent")
 
             # Wait for a specific response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="secret_word_barloney", server_process=process
+            )
 
             assert "barloney" in accumulated_content
 
@@ -596,7 +766,9 @@ def test_server():
             print("WebSocket chunks sent")
 
             # Wait for response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="math_code_auto_run_false", server_process=process
+            )
 
             time.sleep(5)
 
@@ -632,7 +804,9 @@ def test_server():
             )
 
             # Wait for a specific response
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="go_execute_code", server_process=process
+            )
 
             assert "18893094989" in accumulated_content.replace(",", "")
 
@@ -665,7 +839,9 @@ def test_server():
 
             # WebSocket stream may arrive before GET /messages is consistent; keep
             # accumulated_content as a fallback when picking the assistant reply.
-            accumulated_content = await _wait_for_websocket_complete(websocket)
+            accumulated_content = await _wait_for_websocket_complete(
+                websocket, phase="file_exists", server_process=process
+            )
 
             # Get messages
             get_url = _server_http_url("/settings/messages")
@@ -729,7 +905,9 @@ def test_server():
                 await image_websocket.send(json.dumps({"role": "user", "end": True}))
                 print("WebSocket chunks sent")
 
-                accumulated_content = await _wait_for_websocket_complete(image_websocket)
+                accumulated_content = await _wait_for_websocket_complete(
+                    image_websocket, phase="vision_mcq", server_process=process
+                )
 
                 # _wait_for_websocket_complete appends the status content "complete".
                 vision_reply = accumulated_content.removesuffix("complete")


### PR DESCRIPTION
## Background

`test_server` and `test_authenticated_acknowledging_breaking_server` wait for the server's `complete` chunk via `_wait_for_websocket_complete`. On `main` (after #233) this helper blocks on each `recv` for up to `recv_timeout` (default 300s).

## Problem

If the server subprocess crashes mid-turn (uvicorn bind failure, early exit, etc.), the test hangs for the full 300s timeout with no hint about the child, the phase, or the exit code — an opaque CI stall.

## What this PR changes

- `_wait_for_websocket_complete` gains optional `phase=` and `server_process=` parameters.
- While a message is pending, `server_process.is_alive()` is polled; if the child died, it raises immediately with the phase, exit code, and port (documented in the docstring, referencing the port-race from #165).
- The existing per-recv deadline and message-count bounds are preserved, and timeout/message-limit errors now include the phase, messages received, and port.
- Every call site in both server tests passes a phase label for its turn and the server subprocess, so a crash anywhere names the failing turn.
- Adds four unit tests: dead server, mid-recv death, recv timeout, message limit.

No test logic or assertions change.

## Tests

`pytest tests/test_interpreter.py -m "not integration" -k wait_for_websocket_complete` → 4 passed. Full local suite `pytest -m "not integration"` → 762 passed. `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket operation monitoring to detect server failures during communication.
  - Added clearer diagnostics for timeouts, unexpected server exits, and excessive message activity.
  - Improved cancellation of pending receive operations to prevent stalled connections.

- **Tests**
  - Added coverage for server crashes, receive timeouts, dead connections, and message-limit failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->