### PR TITLE
test(server): add timeouts to the HTTP requests in the server tests

### DIFF
--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -526,7 +526,7 @@ def test_authenticated_acknowledging_breaking_server():
                 },
             }
             response = requests.post(
-                post_url, json=settings, headers={"X-API-KEY": "testing"}
+                post_url, json=settings, headers={"X-API-KEY": "testing"}, timeout=30
             )
             print("POST request sent, response:", response.json())
             assert response.status_code == 200
@@ -667,7 +667,7 @@ def test_server():
                 "llm": {"model": "gpt-4o-mini"},
                 "custom_instructions": "",
             }
-            response = requests.post(post_url, json=settings)
+            response = requests.post(post_url, json=settings, timeout=30)
             print("POST request sent, response:", response.json())
             assert response.status_code == 200
 
@@ -705,7 +705,7 @@ def test_server():
                 "llm": {"model": "gpt-4o-mini"},
                 "custom_instructions": "",
             }
-            response = requests.post(post_url, json=settings)
+            response = requests.post(post_url, json=settings, timeout=30)
             print("POST request sent, response:", response.json())
             assert response.status_code == 200
 
@@ -743,7 +743,7 @@ def test_server():
                 "custom_instructions": "",
                 "verbose": False,
             }
-            response = requests.post(post_url, json=settings)
+            response = requests.post(post_url, json=settings, timeout=30)
             print("POST request sent, response:", response.json())
             assert response.status_code == 200
 
@@ -774,7 +774,7 @@ def test_server():
 
             # Send a GET request to /settings/messages
             get_url = _server_http_url("/settings/messages")
-            response = requests.get(get_url)
+            response = requests.get(get_url, timeout=30)
             print("GET request sent, response:", response.json())
 
             # Assert that the last message has a type of 'code'
@@ -845,7 +845,7 @@ def test_server():
 
             # Get messages
             get_url = _server_http_url("/settings/messages")
-            response_json = requests.get(get_url).json()
+            response_json = requests.get(get_url, timeout=30).json()
             print("GET request sent, response:", response_json)
             if isinstance(response_json, str):
                 response_json = json.loads(response_json)


### PR DESCRIPTION
## Background

`test_server` and `test_authenticated_acknowledging_breaking_server` make `requests.get`/`requests.post` calls against the running FastAPI server.

## Problem

Those requests had no timeout, so a wedged server would block the test indefinitely (relying only on pytest's outer timeout) instead of failing at the request that issued the call.

## What this PR changes

Adds `timeout=30` to every HTTP request in the two server tests so a stuck request fails in the test that issued it. Purely additive; no request logic or assertions change. (The `POST /run` request already had `timeout=30`; a `requests.post` in an unrelated non-server test is left untouched.)

## Tests

Full local suite `pytest -m "not integration"` → 762 passed. `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added 30-second timeouts to integration-test requests for server settings and messages.
  * Prevented tests from hanging indefinitely when requests do not complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->