### PR TITLE
test(server): set the poem-bot persona via system_message at startup

### DIFF
--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -478,8 +478,11 @@ def run_auth_server():
     os.environ["INTERPRETER_API_KEY"] = "testing"
     async_interpreter = AsyncInterpreter()
     # auto_run and system_message are blocked on POST /settings; set them at startup.
+    # custom_instructions would be appended to OI's default system message,
+    # diluting the directive; system_message replaces it, so the model follows
+    # the poem-bot persona strictly.
     async_interpreter.auto_run = True
-    async_interpreter.custom_instructions = (
+    async_interpreter.system_message = (
         "You are a poem writing bot. Do not do anything but respond with a poem."
     )
     async_interpreter.print = False


### PR DESCRIPTION
## Background

`run_auth_server` (used by `test_authenticated_acknowledging_breaking_server`) starts the authenticated server and configures a poem-bot persona so the model replies only with a poem.

## Problem

The persona was set with `custom_instructions`. The responder appends `custom_instructions` to OI's default system message (`interpreter/core/respond.py:34-35`), so the directive was diluted by the long default prompt and the model often did not obey "do nothing but respond with a poem".

## What this PR changes

Set the persona with `system_message` instead, which replaces the default system message entirely so the directive is followed strictly. `system_message` (like `auto_run`) is in `SENSITIVE_SERVER_SETTINGS` and silently ignored by POST /settings, so it must be set on the interpreter before `server.run()`. The existing comment already noted this; a why-comment now explains the `custom_instructions` vs `system_message` distinction.

## Tests

Full local suite `pytest -m "not integration"` → 762 passed. `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication server test setup to enforce the poem-writing assistant behavior more reliably.
  * Strengthened validation that responses follow the configured assistant persona.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->