### PR TITLE
test(server): skip the vision turn when no LLM API key is configured

### DIFF
--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -866,6 +866,12 @@ def test_server():
 
             #### TEST IMAGES ####
 
+            # The vision turn needs a vision-capable LLM reachable with an API
+            # key; skip it (with a clear reason) rather than failing when no key
+            # is configured, so the rest of the test still runs locally.
+            if not os.environ.get("OPENAI_API_KEY"):
+                pytest.skip("vision turn requires an LLM API key (OPENAI_API_KEY)")
+
             # Fresh server for an isolated vision turn. With approval binding, reusing
             # the same WebSocket after auto_run=False can leave a pending confirmation
             # and the stream ends with only "complete".


### PR DESCRIPTION
## Background

`test_server` ends with a vision turn: it sends an image to the model and asserts the model answers the multiple-choice question ("B — a color gradient").

## Problem

Without an API key there is no reachable vision-capable LLM, so running the integration test locally fails at the vision turn for reasons unrelated to the server flow being exercised — and after the turn has already restarted a fresh server subprocess.

## What this PR changes

Skips the vision turn with a clear reason when `OPENAI_API_KEY` is unset, so the rest of the server flow still runs locally. The skip is placed before the fresh-server restart so the extra subprocess is not spun up when the turn cannot run. CI sets the key and runs the full turn.

## Tests

Full local suite `pytest -m "not integration"` → 762 passed. `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration testing to skip vision-related checks when the required API credential is unavailable.
  * Test output now clearly indicates when the credential is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->