### PR TITLE
fix(async): stop send_output event-loop spin on client disconnect

### DIFF
--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -668,6 +668,12 @@ def create_router(async_interpreter):
                     try:
                         # First, try to send any unsent messages
                         while async_interpreter.unsent_messages:
+                            # send_message returns False without awaiting when the
+                            # socket is gone, so a disconnected client with a
+                            # stuck message would otherwise spin this loop forever
+                            # and starve the event loop (blocking new connections).
+                            if websocket.client_state != WebSocketState.CONNECTED:
+                                return
                             output = async_interpreter.unsent_messages[0]
                             if async_interpreter.debug:
                                 print("This was unsent, sending it again:", output)

--- a/tests/core/test_async_server_baseline.py
+++ b/tests/core/test_async_server_baseline.py
@@ -131,3 +131,105 @@ def test_input_message_start_interrupts_active_respond_thread():
 
     mock_thread.join.assert_called_once()
     assert async_i.stop_event.is_set()
+
+
+def test_send_output_does_not_spin_when_client_disconnects_with_unsent_messages():
+    """A disconnected client with a stuck unsent message must not starve the event loop.
+
+    Regression for the resume-connection flake in the authenticated server test:
+    when a client drops mid-turn, send_message returns False without awaiting
+    once the socket reports DISCONNECTED, so the drain loop in send_output used
+    to spin forever (never popping the message, never yielding). That blocked
+    the uvicorn event loop, stalling the next connection's WebSocket handshake
+    until its open timeout fired.
+
+    The fake WebSocket reports CONNECTED until the first send attempt, then
+    flips to DISCONNECTED and raises, reproducing the drop-mid-send race. The
+    endpoint coroutine must return promptly instead of hanging.
+
+    The scenario runs in a subprocess with a hard timeout: the pre-fix spin is
+    a tight GIL-bound loop that blocks the event loop (so an in-process
+    asyncio.wait_for can never fire) and starves sibling threads (so even a
+    thread.join budget is unreliable). A subprocess timeout is enforced by the
+    OS and is immune to both.
+    """
+
+    import subprocess
+    import sys
+
+    script = f"""
+import asyncio
+import os
+from collections import deque
+
+os.environ["INTERPRETER_REQUIRE_AUTH"] = "False"
+
+from interpreter.core.async_core import AsyncInterpreter, Server
+from starlette.routing import WebSocketRoute
+from starlette.websockets import WebSocketState
+from websockets.exceptions import ConnectionClosedOK
+
+
+async def run_endpoint():
+    interpreter = AsyncInterpreter()
+    interpreter.require_acknowledge = False
+    interpreter.unsent_messages = deque(
+        [{{"role": "assistant", "type": "message", "content": "pending"}}]
+    )
+
+    server = Server(interpreter)
+    endpoint = next(
+        r.endpoint
+        for r in server.app.routes
+        if isinstance(r, WebSocketRoute) and r.path == "/"
+    )
+
+    class DroppingWebSocket:
+        \"\"\"Fake WebSocket that drops the connection on the first send.\"\"\"
+
+        def __init__(self):
+            self.headers = {{}}
+            self.client_state = WebSocketState.CONNECTED
+
+        async def accept(self):
+            pass
+
+        async def receive(self):
+            return {{"type": "websocket.disconnect"}}
+
+        async def send_text(self, data):
+            self.client_state = WebSocketState.DISCONNECTED
+            raise ConnectionClosedOK(None, None)
+
+        async def send_bytes(self, data):
+            self.client_state = WebSocketState.DISCONNECTED
+            raise ConnectionClosedOK(None, None)
+
+    await endpoint(DroppingWebSocket())
+
+
+asyncio.run(run_endpoint())
+print("COMPLETED")
+"""
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        raise AssertionError(
+            "send_output spun the event loop on a disconnected client with "
+            "unsent messages instead of returning"
+        )
+
+    assert result.returncode == 0, (
+        f"endpoint subprocess failed: rc={result.returncode} "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "COMPLETED" in result.stdout, (
+        "endpoint subprocess did not report completion "
+        f"(stdout={result.stdout!r} stderr={result.stderr!r})"
+    )


### PR DESCRIPTION
## Background

The authenticated server integration test (`test_authenticated_acknowledging_breaking_server`) flakes intermittently with `TimeoutError` on the resume WebSocket connection (`websockets.connect(..., open_timeout=30)`).

## Problem

When a client drops mid-turn with messages still queued in `unsent_messages`, the drain loop in `send_output` calls `send_message`, which returns `False` **without awaiting** once the socket reports `DISCONNECTED`. The failed message is never popped, so the loop repeats forever without yielding — blocking the uvicorn event loop. New connections (the resume handshake) can't complete → `open_timeout=30` → flaky `TimeoutError`. Timing-dependent, hence intermittent.

## What this PR changes

- **`interpreter/core/async_core.py`**: check `websocket.client_state` inside the `while async_interpreter.unsent_messages:` drain loop and `return` when the socket is gone — the same guard already used at the top of the `send_output` while loop.
- **`tests/core/test_async_server_baseline.py`**: deterministic regression test. The scenario runs the websocket endpoint against a fake socket that drops the connection on the first send. Because the pre-fix spin is a tight GIL-bound loop (blocking an in-process `asyncio.wait_for` and starving `thread.join`), the scenario runs in a **subprocess with an OS-enforced timeout**: with the fix it completes in milliseconds; without it the subprocess is reaped at 15s and the test fails.

## Tests

- New regression test: passes with the fix (~7s), fails without it (~19s, subprocess reaped — no hang).
- Full local suite `pytest -m "not integration"` → 773 passed. `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the server from repeatedly processing unsent messages after a WebSocket disconnects.
  - Ensured disconnected connections complete cleanly without blocking the event loop.

- **Tests**
  - Added regression coverage for disconnected WebSocket connections with pending messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->