### PR TITLE
test(async): cover async server endpoints; fix status-code and await bugs

### DIFF
--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -796,10 +796,10 @@ def create_router(async_interpreter):
     @router.post("/")
     async def post_input(payload: Dict[str, Any]):
         try:
-            async_interpreter.input(payload)
+            await async_interpreter.input(payload)
             return {"status": "success"}
         except Exception as e:
-            return {"error": str(e)}, 500
+            return JSONResponse({"error": str(e)}, status_code=500)
 
     @router.post("/settings")
     async def set_settings(payload: Dict[str, Any]):
@@ -827,15 +827,22 @@ def create_router(async_interpreter):
                         if hasattr(getattr(async_interpreter, key), sub_key):
                             setattr(getattr(async_interpreter, key), sub_key, sub_value)
                         else:
-                            return {
-                                "error": f"Sub-setting {sub_key} not found in {key}"
-                            }, 404
+                            return JSONResponse(
+                                {
+                                    "error": f"Sub-setting {sub_key} not found in {key}"
+                                },
+                                status_code=404,
+                            )
                 else:
-                    return {"error": f"Setting {key} not found"}, 404
+                    return JSONResponse(
+                        {"error": f"Setting {key} not found"}, status_code=404
+                    )
             elif hasattr(async_interpreter, key):
                 setattr(async_interpreter, key, value)
             else:
-                return {"error": f"Setting {key} not found"}, 404
+                return JSONResponse(
+                    {"error": f"Setting {key} not found"}, status_code=404
+                )
 
         return {"status": "success"}
 
@@ -846,9 +853,12 @@ def create_router(async_interpreter):
             try:
                 return json.dumps({setting: setting_value})
             except TypeError:
-                return {"error": "Failed to serialize the setting value"}, 500
+                return JSONResponse(
+                    {"error": "Failed to serialize the setting value"},
+                    status_code=500,
+                )
         else:
-            return json.dumps({"error": "Setting not found"}), 404
+            return JSONResponse({"error": "Setting not found"}, status_code=404)
 
     if os.getenv("INTERPRETER_INSECURE_ROUTES", "").lower() == "true":
 
@@ -856,14 +866,16 @@ def create_router(async_interpreter):
         async def run_code(payload: Dict[str, Any]):
             language, code = payload.get("language"), payload.get("code")
             if not (language and code):
-                return {"error": "Both 'language' and 'code' are required."}, 400
+                return JSONResponse(
+                    {"error": "Both 'language' and 'code' are required."}, status_code=400
+                )
             try:
                 print(f"Running {language}:", code)
                 output = async_interpreter.computer.run(language, code)
                 print("Output:", output)
                 return {"output": output}
             except Exception as e:
-                return {"error": str(e)}, 500
+                return JSONResponse({"error": str(e)}, status_code=500)
 
         @router.post("/upload")
         async def upload_file(file: UploadFile = File(...), path: str = Form(...)):
@@ -872,16 +884,16 @@ def create_router(async_interpreter):
                     shutil.copyfileobj(file.file, output_file)
                 return {"status": "success"}
             except Exception as e:
-                return {"error": str(e)}, 500
+                return JSONResponse({"error": str(e)}, status_code=500)
 
-        @router.get("/download/{filename}")
+        @router.get("/download/{filename:path}")
         async def download_file(filename: str):
             try:
                 return StreamingResponse(
                     open(filename, "rb"), media_type="application/octet-stream"
                 )
             except Exception as e:
-                return {"error": str(e)}, 500
+                return JSONResponse({"error": str(e)}, status_code=500)
 
     ### OPENAI COMPATIBLE ENDPOINT
 

--- a/tests/core/test_async_core_extended.py
+++ b/tests/core/test_async_core_extended.py
@@ -77,3 +77,84 @@ def test_input_end_chunk_with_queued_stop_command_joins_response_thread():
     assert async_i.stop_event.is_set()
     thread_cls.assert_not_called()
     assert async_i.messages == []
+
+
+def test_accumulate_accepts_bytes_content():
+    """accumulate() stores bytes content on the current message as bytes."""
+    async_i = AsyncInterpreter()
+    async_i.messages = [{"role": "user", "type": "message", "content": ""}]
+    async_i.accumulate(b"\x00\x01")
+    assert async_i.messages[-1]["content"] == b"\x00\x01"
+
+
+def test_accumulate_appends_bytes_to_bytes_content():
+    """accumulate() concatenates bytes onto an existing bytes message."""
+    async_i = AsyncInterpreter()
+    async_i.messages = [{"role": "user", "type": "message", "content": b"\x00"}]
+    async_i.accumulate(b"\x01")
+    assert async_i.messages[-1]["content"] == b"\x00\x01"
+
+
+def test_respond_emits_error_message_when_generator_raises():
+    """respond() must surface generator exceptions as an error chunk on the output queue."""
+    async_i = AsyncInterpreter()
+    mock_q = mock.MagicMock()
+    async_i.output_queue = mock.MagicMock(sync_q=mock_q)
+
+    def failing_generator():
+        raise RuntimeError("kaboom")
+        yield  # pragma: no cover
+
+    with mock.patch.object(async_i, "_respond_and_store", failing_generator):
+        async_i.respond()
+
+    error_chunks = [
+        call.args[0] for call in mock_q.put.call_args_list if call.args[0]["type"] == "error"
+    ]
+    assert len(error_chunks) == 1
+    assert "kaboom" in error_chunks[0]["content"]
+
+
+def test_respond_retries_when_generator_is_empty():
+    """respond() must retry when the generator yields nothing and then raise a final error."""
+    async_i = AsyncInterpreter()
+    mock_q = mock.MagicMock()
+    async_i.output_queue = mock.MagicMock(sync_q=mock_q)
+    async_i.auto_run = True
+
+    def empty_generator():
+        if False:
+            yield  # pragma: no cover
+
+    with mock.patch.object(async_i, "_respond_and_store", empty_generator):
+        with mock.patch("interpreter.core.async_core.time.sleep"):
+            with pytest.raises(Exception, match="No chunks sent"):
+                async_i.respond()
+
+    error_chunks = [
+        call.args[0]
+        for call in mock_q.put.call_args_list
+        if call.args[0]["type"] == "error"
+    ]
+    assert len(error_chunks) >= 1
+
+
+def test_respond_emits_error_when_no_generator_defined():
+    """respond() must put an error message when the interpreter has no messages to respond to."""
+    async_i = AsyncInterpreter()
+    mock_q = mock.MagicMock()
+    async_i.output_queue = mock.MagicMock(sync_q=mock_q)
+    async_i.auto_run = True
+    async_i.messages = []
+
+    with mock.patch.object(async_i, "_respond_and_store", return_value=[]):
+        with mock.patch("interpreter.core.async_core.time.sleep"):
+            with pytest.raises(Exception, match="No chunks sent"):
+                async_i.respond()
+
+    error_chunks = [
+        call.args[0]
+        for call in mock_q.put.call_args_list
+        if call.args[0]["type"] == "error"
+    ]
+    assert len(error_chunks) >= 1

--- a/tests/core/test_async_server_endpoints.py
+++ b/tests/core/test_async_server_endpoints.py
@@ -15,15 +15,32 @@ def server_pair():
 
 
 @pytest.fixture
+def interpreter():
+    """A fresh AsyncInterpreter for building ad-hoc test servers."""
+    return AsyncInterpreter()
+
+
+@pytest.fixture
 def client(server_pair):
     return server_pair[0]
 
 
 @pytest.fixture
-def client_no_raise(server_pair):
+def client_no_raise(interpreter):
     """TestClient that converts endpoint exceptions into 500 responses."""
-    interpreter = server_pair[1]
     return TestClient(Server(interpreter).app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def insecure_pair(monkeypatch):
+    """(TestClient, AsyncInterpreter) pair with the insecure routes registered.
+
+    create_router() reads INTERPRETER_INSECURE_ROUTES at router build time, so
+    the env var must be set before Server() is constructed.
+    """
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    return TestClient(Server(interpreter).app), interpreter
 
 
 def test_heartbeat_endpoint(client):
@@ -305,51 +322,46 @@ def test_chat_completion_stream_message_via_chat(client, server_pair):
     assert "hi" in response.text
 
 
-def test_insecure_routes_not_registered_by_default(client):
+def test_insecure_routes_not_registered_by_default(monkeypatch):
     """The /run route is absent unless INTERPRETER_INSECURE_ROUTES is enabled."""
+    monkeypatch.delenv("INTERPRETER_INSECURE_ROUTES", raising=False)
+    interpreter = AsyncInterpreter()
+    client = TestClient(Server(interpreter).app)
     response = client.post("/run", json={"language": "python", "code": "1+1"})
     assert response.status_code == 404
 
 
-def test_insecure_run_route(monkeypatch):
+def test_insecure_run_route(insecure_pair):
     """With INTERPRETER_INSECURE_ROUTES=true, /run executes code via the computer."""
-    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
-    interpreter = AsyncInterpreter()
+    client, interpreter = insecure_pair
     interpreter.computer.run = mock.MagicMock(return_value="42")
-    client = TestClient(Server(interpreter).app)
 
     response = client.post("/run", json={"language": "python", "code": "1+1"})
     assert response.status_code == 200
     assert response.json() == {"output": "42"}
 
 
-def test_insecure_run_route_requires_language_and_code(monkeypatch):
+def test_insecure_run_route_requires_language_and_code(insecure_pair):
     """The /run route rejects requests missing language or code."""
-    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
-    interpreter = AsyncInterpreter()
-    client = TestClient(Server(interpreter).app)
+    client, _ = insecure_pair
 
     response = client.post("/run", json={"language": "python"})
     assert response.status_code == 400
 
 
-def test_insecure_run_route_propagates_error(monkeypatch):
+def test_insecure_run_route_propagates_error(insecure_pair):
     """The /run route returns a 500 when computer.run raises."""
-    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
-    interpreter = AsyncInterpreter()
+    client, interpreter = insecure_pair
     interpreter.computer.run = mock.MagicMock(side_effect=RuntimeError("oops"))
-    client = TestClient(Server(interpreter).app)
 
     response = client.post("/run", json={"language": "python", "code": "1+1"})
     assert response.status_code == 500
     assert response.json() == {"error": "oops"}
 
 
-def test_insecure_upload_route(monkeypatch, tmp_path):
+def test_insecure_upload_route(insecure_pair, tmp_path):
     """The /upload route writes the uploaded file to the requested path."""
-    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
-    interpreter = AsyncInterpreter()
-    client = TestClient(Server(interpreter).app)
+    client, _ = insecure_pair
     target = tmp_path / "out.txt"
 
     response = client.post(
@@ -361,11 +373,9 @@ def test_insecure_upload_route(monkeypatch, tmp_path):
     assert target.read_text() == "payload"
 
 
-def test_insecure_upload_route_propagates_error(monkeypatch):
+def test_insecure_upload_route_propagates_error(insecure_pair):
     """The /upload route returns a 500 when it cannot write the file."""
-    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
-    interpreter = AsyncInterpreter()
-    client = TestClient(Server(interpreter).app)
+    client, _ = insecure_pair
 
     response = client.post(
         "/upload",
@@ -375,11 +385,9 @@ def test_insecure_upload_route_propagates_error(monkeypatch):
     assert response.status_code == 500
 
 
-def test_insecure_download_route(monkeypatch, tmp_path):
+def test_insecure_download_route(insecure_pair, tmp_path):
     """The /download route streams the requested file."""
-    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
-    interpreter = AsyncInterpreter()
-    client = TestClient(Server(interpreter).app)
+    client, _ = insecure_pair
     source = tmp_path / "file.bin"
     source.write_bytes(b"xyz")
 
@@ -388,11 +396,9 @@ def test_insecure_download_route(monkeypatch, tmp_path):
     assert response.content == b"xyz"
 
 
-def test_insecure_download_route_missing_file(monkeypatch):
+def test_insecure_download_route_missing_file(insecure_pair):
     """The /download route returns a 500 for a missing file."""
-    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
-    interpreter = AsyncInterpreter()
-    client = TestClient(Server(interpreter).app)
+    client, _ = insecure_pair
 
     response = client.get("/download/no/such/file.bin")
     assert response.status_code == 500

--- a/tests/core/test_async_server_endpoints.py
+++ b/tests/core/test_async_server_endpoints.py
@@ -1,0 +1,398 @@
+import json
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from interpreter.core.async_core import AsyncInterpreter, Server
+
+
+@pytest.fixture
+def server_pair():
+    """Build a (TestClient, AsyncInterpreter) pair for a fresh server."""
+    interpreter = AsyncInterpreter()
+    return TestClient(Server(interpreter).app), interpreter
+
+
+@pytest.fixture
+def client(server_pair):
+    return server_pair[0]
+
+
+@pytest.fixture
+def client_no_raise(server_pair):
+    """TestClient that converts endpoint exceptions into 500 responses."""
+    interpreter = server_pair[1]
+    return TestClient(Server(interpreter).app, raise_server_exceptions=False)
+
+
+def test_heartbeat_endpoint(client):
+    """GET /heartbeat returns a simple aliveness payload."""
+    response = client.get("/heartbeat")
+    assert response.status_code == 200
+    assert response.json() == {"status": "alive"}
+
+
+def test_home_endpoint_serves_html(client):
+    """GET / serves the HTML chat page."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "<!DOCTYPE html>" in response.text
+
+
+def test_post_input_returns_success(client):
+    """POST / accepts an LMC chunk and reports success."""
+    response = client.post("/", json={"role": "user", "type": "message", "start": True})
+    assert response.status_code == 200
+    assert response.json() == {"status": "success"}
+
+
+def test_post_input_propagates_error(client, server_pair):
+    """POST / returns a 500 with the error message when input() fails."""
+    _, interpreter = server_pair
+    interpreter.input = mock.AsyncMock(side_effect=ValueError("boom"))
+    response = client.post("/", json={"role": "user", "type": "message", "start": True})
+    assert response.status_code == 500
+    assert response.json() == {"error": "boom"}
+
+
+def test_get_setting_returns_serialized_value(client):
+    """GET /settings/{name} returns the serialized interpreter attribute."""
+    response = client.get("/settings/auto_run")
+    assert response.status_code == 200
+    assert json.loads(json.loads(response.text)) == {"auto_run": False}
+
+
+def test_get_setting_unknown_name_returns_404(client):
+    """GET /settings/{name} returns 404 for attributes the interpreter lacks."""
+    response = client.get("/settings/no_such_setting")
+    assert response.status_code == 404
+
+
+def test_post_settings_unknown_llm_subsetting_returns_404(client):
+    """POST /settings with an unknown llm sub-key returns 404, not a crash."""
+    response = client.post("/settings", json={"llm": {"no_such_subkey": True}})
+    assert response.status_code == 404
+
+
+def test_post_settings_unknown_top_level_key_returns_404(client):
+    """POST /settings with an unknown top-level key returns 404, not a crash."""
+    response = client.post("/settings", json={"no_such_setting": True})
+    assert response.status_code == 404
+
+
+def test_chat_completion_rejects_non_user_last_message(client_no_raise):
+    """The OpenAI-compatible endpoint requires the last message to be from the user."""
+    response = client_no_raise.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "assistant", "content": "hi"}]},
+    )
+    assert response.status_code == 500
+
+
+def test_chat_completion_stop_token(client, server_pair):
+    """The {STOP} sentinel sets then clears the stop event without a response."""
+    _, interpreter = server_pair
+    with mock.patch("interpreter.core.async_core.time.sleep"):
+        response = client.post(
+            "/openai/chat/completions",
+            json={"messages": [{"role": "user", "content": "{STOP}"}]},
+        )
+    assert response.status_code == 200
+    assert not interpreter.stop_event.is_set()
+
+
+def test_chat_completion_context_mode_on(client, server_pair):
+    """{CONTEXT_MODE_ON} and {REQUIRE_START_ON} enable context mode."""
+    _, interpreter = server_pair
+    for token in ["{CONTEXT_MODE_ON}", "{REQUIRE_START_ON}"]:
+        client.post(
+            "/openai/chat/completions",
+            json={"messages": [{"role": "user", "content": token}]},
+        )
+        assert interpreter.context_mode is True
+
+
+def test_chat_completion_context_mode_off(client, server_pair):
+    """{CONTEXT_MODE_OFF} and {REQUIRE_START_OFF} disable context mode."""
+    _, interpreter = server_pair
+    interpreter.context_mode = True
+    for token in ["{CONTEXT_MODE_OFF}", "{REQUIRE_START_OFF}"]:
+        client.post(
+            "/openai/chat/completions",
+            json={"messages": [{"role": "user", "content": token}]},
+        )
+        assert interpreter.context_mode is False
+
+
+def test_chat_completion_auto_run_toggle(client, server_pair):
+    """{AUTO_RUN_ON} / {AUTO_RUN_OFF} flip the auto_run flag."""
+    _, interpreter = server_pair
+    client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "{AUTO_RUN_ON}"}]},
+    )
+    assert interpreter.auto_run is True
+    client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "{AUTO_RUN_OFF}"}]},
+    )
+    assert interpreter.auto_run is False
+
+
+def test_chat_completion_text_message_returns_assistant_reply(client, server_pair):
+    """A plain text user message is appended and answered via chat()."""
+    _, interpreter = server_pair
+    interpreter.chat = mock.MagicMock(
+        return_value=[{"role": "assistant", "content": "Hello there"}]
+    )
+
+    response = client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "chat.completion"
+    assert payload["choices"][0]["message"]["content"] == "Hello there"
+    assert any(
+        m.get("content") == "hello" for m in interpreter.messages
+    ), "the user message should be stored"
+
+
+def test_chat_completion_list_text_content(client, server_pair):
+    """A content list with a text part is appended as a user message."""
+    _, interpreter = server_pair
+    interpreter.chat = mock.MagicMock(
+        return_value=[{"role": "assistant", "content": "ok"}]
+    )
+    response = client.post(
+        "/openai/chat/completions",
+        json={
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+            ]
+        },
+    )
+    assert response.status_code == 200
+    assert any(
+        m.get("type") == "message" for m in interpreter.messages
+    ), "the text part should become a message"
+
+
+def test_chat_completion_list_base64_image(client, server_pair):
+    """A content list with a base64 image becomes an image message."""
+    _, interpreter = server_pair
+    interpreter.chat = mock.MagicMock(
+        return_value=[{"role": "assistant", "content": "ok"}]
+    )
+    url = "data:image/png;base64,iVBORw0KGgo="
+    response = client.post(
+        "/openai/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "image_url", "image_url": {"url": url}}],
+                }
+            ]
+        },
+    )
+    assert response.status_code == 200
+    image_messages = [m for m in interpreter.messages if m.get("type") == "image"]
+    assert len(image_messages) == 1
+    assert image_messages[0]["format"] == "base64.png"
+    assert image_messages[0]["content"] == "iVBORw0KGgo="
+
+
+def test_chat_completion_image_url_without_url_raises(client_no_raise):
+    """An image_url part missing the url field is rejected."""
+    response = client_no_raise.post(
+        "/openai/chat/completions",
+        json={
+            "messages": [
+                {"role": "user", "content": [{"type": "image_url", "image_url": {}}]}
+            ]
+        },
+    )
+    assert response.status_code == 500
+
+
+def test_chat_completion_image_url_without_base64_raises(client_no_raise):
+    """An image_url that is not a base64 data URI is rejected."""
+    response = client_no_raise.post(
+        "/openai/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "http://x/y.png"}}
+                    ],
+                }
+            ]
+        },
+    )
+    assert response.status_code == 500
+
+
+def test_chat_completion_stream_run_code(client, server_pair):
+    """Streaming a 'yes' after a code message streams chunks from _respond_and_store."""
+    _, interpreter = server_pair
+    interpreter.messages = [
+        {
+            "role": "assistant",
+            "type": "code",
+            "format": "python",
+            "content": "print(1)",
+        }
+    ]
+    interpreter._respond_and_store = mock.MagicMock(
+        return_value=iter(
+            [
+                {"role": "assistant", "type": "message", "content": "hi"},
+                {"role": "assistant", "type": "code", "start": True, "format": "python"},
+                {"role": "assistant", "type": "code", "end": True, "format": "python"},
+            ]
+        )
+    )
+
+    response = client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "yes"}], "stream": True},
+    )
+    assert response.status_code == 200
+    assert "chat.completion.chunk" in response.text
+    assert "hi" in response.text
+
+
+def test_chat_completion_stream_confirmation_breaks(client, server_pair):
+    """A confirmation chunk with auto_run off asks and stops streaming."""
+    _, interpreter = server_pair
+    interpreter.auto_run = False
+    interpreter._respond_and_store = mock.MagicMock(
+        return_value=iter(
+            [
+                {
+                    "role": "computer",
+                    "type": "confirmation",
+                    "content": {"format": "python", "content": "print(1)"},
+                }
+            ]
+        )
+    )
+
+    response = client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "yes"}], "stream": True},
+    )
+    assert response.status_code == 200
+    assert "Do you want to run this code?" in response.text
+
+
+def test_chat_completion_stream_message_via_chat(client, server_pair):
+    """Streaming a normal message streams chunks produced by chat()."""
+    _, interpreter = server_pair
+    interpreter.chat = mock.MagicMock(
+        return_value=[{"role": "assistant", "type": "message", "content": "hi"}]
+    )
+
+    response = client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "hello"}], "stream": True},
+    )
+    assert response.status_code == 200
+    assert "hi" in response.text
+
+
+def test_insecure_routes_not_registered_by_default(client):
+    """The /run route is absent unless INTERPRETER_INSECURE_ROUTES is enabled."""
+    response = client.post("/run", json={"language": "python", "code": "1+1"})
+    assert response.status_code == 404
+
+
+def test_insecure_run_route(monkeypatch):
+    """With INTERPRETER_INSECURE_ROUTES=true, /run executes code via the computer."""
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    interpreter.computer.run = mock.MagicMock(return_value="42")
+    client = TestClient(Server(interpreter).app)
+
+    response = client.post("/run", json={"language": "python", "code": "1+1"})
+    assert response.status_code == 200
+    assert response.json() == {"output": "42"}
+
+
+def test_insecure_run_route_requires_language_and_code(monkeypatch):
+    """The /run route rejects requests missing language or code."""
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    client = TestClient(Server(interpreter).app)
+
+    response = client.post("/run", json={"language": "python"})
+    assert response.status_code == 400
+
+
+def test_insecure_run_route_propagates_error(monkeypatch):
+    """The /run route returns a 500 when computer.run raises."""
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    interpreter.computer.run = mock.MagicMock(side_effect=RuntimeError("oops"))
+    client = TestClient(Server(interpreter).app)
+
+    response = client.post("/run", json={"language": "python", "code": "1+1"})
+    assert response.status_code == 500
+    assert response.json() == {"error": "oops"}
+
+
+def test_insecure_upload_route(monkeypatch, tmp_path):
+    """The /upload route writes the uploaded file to the requested path."""
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    client = TestClient(Server(interpreter).app)
+    target = tmp_path / "out.txt"
+
+    response = client.post(
+        "/upload",
+        files={"file": ("in.txt", b"payload")},
+        data={"path": str(target)},
+    )
+    assert response.status_code == 200
+    assert target.read_text() == "payload"
+
+
+def test_insecure_upload_route_propagates_error(monkeypatch):
+    """The /upload route returns a 500 when it cannot write the file."""
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    client = TestClient(Server(interpreter).app)
+
+    response = client.post(
+        "/upload",
+        files={"file": ("in.txt", b"payload")},
+        data={"path": "/no/such/dir/out.txt"},
+    )
+    assert response.status_code == 500
+
+
+def test_insecure_download_route(monkeypatch, tmp_path):
+    """The /download route streams the requested file."""
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    client = TestClient(Server(interpreter).app)
+    source = tmp_path / "file.bin"
+    source.write_bytes(b"xyz")
+
+    response = client.get(f"/download/{source}")
+    assert response.status_code == 200
+    assert response.content == b"xyz"
+
+
+def test_insecure_download_route_missing_file(monkeypatch):
+    """The /download route returns a 500 for a missing file."""
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    client = TestClient(Server(interpreter).app)
+
+    response = client.get("/download/no/such/file.bin")
+    assert response.status_code == 500


### PR DESCRIPTION
## Background

`interpreter/core/async_core.py` (the async HTTP/WebSocket server) was the largest under-covered file in the repo at ~45% statement coverage. The recently fixed send_output drain loop lives here, and CI's codecov/project gate flags regressions on it.

## Problem

Most of the HTTP endpoints had no coverage at all. Writing tests for them exposed three real bugs:

1. **Status codes never applied.** The endpoints used Flask-style tuple returns `(content, status)` (e.g. `return {"error": ...}, 404`). FastAPI does not honor that; it serialized the tuple as a JSON array with HTTP 200. Every 400/404/500 error path was silently returning 200.
2. **`POST /` never awaited `input()`.** `async_interpreter.input(payload)` without `await` meant the payload was never processed and the exception handler was dead code.
3. **`/download` couldn't match paths.** `{filename}` matches a single path segment, so absolute paths (the intended use) 404'd. Now `{filename:path}`.

## What this PR changes

- **`interpreter/core/async_core.py`**: all error-path tuple returns converted to `JSONResponse(..., status_code=...)`; `POST /` now `await`s `input()`; `/download/{filename}` → `/download/{filename:path}`.
- **`tests/core/test_async_server_endpoints.py`** (new, 29 tests): `/heartbeat`, `/` (GET + POST), `/settings` GET + error branches, the OpenAI-compatible `/openai/chat/completions` endpoint (sentinels `{STOP}`, context-mode and auto-run toggles, text/list/base64-image content, run-code streaming, confirmation-break streaming), and the insecure `/run`, `/upload`, `/download` routes (registered only when `INTERPRETER_INSECURE_ROUTES=true`).
- **`tests/core/test_async_core_extended.py`**: respond() error/retry branches (generator raising, empty generator) and accumulate() bytes-content branches.

## Tests

- `pytest -m "not integration"` → 807 passed (was 773).
- `async_core.py` statement coverage 45% → 69%; overall 70% → 72% (with `--cov-branch`).
- `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error responses with clear JSON details and appropriate status codes.
  * Enhanced file downloads to support nested file paths.
  * Improved handling of streamed responses when processing encounters errors or produces no output.
  * Corrected byte-content accumulation behavior.

* **Tests**
  * Expanded coverage for health checks, settings, chat completions, streaming, media messages, control tokens, and file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->