### PR TITLE
test(async): cover async server HTTP endpoints (tests only)

### DIFF
--- a/tests/core/test_async_core_extended.py
+++ b/tests/core/test_async_core_extended.py
@@ -77,3 +77,84 @@ def test_input_end_chunk_with_queued_stop_command_joins_response_thread():
     assert async_i.stop_event.is_set()
     thread_cls.assert_not_called()
     assert async_i.messages == []
+
+
+def test_accumulate_accepts_bytes_content():
+    """accumulate() stores bytes content on the current message as bytes."""
+    async_i = AsyncInterpreter()
+    async_i.messages = [{"role": "user", "type": "message", "content": ""}]
+    async_i.accumulate(b"\x00\x01")
+    assert async_i.messages[-1]["content"] == b"\x00\x01"
+
+
+def test_accumulate_appends_bytes_to_bytes_content():
+    """accumulate() concatenates bytes onto an existing bytes message."""
+    async_i = AsyncInterpreter()
+    async_i.messages = [{"role": "user", "type": "message", "content": b"\x00"}]
+    async_i.accumulate(b"\x01")
+    assert async_i.messages[-1]["content"] == b"\x00\x01"
+
+
+def test_respond_emits_error_message_when_generator_raises():
+    """respond() must surface generator exceptions as an error chunk on the output queue."""
+    async_i = AsyncInterpreter()
+    mock_q = mock.MagicMock()
+    async_i.output_queue = mock.MagicMock(sync_q=mock_q)
+
+    def failing_generator():
+        raise RuntimeError("kaboom")
+        yield  # pragma: no cover
+
+    with mock.patch.object(async_i, "_respond_and_store", failing_generator):
+        async_i.respond()
+
+    error_chunks = [
+        call.args[0] for call in mock_q.put.call_args_list if call.args[0]["type"] == "error"
+    ]
+    assert len(error_chunks) == 1
+    assert "kaboom" in error_chunks[0]["content"]
+
+
+def test_respond_retries_when_generator_is_empty():
+    """respond() must retry when the generator yields nothing and then raise a final error."""
+    async_i = AsyncInterpreter()
+    mock_q = mock.MagicMock()
+    async_i.output_queue = mock.MagicMock(sync_q=mock_q)
+    async_i.auto_run = True
+
+    def empty_generator():
+        if False:
+            yield  # pragma: no cover
+
+    with mock.patch.object(async_i, "_respond_and_store", empty_generator):
+        with mock.patch("interpreter.core.async_core.time.sleep"):
+            with pytest.raises(Exception, match="No chunks sent"):
+                async_i.respond()
+
+    error_chunks = [
+        call.args[0]
+        for call in mock_q.put.call_args_list
+        if call.args[0]["type"] == "error"
+    ]
+    assert len(error_chunks) >= 1
+
+
+def test_respond_emits_error_when_no_generator_defined():
+    """respond() must put an error message when the interpreter has no messages to respond to."""
+    async_i = AsyncInterpreter()
+    mock_q = mock.MagicMock()
+    async_i.output_queue = mock.MagicMock(sync_q=mock_q)
+    async_i.auto_run = True
+    async_i.messages = []
+
+    with mock.patch.object(async_i, "_respond_and_store", return_value=[]):
+        with mock.patch("interpreter.core.async_core.time.sleep"):
+            with pytest.raises(Exception, match="No chunks sent"):
+                async_i.respond()
+
+    error_chunks = [
+        call.args[0]
+        for call in mock_q.put.call_args_list
+        if call.args[0]["type"] == "error"
+    ]
+    assert len(error_chunks) >= 1

--- a/tests/core/test_async_core_extended.py
+++ b/tests/core/test_async_core_extended.py
@@ -122,14 +122,14 @@ def test_respond_retries_when_generator_is_empty():
     async_i.output_queue = mock.MagicMock(sync_q=mock_q)
     async_i.auto_run = True
 
-    def empty_generator():
-        if False:
-            yield  # pragma: no cover
+    empty_response = mock.MagicMock(return_value=iter(()))
 
-    with mock.patch.object(async_i, "_respond_and_store", empty_generator):
+    with mock.patch.object(async_i, "_respond_and_store", empty_response):
         with mock.patch("interpreter.core.async_core.time.sleep"):
             with pytest.raises(Exception, match="No chunks sent"):
                 async_i.respond()
+
+    assert empty_response.call_count == 5
 
     error_chunks = [
         call.args[0]
@@ -139,13 +139,12 @@ def test_respond_retries_when_generator_is_empty():
     assert len(error_chunks) >= 1
 
 
-def test_respond_emits_error_when_no_generator_defined():
-    """respond() must put an error message when the interpreter has no messages to respond to."""
+def test_respond_emits_error_when_response_is_empty():
+    """respond() must put an error message when the response iterable is empty."""
     async_i = AsyncInterpreter()
     mock_q = mock.MagicMock()
     async_i.output_queue = mock.MagicMock(sync_q=mock_q)
     async_i.auto_run = True
-    async_i.messages = []
 
     with mock.patch.object(async_i, "_respond_and_store", return_value=[]):
         with mock.patch("interpreter.core.async_core.time.sleep"):

--- a/tests/core/test_async_server_endpoints.py
+++ b/tests/core/test_async_server_endpoints.py
@@ -1,0 +1,462 @@
+import json
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from interpreter.core.async_core import AsyncInterpreter, Server
+
+
+@pytest.fixture
+def server_pair():
+    """Build a (TestClient, AsyncInterpreter) pair for a fresh server."""
+    interpreter = AsyncInterpreter()
+    return TestClient(Server(interpreter).app), interpreter
+
+
+@pytest.fixture
+def interpreter():
+    """A fresh AsyncInterpreter for building ad-hoc test servers."""
+    return AsyncInterpreter()
+
+
+@pytest.fixture
+def client(server_pair):
+    return server_pair[0]
+
+
+@pytest.fixture
+def client_no_raise(interpreter):
+    """TestClient that converts endpoint exceptions into 500 responses."""
+    return TestClient(Server(interpreter).app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def insecure_pair(monkeypatch):
+    """(TestClient, AsyncInterpreter) pair with the insecure routes registered.
+
+    create_router() reads INTERPRETER_INSECURE_ROUTES at router build time, so
+    the env var must be set before Server() is constructed.
+    """
+    monkeypatch.setenv("INTERPRETER_INSECURE_ROUTES", "true")
+    interpreter = AsyncInterpreter()
+    return TestClient(Server(interpreter).app), interpreter
+
+
+def test_heartbeat_endpoint(client):
+    """GET /heartbeat returns a simple aliveness payload."""
+    response = client.get("/heartbeat")
+    assert response.status_code == 200
+    assert response.json() == {"status": "alive"}
+
+
+def test_home_endpoint_serves_html(client):
+    """GET / serves the HTML chat page."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "<!DOCTYPE html>" in response.text
+
+
+def test_post_input_returns_success(client):
+    """POST / accepts an LMC chunk and reports success."""
+    response = client.post("/", json={"role": "user", "type": "message", "start": True})
+    assert response.status_code == 200
+    assert response.json() == {"status": "success"}
+
+
+def test_post_input_propagates_error(client, server_pair):
+    """POST / swallows input() failures and reports success.
+
+    KNOWN BUG: the handler calls async_interpreter.input(payload) without
+    await, so the coroutine is never awaited and its exception is never
+    raised. It responds 200 "success" and the error path is dead code. This
+    test documents the current (wrong) behavior.
+    """
+    _, interpreter = server_pair
+    interpreter.input = mock.AsyncMock(side_effect=ValueError("boom"))
+    response = client.post("/", json={"role": "user", "type": "message", "start": True})
+    assert response.status_code == 200
+    assert response.json() == {"status": "success"}
+
+
+def test_get_setting_returns_serialized_value(client):
+    """GET /settings/{name} returns the serialized interpreter attribute."""
+    response = client.get("/settings/auto_run")
+    assert response.status_code == 200
+    assert json.loads(json.loads(response.text)) == {"auto_run": False}
+
+
+def test_get_setting_unknown_name_returns_200_with_tuple_body(client):
+    """GET /settings/{name} for an unknown name returns 200 with an array body.
+
+    KNOWN BUG: the handler returns a Flask-style (content, status) tuple
+    which FastAPI does not interpret as a status code. The response is HTTP
+    200 with a JSON array [..., 404] instead of a 404 response.
+    """
+    response = client.get("/settings/no_such_setting")
+    assert response.status_code == 200
+    assert response.json() == [json.dumps({"error": "Setting not found"}), 404]
+
+
+def test_post_settings_unknown_llm_subsetting_returns_200_with_tuple_body(client):
+    """POST /settings with an unknown llm sub-key returns 200 with an array body.
+
+    KNOWN BUG: same Flask-style tuple issue; should be a 404 response but is
+    HTTP 200 with a JSON array [..., 404].
+    """
+    response = client.post("/settings", json={"llm": {"no_such_subkey": True}})
+    assert response.status_code == 200
+    assert response.json() == [
+        {"error": "Sub-setting no_such_subkey not found in llm"},
+        404,
+    ]
+
+
+def test_post_settings_unknown_top_level_key_returns_200_with_tuple_body(client):
+    """POST /settings with an unknown top-level key returns 200 with an array body.
+
+    KNOWN BUG: same Flask-style tuple issue; should be a 404 response but is
+    HTTP 200 with a JSON array [..., 404].
+    """
+    response = client.post("/settings", json={"no_such_setting": True})
+    assert response.status_code == 200
+    assert response.json() == [{"error": "Setting no_such_setting not found"}, 404]
+
+
+def test_chat_completion_rejects_non_user_last_message(client_no_raise):
+    """The OpenAI-compatible endpoint requires the last message to be from the user."""
+    response = client_no_raise.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "assistant", "content": "hi"}]},
+    )
+    assert response.status_code == 500
+
+
+def test_chat_completion_stop_token(client, server_pair):
+    """The {STOP} sentinel sets then clears the stop event without a response."""
+    _, interpreter = server_pair
+    with mock.patch("interpreter.core.async_core.time.sleep"):
+        response = client.post(
+            "/openai/chat/completions",
+            json={"messages": [{"role": "user", "content": "{STOP}"}]},
+        )
+    assert response.status_code == 200
+    assert not interpreter.stop_event.is_set()
+
+
+def test_chat_completion_context_mode_on(client, server_pair):
+    """{CONTEXT_MODE_ON} and {REQUIRE_START_ON} enable context mode."""
+    _, interpreter = server_pair
+    for token in ["{CONTEXT_MODE_ON}", "{REQUIRE_START_ON}"]:
+        client.post(
+            "/openai/chat/completions",
+            json={"messages": [{"role": "user", "content": token}]},
+        )
+        assert interpreter.context_mode is True
+
+
+def test_chat_completion_context_mode_off(client, server_pair):
+    """{CONTEXT_MODE_OFF} and {REQUIRE_START_OFF} disable context mode."""
+    _, interpreter = server_pair
+    interpreter.context_mode = True
+    for token in ["{CONTEXT_MODE_OFF}", "{REQUIRE_START_OFF}"]:
+        client.post(
+            "/openai/chat/completions",
+            json={"messages": [{"role": "user", "content": token}]},
+        )
+        assert interpreter.context_mode is False
+
+
+def test_chat_completion_auto_run_toggle(client, server_pair):
+    """{AUTO_RUN_ON} / {AUTO_RUN_OFF} flip the auto_run flag."""
+    _, interpreter = server_pair
+    client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "{AUTO_RUN_ON}"}]},
+    )
+    assert interpreter.auto_run is True
+    client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "{AUTO_RUN_OFF}"}]},
+    )
+    assert interpreter.auto_run is False
+
+
+def test_chat_completion_text_message_returns_assistant_reply(client, server_pair):
+    """A plain text user message is appended and answered via chat()."""
+    _, interpreter = server_pair
+    interpreter.chat = mock.MagicMock(
+        return_value=[{"role": "assistant", "content": "Hello there"}]
+    )
+
+    response = client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "hello"}]},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "chat.completion"
+    assert payload["choices"][0]["message"]["content"] == "Hello there"
+    assert any(
+        m.get("content") == "hello" for m in interpreter.messages
+    ), "the user message should be stored"
+
+
+def test_chat_completion_list_text_content(client, server_pair):
+    """A content list with a text part is appended as a user message."""
+    _, interpreter = server_pair
+    interpreter.chat = mock.MagicMock(
+        return_value=[{"role": "assistant", "content": "ok"}]
+    )
+    response = client.post(
+        "/openai/chat/completions",
+        json={
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+            ]
+        },
+    )
+    assert response.status_code == 200
+    assert any(
+        m.get("type") == "message" for m in interpreter.messages
+    ), "the text part should become a message"
+
+
+def test_chat_completion_list_base64_image(client, server_pair):
+    """A content list with a base64 image becomes an image message."""
+    _, interpreter = server_pair
+    interpreter.chat = mock.MagicMock(
+        return_value=[{"role": "assistant", "content": "ok"}]
+    )
+    url = "data:image/png;base64,iVBORw0KGgo="
+    response = client.post(
+        "/openai/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "image_url", "image_url": {"url": url}}],
+                }
+            ]
+        },
+    )
+    assert response.status_code == 200
+    image_messages = [m for m in interpreter.messages if m.get("type") == "image"]
+    assert len(image_messages) == 1
+    assert image_messages[0]["format"] == "base64.png"
+    assert image_messages[0]["content"] == "iVBORw0KGgo="
+
+
+def test_chat_completion_image_url_without_url_raises(client_no_raise):
+    """An image_url part missing the url field is rejected."""
+    response = client_no_raise.post(
+        "/openai/chat/completions",
+        json={
+            "messages": [
+                {"role": "user", "content": [{"type": "image_url", "image_url": {}}]}
+            ]
+        },
+    )
+    assert response.status_code == 500
+
+
+def test_chat_completion_image_url_without_base64_raises(client_no_raise):
+    """An image_url that is not a base64 data URI is rejected."""
+    response = client_no_raise.post(
+        "/openai/chat/completions",
+        json={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "http://x/y.png"}}
+                    ],
+                }
+            ]
+        },
+    )
+    assert response.status_code == 500
+
+
+def test_chat_completion_stream_run_code(client, server_pair):
+    """Streaming a 'yes' after a code message streams chunks from _respond_and_store."""
+    _, interpreter = server_pair
+    interpreter.messages = [
+        {
+            "role": "assistant",
+            "type": "code",
+            "format": "python",
+            "content": "print(1)",
+        }
+    ]
+    interpreter._respond_and_store = mock.MagicMock(
+        return_value=iter(
+            [
+                {"role": "assistant", "type": "message", "content": "hi"},
+                {"role": "assistant", "type": "code", "start": True, "format": "python"},
+                {"role": "assistant", "type": "code", "end": True, "format": "python"},
+            ]
+        )
+    )
+
+    response = client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "yes"}], "stream": True},
+    )
+    assert response.status_code == 200
+    assert "chat.completion.chunk" in response.text
+    assert "hi" in response.text
+
+
+def test_chat_completion_stream_confirmation_breaks(client, server_pair):
+    """A confirmation chunk with auto_run off asks and stops streaming."""
+    _, interpreter = server_pair
+    interpreter.auto_run = False
+    interpreter._respond_and_store = mock.MagicMock(
+        return_value=iter(
+            [
+                {
+                    "role": "computer",
+                    "type": "confirmation",
+                    "content": {"format": "python", "content": "print(1)"},
+                }
+            ]
+        )
+    )
+
+    response = client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "yes"}], "stream": True},
+    )
+    assert response.status_code == 200
+    assert "Do you want to run this code?" in response.text
+
+
+def test_chat_completion_stream_message_via_chat(client, server_pair):
+    """Streaming a normal message streams chunks produced by chat()."""
+    _, interpreter = server_pair
+    interpreter.chat = mock.MagicMock(
+        return_value=[{"role": "assistant", "type": "message", "content": "hi"}]
+    )
+
+    response = client.post(
+        "/openai/chat/completions",
+        json={"messages": [{"role": "user", "content": "hello"}], "stream": True},
+    )
+    assert response.status_code == 200
+    assert "hi" in response.text
+
+
+def test_insecure_routes_not_registered_by_default(monkeypatch):
+    """The /run route is absent unless INTERPRETER_INSECURE_ROUTES is enabled."""
+    monkeypatch.delenv("INTERPRETER_INSECURE_ROUTES", raising=False)
+    interpreter = AsyncInterpreter()
+    client = TestClient(Server(interpreter).app)
+    response = client.post("/run", json={"language": "python", "code": "1+1"})
+    assert response.status_code == 404
+
+
+def test_insecure_run_route(insecure_pair):
+    """With INTERPRETER_INSECURE_ROUTES=true, /run executes code via the computer."""
+    client, interpreter = insecure_pair
+    interpreter.computer.run = mock.MagicMock(return_value="42")
+
+    response = client.post("/run", json={"language": "python", "code": "1+1"})
+    assert response.status_code == 200
+    assert response.json() == {"output": "42"}
+
+
+def test_insecure_run_route_requires_language_and_code(insecure_pair):
+    """The /run route reports 200 with an array body when code is missing.
+
+    KNOWN BUG: Flask-style (content, status) tuple return; FastAPI does not
+    interpret the second element as a status code, so the response is HTTP
+    200 with a JSON array [..., 400] instead of a 400.
+    """
+    client, _ = insecure_pair
+
+    response = client.post("/run", json={"language": "python"})
+    assert response.status_code == 200
+    assert response.json() == [
+        {"error": "Both 'language' and 'code' are required."},
+        400,
+    ]
+
+
+def test_insecure_run_route_propagates_error(insecure_pair):
+    """The /run route reports 200 with an array body when computer.run raises.
+
+    KNOWN BUG: same Flask-style tuple issue; should be a 500 response but is
+    HTTP 200 with a JSON array [..., 500].
+    """
+    client, interpreter = insecure_pair
+    interpreter.computer.run = mock.MagicMock(side_effect=RuntimeError("oops"))
+
+    response = client.post("/run", json={"language": "python", "code": "1+1"})
+    assert response.status_code == 200
+    assert response.json() == [{"error": "oops"}, 500]
+
+
+def test_insecure_upload_route(insecure_pair, tmp_path):
+    """The /upload route writes the uploaded file to the requested path."""
+    client, _ = insecure_pair
+    target = tmp_path / "out.txt"
+
+    response = client.post(
+        "/upload",
+        files={"file": ("in.txt", b"payload")},
+        data={"path": str(target)},
+    )
+    assert response.status_code == 200
+    assert target.read_text() == "payload"
+
+
+def test_insecure_upload_route_propagates_error(insecure_pair):
+    """The /upload route reports 200 with an array body when it cannot write.
+
+    KNOWN BUG: same Flask-style tuple issue; should be a 500 response but is
+    HTTP 200 with a JSON array [..., 500].
+    """
+    client, _ = insecure_pair
+
+    response = client.post(
+        "/upload",
+        files={"file": ("in.txt", b"payload")},
+        data={"path": "/no/such/dir/out.txt"},
+    )
+    assert response.status_code == 200
+    assert response.json() == [
+        {"error": "[Errno 2] No such file or directory: '/no/such/dir/out.txt'"},
+        500,
+    ]
+
+
+def test_insecure_download_route_with_slashes_not_registered(insecure_pair):
+    """The /download route does not match paths containing slashes.
+
+    KNOWN BUG: the route is declared as /download/{filename}, which matches a
+    single path segment. Any path with a slash (including the absolute paths
+    the endpoint is meant to serve) falls through to 404. Documenting current
+    behavior; a fix would use {filename:path}.
+    """
+    client, _ = insecure_pair
+    response = client.get("/download/some/dir/file.bin")
+    assert response.status_code == 404
+
+
+def test_insecure_download_route_missing_file_reports_200_with_array_body(
+    insecure_pair,
+):
+    """A missing file on /download reports 200 with an array body.
+
+    KNOWN BUG: same Flask-style tuple issue; should be a 500 response but is
+    HTTP 200 with a JSON array [..., 500].
+    """
+    client, _ = insecure_pair
+
+    response = client.get("/download/nope.bin")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"error": "[Errno 2] No such file or directory: 'nope.bin'"},
+        500,
+    ]


### PR DESCRIPTION
## Background

`interpreter/core/async_core.py` (the async HTTP/WebSocket server) is the largest under-covered file in the repo (~45% statement coverage). The recently fixed send_output drain loop lives here, and CI's codecov/project gate flags regressions on it.

## Problem

The HTTP endpoints had no coverage. This PR is **tests only** — it documents the current behavior of every endpoint, including several that look wrong.

## What this PR changes

- **`tests/core/test_async_server_endpoints.py`** (new, 29 tests): `/heartbeat`, `/` (GET + POST), `/settings` GET + error branches, the OpenAI-compatible `/openai/chat/completions` endpoint (sentinels, context-mode/auto-run toggles, text/list/base64-image content, run-code streaming, confirmation-break streaming), and the opt-in insecure `/run`, `/upload`, `/download` routes (registered only when `INTERPRETER_INSECURE_ROUTES=true`).
- **`tests/core/test_async_core_extended.py`**: respond() error/retry branches and accumulate() bytes-content branches.

The buggy-looking behaviors are **documented, not fixed**, each marked `KNOWN BUG`:
- Flask-style `(content, status)` tuple returns that FastAPI serializes as HTTP 200 JSON arrays (never set a status code).
- `POST /` never awaits `input()`, so the payload is never processed and the error path is dead code.
- `/download/{filename}` cannot match paths with slashes.

These are resolved in a separate follow-up PR that flips the tests to the corrected behavior.

## Tests

- `pytest -m "not integration"` → 807 passed against **un-fixed** `main` code (all tests pass because they document current behavior).
- `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for asynchronous response handling, including byte accumulation, generator failures, retries, and empty responses.
  * Added comprehensive tests for server endpoints, including health checks, settings, chat interactions, control tokens, text and image inputs, streaming, and file operations.
  * Documented current edge-case behaviors in endpoint responses and downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->