### PR TITLE
fix(async): HTTP endpoints honor status codes, await input, match slashed paths

### DIFF
--- a/interpreter/core/async_core.py
+++ b/interpreter/core/async_core.py
@@ -796,10 +796,10 @@ def create_router(async_interpreter):
     @router.post("/")
     async def post_input(payload: Dict[str, Any]):
         try:
-            async_interpreter.input(payload)
+            await async_interpreter.input(payload)
             return {"status": "success"}
         except Exception as e:
-            return {"error": str(e)}, 500
+            return JSONResponse({"error": str(e)}, status_code=500)
 
     @router.post("/settings")
     async def set_settings(payload: Dict[str, Any]):
@@ -827,15 +827,22 @@ def create_router(async_interpreter):
                         if hasattr(getattr(async_interpreter, key), sub_key):
                             setattr(getattr(async_interpreter, key), sub_key, sub_value)
                         else:
-                            return {
-                                "error": f"Sub-setting {sub_key} not found in {key}"
-                            }, 404
+                            return JSONResponse(
+                                {
+                                    "error": f"Sub-setting {sub_key} not found in {key}"
+                                },
+                                status_code=404,
+                            )
                 else:
-                    return {"error": f"Setting {key} not found"}, 404
+                    return JSONResponse(
+                        {"error": f"Setting {key} not found"}, status_code=404
+                    )
             elif hasattr(async_interpreter, key):
                 setattr(async_interpreter, key, value)
             else:
-                return {"error": f"Setting {key} not found"}, 404
+                return JSONResponse(
+                    {"error": f"Setting {key} not found"}, status_code=404
+                )
 
         return {"status": "success"}
 
@@ -846,9 +853,12 @@ def create_router(async_interpreter):
             try:
                 return json.dumps({setting: setting_value})
             except TypeError:
-                return {"error": "Failed to serialize the setting value"}, 500
+                return JSONResponse(
+                    {"error": "Failed to serialize the setting value"},
+                    status_code=500,
+                )
         else:
-            return json.dumps({"error": "Setting not found"}), 404
+            return JSONResponse({"error": "Setting not found"}, status_code=404)
 
     if os.getenv("INTERPRETER_INSECURE_ROUTES", "").lower() == "true":
 
@@ -856,14 +866,16 @@ def create_router(async_interpreter):
         async def run_code(payload: Dict[str, Any]):
             language, code = payload.get("language"), payload.get("code")
             if not (language and code):
-                return {"error": "Both 'language' and 'code' are required."}, 400
+                return JSONResponse(
+                    {"error": "Both 'language' and 'code' are required."}, status_code=400
+                )
             try:
                 print(f"Running {language}:", code)
                 output = async_interpreter.computer.run(language, code)
                 print("Output:", output)
                 return {"output": output}
             except Exception as e:
-                return {"error": str(e)}, 500
+                return JSONResponse({"error": str(e)}, status_code=500)
 
         @router.post("/upload")
         async def upload_file(file: UploadFile = File(...), path: str = Form(...)):
@@ -872,16 +884,16 @@ def create_router(async_interpreter):
                     shutil.copyfileobj(file.file, output_file)
                 return {"status": "success"}
             except Exception as e:
-                return {"error": str(e)}, 500
+                return JSONResponse({"error": str(e)}, status_code=500)
 
-        @router.get("/download/{filename}")
+        @router.get("/download/{filename:path}")
         async def download_file(filename: str):
             try:
                 return StreamingResponse(
                     open(filename, "rb"), media_type="application/octet-stream"
                 )
             except Exception as e:
-                return {"error": str(e)}, 500
+                return JSONResponse({"error": str(e)}, status_code=500)
 
     ### OPENAI COMPATIBLE ENDPOINT
 

--- a/tests/core/test_async_server_endpoints.py
+++ b/tests/core/test_async_server_endpoints.py
@@ -65,18 +65,12 @@ def test_post_input_returns_success(client):
 
 
 def test_post_input_propagates_error(client, server_pair):
-    """POST / swallows input() failures and reports success.
-
-    KNOWN BUG: the handler calls async_interpreter.input(payload) without
-    await, so the coroutine is never awaited and its exception is never
-    raised. It responds 200 "success" and the error path is dead code. This
-    test documents the current (wrong) behavior.
-    """
+    """POST / returns a 500 with the error message when input() fails."""
     _, interpreter = server_pair
     interpreter.input = mock.AsyncMock(side_effect=ValueError("boom"))
     response = client.post("/", json={"role": "user", "type": "message", "start": True})
-    assert response.status_code == 200
-    assert response.json() == {"status": "success"}
+    assert response.status_code == 500
+    assert response.json() == {"error": "boom"}
 
 
 def test_get_setting_returns_serialized_value(client):
@@ -86,41 +80,27 @@ def test_get_setting_returns_serialized_value(client):
     assert json.loads(json.loads(response.text)) == {"auto_run": False}
 
 
-def test_get_setting_unknown_name_returns_200_with_tuple_body(client):
-    """GET /settings/{name} for an unknown name returns 200 with an array body.
-
-    KNOWN BUG: the handler returns a Flask-style (content, status) tuple
-    which FastAPI does not interpret as a status code. The response is HTTP
-    200 with a JSON array [..., 404] instead of a 404 response.
-    """
+def test_get_setting_unknown_name_returns_404(client):
+    """GET /settings/{name} for an unknown name returns a 404 response."""
     response = client.get("/settings/no_such_setting")
-    assert response.status_code == 200
-    assert response.json() == [json.dumps({"error": "Setting not found"}), 404]
+    assert response.status_code == 404
+    assert response.json() == {"error": "Setting not found"}
 
 
-def test_post_settings_unknown_llm_subsetting_returns_200_with_tuple_body(client):
-    """POST /settings with an unknown llm sub-key returns 200 with an array body.
-
-    KNOWN BUG: same Flask-style tuple issue; should be a 404 response but is
-    HTTP 200 with a JSON array [..., 404].
-    """
+def test_post_settings_unknown_llm_subsetting_returns_404(client):
+    """POST /settings with an unknown llm sub-key returns a 404 response."""
     response = client.post("/settings", json={"llm": {"no_such_subkey": True}})
-    assert response.status_code == 200
-    assert response.json() == [
-        {"error": "Sub-setting no_such_subkey not found in llm"},
-        404,
-    ]
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": "Sub-setting no_such_subkey not found in llm"
+    }
 
 
-def test_post_settings_unknown_top_level_key_returns_200_with_tuple_body(client):
-    """POST /settings with an unknown top-level key returns 200 with an array body.
-
-    KNOWN BUG: same Flask-style tuple issue; should be a 404 response but is
-    HTTP 200 with a JSON array [..., 404].
-    """
+def test_post_settings_unknown_top_level_key_returns_404(client):
+    """POST /settings with an unknown top-level key returns a 404 response."""
     response = client.post("/settings", json={"no_such_setting": True})
-    assert response.status_code == 200
-    assert response.json() == [{"error": "Setting no_such_setting not found"}, 404]
+    assert response.status_code == 404
+    assert response.json() == {"error": "Setting no_such_setting not found"}
 
 
 def test_chat_completion_rejects_non_user_last_message(client_no_raise):
@@ -367,34 +347,24 @@ def test_insecure_run_route(insecure_pair):
 
 
 def test_insecure_run_route_requires_language_and_code(insecure_pair):
-    """The /run route reports 200 with an array body when code is missing.
-
-    KNOWN BUG: Flask-style (content, status) tuple return; FastAPI does not
-    interpret the second element as a status code, so the response is HTTP
-    200 with a JSON array [..., 400] instead of a 400.
-    """
+    """The /run route rejects requests missing language or code with a 400."""
     client, _ = insecure_pair
 
     response = client.post("/run", json={"language": "python"})
-    assert response.status_code == 200
-    assert response.json() == [
-        {"error": "Both 'language' and 'code' are required."},
-        400,
-    ]
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": "Both 'language' and 'code' are required."
+    }
 
 
 def test_insecure_run_route_propagates_error(insecure_pair):
-    """The /run route reports 200 with an array body when computer.run raises.
-
-    KNOWN BUG: same Flask-style tuple issue; should be a 500 response but is
-    HTTP 200 with a JSON array [..., 500].
-    """
+    """The /run route returns a 500 when computer.run raises."""
     client, interpreter = insecure_pair
     interpreter.computer.run = mock.MagicMock(side_effect=RuntimeError("oops"))
 
     response = client.post("/run", json={"language": "python", "code": "1+1"})
-    assert response.status_code == 200
-    assert response.json() == [{"error": "oops"}, 500]
+    assert response.status_code == 500
+    assert response.json() == {"error": "oops"}
 
 
 def test_insecure_upload_route(insecure_pair, tmp_path):
@@ -412,11 +382,7 @@ def test_insecure_upload_route(insecure_pair, tmp_path):
 
 
 def test_insecure_upload_route_propagates_error(insecure_pair):
-    """The /upload route reports 200 with an array body when it cannot write.
-
-    KNOWN BUG: same Flask-style tuple issue; should be a 500 response but is
-    HTTP 200 with a JSON array [..., 500].
-    """
+    """The /upload route returns a 500 when it cannot write the file."""
     client, _ = insecure_pair
 
     response = client.post(
@@ -424,39 +390,25 @@ def test_insecure_upload_route_propagates_error(insecure_pair):
         files={"file": ("in.txt", b"payload")},
         data={"path": "/no/such/dir/out.txt"},
     )
-    assert response.status_code == 200
-    assert response.json() == [
-        {"error": "[Errno 2] No such file or directory: '/no/such/dir/out.txt'"},
-        500,
-    ]
+    assert response.status_code == 500
+    assert "No such file or directory" in response.json()["error"]
 
 
-def test_insecure_download_route_with_slashes_not_registered(insecure_pair):
-    """The /download route does not match paths containing slashes.
-
-    KNOWN BUG: the route is declared as /download/{filename}, which matches a
-    single path segment. Any path with a slash (including the absolute paths
-    the endpoint is meant to serve) falls through to 404. Documenting current
-    behavior; a fix would use {filename:path}.
-    """
+def test_insecure_download_route(insecure_pair, tmp_path):
+    """The /download route streams a file at an absolute path."""
     client, _ = insecure_pair
-    response = client.get("/download/some/dir/file.bin")
-    assert response.status_code == 404
+    source = tmp_path / "file.bin"
+    source.write_bytes(b"xyz")
+
+    response = client.get(f"/download/{source}")
+    assert response.status_code == 200
+    assert response.content == b"xyz"
 
 
-def test_insecure_download_route_missing_file_reports_200_with_array_body(
-    insecure_pair,
-):
-    """A missing file on /download reports 200 with an array body.
-
-    KNOWN BUG: same Flask-style tuple issue; should be a 500 response but is
-    HTTP 200 with a JSON array [..., 500].
-    """
+def test_insecure_download_route_missing_file(insecure_pair):
+    """The /download route returns a 500 for a missing file."""
     client, _ = insecure_pair
 
     response = client.get("/download/nope.bin")
-    assert response.status_code == 200
-    assert response.json() == [
-        {"error": "[Errno 2] No such file or directory: 'nope.bin'"},
-        500,
-    ]
+    assert response.status_code == 500
+    assert "No such file or directory" in response.json()["error"]


### PR DESCRIPTION
## Background

Follow-up to #241 (tests-only coverage of the async server HTTP endpoints). That PR documented several behaviors that look wrong, each marked `KNOWN BUG`. This PR is the deliberate bug-fix phase: fix the code, flip the documenting tests to assert the corrected behavior.

## Problem

Three bugs in `interpreter/core/async_core.py`, all invisible before the tests existed because they fail *silently*:

1. **Flask-style tuple returns** — error paths return `(content, status)` like Flask, but FastAPI doesn't interpret the second element as a status code. Every error serialized as **HTTP 200** with a JSON array body `[{error}, 404]`. Clients saw "success" while the server failed.
2. **`POST /` never awaited `input()`** — the coroutine was created and dropped (RuntimeWarning), so the payload was never processed and the error path was dead code. The endpoint replied "success" for every request.
3. **`/download/{filename}` couldn't match slashes** — the endpoint is meant to serve absolute paths, but a single-segment route 404'd on any path containing a slash.

## What this PR changes

- `interpreter/core/async_core.py`: `await` on `input(payload)`; all error tuple returns converted to `JSONResponse(..., status_code=...)`; `/download/{filename}` → `/download/{filename:path}`.
- `tests/core/test_async_server_endpoints.py`: the 9 `KNOWN BUG` tests flipped to assert the corrected behavior (real status codes, awaited input, slashed downloads).

The flipped tests **fail without** the code changes (verified by stashing the fix) and pass with them.

## Tests

- `pytest -m "not integration"` → 807 passed.
- `ruff check` clean.
- Stacked on #241; only the fix + test flips are in this diff.

## Related work

- #241 (coverage, tests only) — merge this first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API errors now return proper HTTP status codes with consistent JSON error details.
  * File downloads now support filenames containing path separators.
  * Missing or invalid files correctly return server error responses instead of appearing successful.

* **Tests**
  * Updated endpoint coverage to verify accurate error statuses, JSON responses, and download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->