### PR TITLE
test(async): cover async server WebSocket receive path and auth middleware

### DIFF
--- a/tests/core/computer/display/point/test_point.py
+++ b/tests/core/computer/display/point/test_point.py
@@ -72,6 +72,7 @@ def test_find_icon_filters_extremes_and_returns_normalized_center(monkeypatch):
     captured = {}
 
     def fake_image_search(description, icons, hashes, debug):
+        """Record the call args and return the first icon for filtering."""
         captured["description"] = description
         captured["icons"] = icons
         return icons[:1]
@@ -105,6 +106,7 @@ def test_find_icon_skips_description_icon_suffix(monkeypatch):
     captured = {}
 
     def fake_image_search(description, icons, hashes, debug):
+        """Record the description and return no matching icons."""
         captured["description"] = description
         return []
 
@@ -156,6 +158,7 @@ def test_find_icon_combines_overlapping_boxes(monkeypatch):
     ]
 
     def fake_image_search(description, icons, hashes, debug):
+        """Return the first icon so find_icon yields its normalized coordinate."""
         return icons[:1]
 
     with mock.patch.object(point_mod, "get_element_boxes", return_value=boxes):
@@ -218,6 +221,7 @@ class _FakeBatch:
         return self._items[idx]
 
     def to(self, device):
+        """Return self; the fake batch ignores device transfer."""
         return self
 
 

--- a/tests/core/computer/display/point/test_point.py
+++ b/tests/core/computer/display/point/test_point.py
@@ -389,12 +389,18 @@ def test_get_element_boxes_permutates_when_env_set(monkeypatch):
     random_stub.uniform = mock.Mock(
         side_effect=[float(n) for n in range(1, 11)]
     )
-    # Select from real production candidate sets: blockSize (odd 1..9),
-    # adaptiveMethod, thresholdType. Repeat the sequence so all 10 iterations
-    # are covered; each iteration still varies which candidate is picked.
-    random_stub.choice = mock.Mock(
-        side_effect=[1, 0, 3, 5, 2, 1, 9, 0, 3, 1, 2, 1] * 3
-    )
+    # Return values only ever come from the supplied options (odd block sizes,
+    # adaptive methods, threshold types), while rotating through them so the
+    # threshold parameters actually change across the 10 iterations.
+    choice_state = {}
+
+    def _rotate(options):
+        key = tuple(options)
+        index = choice_state.get(key, 0)
+        choice_state[key] = index + 1
+        return options[index % len(options)]
+
+    random_stub.choice = mock.Mock(side_effect=_rotate)
     random_stub.randint = mock.Mock(side_effect=[-5, 5] * 5)
     monkeypatch.setitem(sys.modules, "random", random_stub)
 

--- a/tests/core/computer/display/point/test_point.py
+++ b/tests/core/computer/display/point/test_point.py
@@ -182,3 +182,204 @@ def test_take_screenshot_to_pil_captures_and_cleans_up(monkeypatch, tmp_path):
     run.assert_called_once_with(["screencapture", "-x", filename], check=True)
     remove.assert_called_once_with(filename)
     assert result.size == (50, 50)
+
+
+def _fake_embed():
+    """A tensor-ish fake with the .to/.unsqueeze surface image_search touches."""
+
+    def _to(device):
+        return _fake_embed()
+
+    def _unsqueeze(_dim):
+        return _fake_embed()
+
+    e = SimpleNamespace(label="embed")
+    e.to = _to
+    e.unsqueeze = _unsqueeze
+    return e
+
+
+class _FakeBatch:
+    """Mimics the tensor surface model.encode exposes: [0], [1:] and .to()."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return _FakeBatch(self._items[idx])
+        return self._items[idx]
+
+    def to(self, device):
+        return self
+
+
+def test_image_search_embeds_unhashed_and_filters_by_score(monkeypatch):
+    """image_search embeds query + uncached icons, caches hashes, and returns
+    only icons whose semantic score exceeds 90."""
+    point_mod = _import_point(monkeypatch)
+
+    icons = [
+        {"hash": "new1", "data": "img1"},
+        {"hash": "cached", "data": "img2"},
+    ]
+    hashes = {"cached": _fake_embed()}
+
+    query = _fake_embed()
+    model = mock.Mock()
+    model.encode.return_value = _FakeBatch([query, _fake_embed()])
+    monkeypatch.setattr(point_mod, "model", model)
+    monkeypatch.setattr(
+        point_mod.torch,
+        "cat",
+        lambda *_a, **_k: [_fake_embed(), hashes["cached"]],
+    )
+    monkeypatch.setattr(
+        point_mod.util,
+        "semantic_search",
+        lambda *_a, **_k: [
+            [
+                {"corpus_id": 0, "score": 99.0},
+                {"corpus_id": 1, "score": 95.0},
+            ]
+        ],
+    )
+
+    result = point_mod.image_search(query, icons, hashes, False)
+
+    encoded = model.encode.call_args[0][0]
+    assert encoded[0] is query
+    assert encoded[1:] == ["img1"]
+    assert "new1" in hashes
+    assert [i["hash"] for i in result] == ["new1", "cached"]
+
+
+def test_image_search_forces_top_hit_into_results(monkeypatch):
+    """A low-scoring top hit is still included ahead of the qualifying ones."""
+    point_mod = _import_point(monkeypatch)
+
+    icons = [
+        {"hash": "new1", "data": "img1"},
+        {"hash": "new2", "data": "img2"},
+    ]
+    hashes = {}
+    query = _fake_embed()
+    model = mock.Mock()
+    model.encode.return_value = _FakeBatch([query, _fake_embed(), _fake_embed()])
+    monkeypatch.setattr(point_mod, "model", model)
+    monkeypatch.setattr(
+        point_mod.torch,
+        "cat",
+        lambda *_a, **_k: [_fake_embed(), _fake_embed()],
+    )
+    monkeypatch.setattr(
+        point_mod.util,
+        "semantic_search",
+        lambda *_a, **_k: [
+            [
+                {"corpus_id": 0, "score": 50.0},
+                {"corpus_id": 1, "score": 99.0},
+            ]
+        ],
+    )
+
+    result = point_mod.image_search(query, icons, hashes, False)
+
+    assert [i["hash"] for i in result] == ["new1", "new2"]
+
+
+def test_image_search_slow_model_uses_embed_images(monkeypatch):
+    """When fast_model is False, embedding goes through embed_images()."""
+    point_mod = _import_point(monkeypatch)
+    monkeypatch.setattr(point_mod, "fast_model", False)
+
+    icons = [{"hash": "new1", "data": "img1"}]
+    hashes = {}
+    embeds = _FakeBatch([_fake_embed(), _fake_embed()])
+    monkeypatch.setattr(
+        point_mod, "embed_images", mock.Mock(return_value=embeds), raising=False
+    )
+    monkeypatch.setattr(point_mod, "transforms", None, raising=False)
+    monkeypatch.setattr(point_mod.torch, "cat", lambda *_a, **_k: [_fake_embed()])
+    monkeypatch.setattr(
+        point_mod.util,
+        "semantic_search",
+        lambda *_a, **_k: [[{"corpus_id": 0, "score": 100.0}]],
+    )
+
+    result = point_mod.image_search("folder", icons, hashes, False)
+
+    assert [i["hash"] for i in result] == ["new1"]
+
+
+def test_get_element_boxes_builds_boxes_from_contours(monkeypatch):
+    """get_element_boxes runs the cv2 pipeline and returns boundingRect boxes."""
+    point_mod = _import_point(monkeypatch)
+
+    screenshot = Image.new("RGB", (100, 100), "white")
+
+    monkeypatch.setattr(point_mod.cv2, "cvtColor", lambda *_a, **_k: "bgr", raising=False)
+    monkeypatch.setattr(
+        point_mod.cv2, "adaptiveThreshold", lambda *_a, **_k: "binary", raising=False
+    )
+    monkeypatch.setattr(
+        point_mod.cv2,
+        "findContours",
+        lambda *_a, **_k: ([{"contour": 1}, {"contour": 2}], None),
+        raising=False,
+    )
+    monkeypatch.setattr(point_mod.cv2, "drawContours", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setattr(
+        point_mod.cv2,
+        "boundingRect",
+        lambda contour: {"contour": 1} == contour and (5, 10, 20, 30) or (15, 25, 10, 5),
+        raising=False,
+    )
+    # process_image's default args reference these at definition time.
+    monkeypatch.setattr(point_mod.cv2, "ADAPTIVE_THRESH_MEAN_C", 0, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "THRESH_BINARY_INV", 1, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "COLOR_RGB2BGR", 4, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "COLOR_BGR2GRAY", 5, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "RETR_LIST", 6, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "CHAIN_APPROX_NONE", 7, raising=False)
+
+    boxes = point_mod.get_element_boxes(screenshot, False)
+
+    assert boxes == [
+        {"x": 5, "y": 10, "width": 20, "height": 30},
+        {"x": 15, "y": 25, "width": 10, "height": 5},
+    ]
+
+
+def test_get_element_boxes_permutates_when_env_set(monkeypatch):
+    """OI_POINT_PERMUTATE=True runs process_image with randomized parameters."""
+    point_mod = _import_point(monkeypatch)
+    monkeypatch.setenv("OI_POINT_PERMUTATE", "True")
+
+    screenshot = Image.new("RGB", (100, 100), "white")
+
+    monkeypatch.setattr(point_mod.cv2, "cvtColor", lambda *_a, **_k: "bgr", raising=False)
+    monkeypatch.setattr(
+        point_mod.cv2, "adaptiveThreshold", lambda *_a, **_k: "binary", raising=False
+    )
+    monkeypatch.setattr(
+        point_mod.cv2,
+        "findContours",
+        lambda *_a, **_k: ([{"contour": 1}], None),
+        raising=False,
+    )
+    monkeypatch.setattr(point_mod.cv2, "drawContours", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "boundingRect", lambda _c: (1, 2, 3, 4), raising=False)
+    # process_image's default args reference these at definition time.
+    monkeypatch.setattr(point_mod.cv2, "ADAPTIVE_THRESH_MEAN_C", 0, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "THRESH_BINARY_INV", 1, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "ADAPTIVE_THRESH_GAUSSIAN_C", 2, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "THRESH_BINARY", 3, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "COLOR_RGB2BGR", 4, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "COLOR_BGR2GRAY", 5, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "RETR_LIST", 6, raising=False)
+    monkeypatch.setattr(point_mod.cv2, "CHAIN_APPROX_NONE", 7, raising=False)
+
+    boxes = point_mod.get_element_boxes(screenshot, False)
+
+    assert boxes == [{"x": 1, "y": 2, "width": 3, "height": 4}]

--- a/tests/core/computer/display/point/test_point.py
+++ b/tests/core/computer/display/point/test_point.py
@@ -19,6 +19,7 @@ from tests.helpers import install_point_heavy_deps
 
 
 def _import_point(monkeypatch):
+    """Install heavy deps then import the point module for testing."""
     install_point_heavy_deps(monkeypatch)
     import interpreter.core.computer.display.point.point as point_mod
 
@@ -190,9 +191,11 @@ def _fake_embed():
     """A tensor-ish fake with the .to/.unsqueeze surface image_search touches."""
 
     def _to(device):
+        """Return a fresh fake embed (device transfer is a no-op)."""
         return _fake_embed()
 
     def _unsqueeze(_dim):
+        """Return a fresh fake embed (dimension expansion is a no-op)."""
         return _fake_embed()
 
     e = SimpleNamespace(label="embed")
@@ -205,9 +208,11 @@ class _FakeBatch:
     """Mimics the tensor surface model.encode exposes: [0], [1:] and .to()."""
 
     def __init__(self, items):
+        """Store the underlying item list for slicing/indexing."""
         self._items = items
 
     def __getitem__(self, idx):
+        """Return an item, or a nested fake batch when indexed with a slice."""
         if isinstance(idx, slice):
             return _FakeBatch(self._items[idx])
         return self._items[idx]
@@ -395,6 +400,7 @@ def test_get_element_boxes_permutates_when_env_set(monkeypatch):
     choice_state = {}
 
     def _rotate(options):
+        """Return each supplied option in turn, wrapping around to the first."""
         key = tuple(options)
         index = choice_state.get(key, 0)
         choice_state[key] = index + 1

--- a/tests/core/computer/display/point/test_point.py
+++ b/tests/core/computer/display/point/test_point.py
@@ -389,8 +389,11 @@ def test_get_element_boxes_permutates_when_env_set(monkeypatch):
     random_stub.uniform = mock.Mock(
         side_effect=[float(n) for n in range(1, 11)]
     )
+    # Select from real production candidate sets: blockSize (odd 1..9),
+    # adaptiveMethod, thresholdType. Repeat the sequence so all 10 iterations
+    # are covered; each iteration still varies which candidate is picked.
     random_stub.choice = mock.Mock(
-        side_effect=[0, 3, 2, 1] * 8  # blockSize, adaptiveMethod, thresholdType
+        side_effect=[1, 0, 3, 5, 2, 1, 9, 0, 3, 1, 2, 1] * 3
     )
     random_stub.randint = mock.Mock(side_effect=[-5, 5] * 5)
     monkeypatch.setitem(sys.modules, "random", random_stub)

--- a/tests/core/computer/display/point/test_point.py
+++ b/tests/core/computer/display/point/test_point.py
@@ -13,6 +13,8 @@ from unittest import mock
 import pytest
 from PIL import Image
 
+import sys
+
 from tests.helpers import install_point_heavy_deps
 
 
@@ -240,7 +242,7 @@ def test_image_search_embeds_unhashed_and_filters_by_score(monkeypatch):
         lambda *_a, **_k: [
             [
                 {"corpus_id": 0, "score": 99.0},
-                {"corpus_id": 1, "score": 95.0},
+                {"corpus_id": 1, "score": 90.0},
             ]
         ],
     )
@@ -251,7 +253,8 @@ def test_image_search_embeds_unhashed_and_filters_by_score(monkeypatch):
     assert encoded[0] is query
     assert encoded[1:] == ["img1"]
     assert "new1" in hashes
-    assert [i["hash"] for i in result] == ["new1", "cached"]
+    # Only the strictly->90 hit survives; the 90.0 boundary is filtered out.
+    assert [i["hash"] for i in result] == ["new1"]
 
 
 def test_image_search_forces_top_hit_into_results(monkeypatch):
@@ -352,16 +355,17 @@ def test_get_element_boxes_builds_boxes_from_contours(monkeypatch):
 
 
 def test_get_element_boxes_permutates_when_env_set(monkeypatch):
-    """OI_POINT_PERMUTATE=True runs process_image with randomized parameters."""
+    """OI_POINT_PERMUTATE=True varies threshold parameters across iterations."""
+    import types
+
     point_mod = _import_point(monkeypatch)
     monkeypatch.setenv("OI_POINT_PERMUTATE", "True")
 
     screenshot = Image.new("RGB", (100, 100), "white")
 
     monkeypatch.setattr(point_mod.cv2, "cvtColor", lambda *_a, **_k: "bgr", raising=False)
-    monkeypatch.setattr(
-        point_mod.cv2, "adaptiveThreshold", lambda *_a, **_k: "binary", raising=False
-    )
+    adaptive = mock.Mock(return_value="binary")
+    monkeypatch.setattr(point_mod.cv2, "adaptiveThreshold", adaptive, raising=False)
     monkeypatch.setattr(
         point_mod.cv2,
         "findContours",
@@ -380,6 +384,24 @@ def test_get_element_boxes_permutates_when_env_set(monkeypatch):
     monkeypatch.setattr(point_mod.cv2, "RETR_LIST", 6, raising=False)
     monkeypatch.setattr(point_mod.cv2, "CHAIN_APPROX_NONE", 7, raising=False)
 
+    # get_element_boxes does `import random` locally, so stub sys.modules.
+    random_stub = types.ModuleType("random")
+    random_stub.uniform = mock.Mock(
+        side_effect=[float(n) for n in range(1, 11)]
+    )
+    random_stub.choice = mock.Mock(
+        side_effect=[0, 3, 2, 1] * 8  # blockSize, adaptiveMethod, thresholdType
+    )
+    random_stub.randint = mock.Mock(side_effect=[-5, 5] * 5)
+    monkeypatch.setitem(sys.modules, "random", random_stub)
+
     boxes = point_mod.get_element_boxes(screenshot, False)
 
     assert boxes == [{"x": 1, "y": 2, "width": 3, "height": 4}]
+    assert adaptive.call_count == 10
+    param_sets = {
+        (c.kwargs["adaptiveMethod"], c.kwargs["thresholdType"], c.kwargs["C"])
+        for c in adaptive.call_args_list
+    }
+    # The random draws must have actually changed the threshold parameters.
+    assert len(param_sets) > 1

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -88,6 +88,7 @@ class TestWebSocketOriginPolicy(TestCase):
 
 class TestSettingsEndpointGuards(TestCase):
     def setUp(self):
+        """Build a TestClient around a fresh server app."""
         from fastapi.testclient import TestClient
 
         self.client = TestClient(Server(AsyncInterpreter()).app)
@@ -119,6 +120,7 @@ class TestSettingsEndpointGuards(TestCase):
 
 class TestAsyncApprovalBinding(TestCase):
     def setUp(self):
+        """An interpreter that pauses at confirmation chunks."""
         self.interpreter = AsyncInterpreter()
         self.interpreter.auto_run = False
 
@@ -155,6 +157,7 @@ class TestAsyncApprovalBinding(TestCase):
 
 class TestAsyncInputCommandHandling(TestCase):
     def setUp(self):
+        """An interpreter with a live respond thread and queued error output."""
         self.interpreter = AsyncInterpreter()
         self.interpreter.auto_run = False
         self.interpreter.output_queue = mock.MagicMock()
@@ -167,6 +170,7 @@ class TestAsyncInputCommandHandling(TestCase):
         import asyncio
 
         async def run():
+            """Feed the start/content/end command chunks to interpreter.input."""
             await self.interpreter.input(
                 {"role": "user", "type": "command", "start": True}
             )
@@ -192,6 +196,7 @@ class TestAsyncInputCommandHandling(TestCase):
         import asyncio
 
         async def run():
+            """Feed a start-only command chunk and check join is never called."""
             await self.interpreter.input(
                 {"role": "user", "type": "command", "start": True}
             )
@@ -241,6 +246,7 @@ class TestAsyncInputCommandHandling(TestCase):
 
 class TestAsyncRespondApproval(TestCase):
     def setUp(self):
+        """An interpreter whose respond output lands on a mock sync queue."""
         self.interpreter = AsyncInterpreter()
         self.interpreter.auto_run = False
         self.mock_q = mock.MagicMock()
@@ -256,11 +262,13 @@ class TestAsyncRespondApproval(TestCase):
         import time
 
         def fake_store():
+            """Yield the test chunks as the stored response stream."""
             yield from chunks
 
         with mock.patch.object(self.interpreter, "_respond_and_store", fake_store):
 
             def respond_thread():
+                """Run respond() to completion on a worker thread."""
                 self.interpreter.respond()
 
             worker = threading.Thread(target=respond_thread)

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -73,6 +73,15 @@ class TestWebSocketOriginPolicy(TestCase):
     def test_remote_origins_rejected(self):
         self.assertFalse(is_websocket_origin_allowed("https://evil.example"))
 
+    def test_null_origin_allowed_for_non_browser_clients(self):
+        """The literal 'null' origin is accepted, as some local clients send it."""
+        self.assertTrue(is_websocket_origin_allowed("null"))
+
+    def test_non_http_scheme_rejected_even_for_local_host(self):
+        """Origins with a non-http scheme (e.g. ftp) are never allowed."""
+        self.assertFalse(is_websocket_origin_allowed("ftp://localhost"))
+        self.assertFalse(is_websocket_origin_allowed("file:///etc/passwd"))
+
 
 class TestSettingsEndpointGuards(TestCase):
     def setUp(self):
@@ -292,3 +301,104 @@ class TestAsyncRespondApproval(TestCase):
 
         put_chunks = [call.args[0] for call in self.mock_q.put.call_args_list]
         self.assertFalse(any(c.get("content") == "ok" for c in put_chunks))
+
+
+class TestServerRunAndSetters(TestCase):
+    def test_host_setter_recreates_uvicorn_server(self):
+        """Assigning Server.host rebuilds the underlying uvicorn.Server."""
+        s = Server(AsyncInterpreter())
+        old_uvicorn = s.uvicorn_server
+        s.host = "0.0.0.0"
+        self.assertEqual(s.host, "0.0.0.0")
+        self.assertIsNot(s.uvicorn_server, old_uvicorn)
+        self.assertEqual(s.uvicorn_server.config.host, "0.0.0.0")
+
+    def test_port_setter_recreates_uvicorn_server(self):
+        """Assigning Server.port rebuilds the underlying uvicorn.Server."""
+        s = Server(AsyncInterpreter())
+        old_uvicorn = s.uvicorn_server
+        s.port = 9999
+        self.assertEqual(s.port, 9999)
+        self.assertIsNot(s.uvicorn_server, old_uvicorn)
+        self.assertEqual(s.uvicorn_server.config.port, 9999)
+
+    def test_run_warns_when_host_is_0_0_0_0(self):
+        """run() with 0.0.0.0 warns about LAN exposure and binds to the public IP."""
+        import contextlib
+        import io
+
+        s = Server(AsyncInterpreter())
+        s.uvicorn_server.run = mock.Mock()
+        # Set host directly on config (bypasses the property setter which recreates uvicorn).
+        s.config.host = "0.0.0.0"
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            s.run()
+        out = buf.getvalue()
+        self.assertIn("Warning", out)
+        self.assertIn("0.0.0.0", out)
+        s.uvicorn_server.run.assert_called_once_with()
+
+    def test_run_with_explicit_host_and_port(self):
+        """run(host, port) overrides the stored config and binds to that host."""
+        import contextlib
+        import io
+
+        s = Server(AsyncInterpreter())
+        s.uvicorn_server.run = mock.Mock()
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with mock.patch("interpreter.core.async_core.uvicorn.Server"):
+                s.run(host="127.0.0.1", port=8080)
+        self.assertEqual(s.host, "127.0.0.1")
+        self.assertEqual(s.port, 8080)
+        out = buf.getvalue()
+        self.assertIn("127.0.0.1", out)
+        self.assertIn("8080", out)
+
+
+class TestServerAuthMiddleware(TestCase):
+    def test_heartbeat_skips_authentication(self):
+        """The /heartbeat route bypasses API-key auth even when a key is set."""
+        with mock.patch.dict(
+            os.environ, {"INTERPRETER_API_KEY": "supersecret"}
+        ):
+            from fastapi.testclient import TestClient
+
+            client = TestClient(Server(AsyncInterpreter()).app)
+            response = client.get("/heartbeat")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["status"], "alive")
+
+    def test_wrong_api_key_returns_403(self):
+        """An incorrect X-API-KEY is rejected with 403 by the auth middleware."""
+        with mock.patch.dict(
+            os.environ, {"INTERPRETER_API_KEY": "supersecret"}
+        ):
+            from fastapi.testclient import TestClient
+
+            client = TestClient(Server(AsyncInterpreter()).app)
+            response = client.post(
+                "/settings",
+                json={"llm": {"model": "gpt-4o-mini"}},
+                headers={"X-API-KEY": "wrong"},
+            )
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(
+                response.json()["detail"], "Authentication failed"
+            )
+
+    def test_correct_api_key_returns_200(self):
+        """The matching X-API-KEY is accepted by the auth middleware."""
+        with mock.patch.dict(
+            os.environ, {"INTERPRETER_API_KEY": "supersecret"}
+        ):
+            from fastapi.testclient import TestClient
+
+            client = TestClient(Server(AsyncInterpreter()).app)
+            response = client.post(
+                "/settings",
+                json={"llm": {"model": "gpt-4o-mini"}},
+                headers={"X-API-KEY": "supersecret"},
+            )
+            self.assertEqual(response.status_code, 200)

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -63,14 +63,17 @@ class TestServerConstruction(TestCase):
 
 class TestWebSocketOriginPolicy(TestCase):
     def test_missing_origin_allowed_for_local_clients(self):
+        """None and empty origins are accepted for non-browser local clients."""
         self.assertTrue(is_websocket_origin_allowed(None))
         self.assertTrue(is_websocket_origin_allowed(""))
 
     def test_localhost_origins_allowed(self):
+        """http origins resolving to localhost are permitted."""
         self.assertTrue(is_websocket_origin_allowed("http://127.0.0.1:8000"))
         self.assertTrue(is_websocket_origin_allowed("http://localhost:8000"))
 
     def test_remote_origins_rejected(self):
+        """Origins outside the local network are rejected."""
         self.assertFalse(is_websocket_origin_allowed("https://evil.example"))
 
     def test_null_origin_allowed_for_non_browser_clients(self):
@@ -90,6 +93,7 @@ class TestSettingsEndpointGuards(TestCase):
         self.client = TestClient(Server(AsyncInterpreter()).app)
 
     def _assert_settings_blocked(self, payload, error_substring):
+        """POST the given settings payload and assert it is rejected with 403."""
         response = self.client.post("/settings", json=payload)
         self.assertEqual(response.status_code, 403)
         self.assertIn(error_substring, response.json()["error"])
@@ -119,6 +123,7 @@ class TestAsyncApprovalBinding(TestCase):
         self.interpreter.auto_run = False
 
     def test_confirmation_digest_is_stable(self):
+        """The same confirmation payload always produces the same digest."""
         payload = {"type": "code", "format": "python", "content": "print('hi')"}
         self.assertEqual(
             confirmation_digest(payload),
@@ -126,9 +131,11 @@ class TestAsyncApprovalBinding(TestCase):
         )
 
     def test_approve_pending_confirmation_requires_pending_state(self):
+        """Approval is refused when no confirmation is currently pending."""
         self.assertFalse(self.interpreter._approve_pending_confirmation())
 
     def test_approve_pending_confirmation_accepts_matching_digest(self):
+        """Approval succeeds when the provided digest matches the pending one."""
         payload = {"type": "code", "format": "python", "content": "print(1)"}
         self.interpreter.pending_confirmation = payload
         self.interpreter.pending_confirmation_digest = confirmation_digest(payload)
@@ -138,6 +145,7 @@ class TestAsyncApprovalBinding(TestCase):
         self.assertTrue(self.interpreter._approval_granted)
 
     def test_approve_pending_confirmation_rejects_wrong_digest(self):
+        """Approval is refused when the provided digest does not match."""
         payload = {"type": "code", "format": "python", "content": "print(1)"}
         self.interpreter.pending_confirmation = payload
         self.interpreter.pending_confirmation_digest = confirmation_digest(payload)
@@ -155,6 +163,7 @@ class TestAsyncInputCommandHandling(TestCase):
         self.interpreter.respond_thread.is_alive.return_value = True
 
     def _run_go_command(self, command="go"):
+        """Feed a complete user command chunk sequence through interpreter.input."""
         import asyncio
 
         async def run():
@@ -171,6 +180,7 @@ class TestAsyncInputCommandHandling(TestCase):
         asyncio.run(run())
 
     def _error_messages(self):
+        """Return the error chunk contents put onto the sync output queue."""
         return [
             call.args[0].get("content", "")
             for call in self.interpreter.output_queue.sync_q.put.call_args_list
@@ -178,6 +188,7 @@ class TestAsyncInputCommandHandling(TestCase):
         ]
 
     def test_command_start_does_not_require_join(self):
+        """A command start chunk must not join the respond thread."""
         import asyncio
 
         async def run():
@@ -236,9 +247,11 @@ class TestAsyncRespondApproval(TestCase):
         self.interpreter.output_queue = mock.MagicMock(sync_q=self.mock_q)
 
     def _confirmation_payload(self):
+        """The code payload used by the respond-approval tests."""
         return {"format": "python", "content": "print(1)"}
 
     def _run_respond_with_chunks(self, chunks, approve=True):
+        """Run respond() in a thread over the given chunks, then grant or deny approval."""
         import threading
         import time
 

--- a/tests/core/test_async_core.py
+++ b/tests/core/test_async_core.py
@@ -332,11 +332,19 @@ class TestServerRunAndSetters(TestCase):
         # Set host directly on config (bypasses the property setter which recreates uvicorn).
         s.config.host = "0.0.0.0"
         buf = io.StringIO()
-        with contextlib.redirect_stdout(buf):
-            s.run()
+        # The 0.0.0.0 branch probes the LAN IP via a UDP socket; mock it so the
+        # test never makes a real network call.
+        fake_socket = mock.Mock()
+        fake_socket.getsockname.return_value = ("192.168.1.50", 12345)
+        with mock.patch(
+            "interpreter.core.async_core.socket.socket", return_value=fake_socket
+        ):
+            with contextlib.redirect_stdout(buf):
+                s.run()
         out = buf.getvalue()
         self.assertIn("Warning", out)
         self.assertIn("0.0.0.0", out)
+        self.assertIn("192.168.1.50", out)
         s.uvicorn_server.run.assert_called_once_with()
 
     def test_run_with_explicit_host_and_port(self):
@@ -345,16 +353,20 @@ class TestServerRunAndSetters(TestCase):
         import io
 
         s = Server(AsyncInterpreter())
-        s.uvicorn_server.run = mock.Mock()
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
-            with mock.patch("interpreter.core.async_core.uvicorn.Server"):
+            # Both setters rebuild the uvicorn server from the config, so capture
+            # the replacement instance and assert THAT one is started.
+            with mock.patch(
+                "interpreter.core.async_core.uvicorn.Server"
+            ) as uvicorn_server_cls:
                 s.run(host="127.0.0.1", port=8080)
         self.assertEqual(s.host, "127.0.0.1")
         self.assertEqual(s.port, 8080)
         out = buf.getvalue()
         self.assertIn("127.0.0.1", out)
         self.assertIn("8080", out)
+        uvicorn_server_cls.return_value.run.assert_called_once_with()
 
 
 class TestServerAuthMiddleware(TestCase):

--- a/tests/core/test_async_server_websocket.py
+++ b/tests/core/test_async_server_websocket.py
@@ -35,7 +35,8 @@ def interpreter():
 
 
 @pytest.fixture
-def client(interpreter):
+def client(interpreter, monkeypatch):
+    monkeypatch.delenv("INTERPRETER_API_KEY", raising=False)
     return TestClient(Server(interpreter).app)
 
 
@@ -162,6 +163,7 @@ def test_payload_before_authentication_is_discarded_not_processed(ws_pair):
     client, _, inp = ws_pair
     with client.websocket_connect("/") as ws:
         ws.send_text(json.dumps({"role": "user", "start": True}))
+        assert ws.receive_json() == {"auth": False}
     assert inp.await_count == 0
 
 

--- a/tests/core/test_async_server_websocket.py
+++ b/tests/core/test_async_server_websocket.py
@@ -31,11 +31,13 @@ async def _hang_output():
 
 @pytest.fixture
 def interpreter():
+    """A fresh AsyncInterpreter for the websocket flow tests."""
     return AsyncInterpreter()
 
 
 @pytest.fixture
 def client(interpreter, monkeypatch):
+    """A TestClient bound to the interpreter's server app with auth open."""
     monkeypatch.delenv("INTERPRETER_API_KEY", raising=False)
     return TestClient(Server(interpreter).app)
 

--- a/tests/core/test_async_server_websocket.py
+++ b/tests/core/test_async_server_websocket.py
@@ -1,0 +1,219 @@
+"""Tests for the async server WebSocket endpoint and authentication layer.
+
+The browser-facing WebSocket interface (websocket_endpoint/receive_input/
+send_output) and the HTTP auth middleware (validate_api_key) are how external
+clients actually talk to Open Interpreter, so a regression here breaks every
+frontend integration at once. These tests exercise the full flow end-to-end
+through TestClient.websocket_connect.
+"""
+
+import asyncio
+import json
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from interpreter.core.async_core import AsyncInterpreter, Server, authenticate_function
+
+
+async def _hang_output():
+    """Stub for interpreter.output() that parks forever without spinning.
+
+    send_output() polls output() continuously once connected; a stub that
+    returns immediately would busy-loop and race the assertions below.
+    asyncio.sleep keeps the task cancellable, so gather() unwinds cleanly
+    when the test client disconnects.
+    """
+    await asyncio.sleep(3600)
+
+
+@pytest.fixture
+def interpreter():
+    return AsyncInterpreter()
+
+
+@pytest.fixture
+def client(interpreter):
+    return TestClient(Server(interpreter).app)
+
+
+@pytest.fixture
+def ws_pair(client, interpreter):
+    """(client, interpreter, input-mock) with output emission parked."""
+    interpreter.output = _hang_output
+    interpreter.require_acknowledge = False
+    inp = mock.AsyncMock()
+    interpreter.input = inp
+    return client, interpreter, inp
+
+
+def _handshake(ws):
+    """Complete the mandatory auth exchange for a server with no API key set."""
+    ws.send_text(json.dumps({"auth": "not-checked-without-api-key"}))
+    assert ws.receive_json() == {"auth": True}
+
+
+def test_heartbeat_bypasses_api_key_auth(monkeypatch, interpreter):
+    """With an API key configured, /heartbeat must stay reachable without a key."""
+    monkeypatch.setenv("INTERPRETER_API_KEY", "secret")
+    client = TestClient(Server(interpreter).app)
+    response = client.get("/heartbeat")
+    assert response.status_code == 200
+    assert response.json() == {"status": "alive"}
+
+
+def test_requests_without_key_allowed_when_no_api_key_configured(monkeypatch, client):
+    """No INTERPRETER_API_KEY means open access: requests pass with any/no header."""
+    monkeypatch.delenv("INTERPRETER_API_KEY", raising=False)
+    response = client.get("/settings/auto_run")
+    assert response.status_code == 200
+
+
+def test_missing_api_key_header_rejected(monkeypatch, client):
+    """When INTERPRETER_API_KEY is set, requests without X-API-KEY get 403."""
+    monkeypatch.setenv("INTERPRETER_API_KEY", "secret")
+    response = client.get("/settings/auto_run")
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Authentication failed"}
+
+
+def test_wrong_api_key_rejected(monkeypatch, client):
+    """A non-matching X-API-KEY value is rejected with 403."""
+    monkeypatch.setenv("INTERPRETER_API_KEY", "secret")
+    response = client.get("/settings/auto_run", headers={"X-API-KEY": "wrong"})
+    assert response.status_code == 403
+
+
+def test_correct_api_key_accepted(monkeypatch, client):
+    """The matching X-API-KEY grants normal access to protected routes."""
+    monkeypatch.setenv("INTERPRETER_API_KEY", "secret")
+    response = client.get("/settings/auto_run", headers={"X-API-KEY": "secret"})
+    assert response.status_code == 200
+
+
+def test_authenticate_function_open_when_no_key(monkeypatch):
+    """Without INTERPRETER_API_KEY, authenticate_function accepts everything."""
+    monkeypatch.delenv("INTERPRETER_API_KEY", raising=False)
+    assert authenticate_function(None) is True
+    assert authenticate_function("anything") is True
+
+
+def test_authenticate_function_requires_exact_match(monkeypatch):
+    """With INTERPRETER_API_KEY set, only an equal string authenticates."""
+    monkeypatch.setenv("INTERPRETER_API_KEY", "secret")
+    assert authenticate_function("secret") is True
+    assert authenticate_function("Secret") is False
+    assert authenticate_function(None) is False
+
+
+def test_host_and_port_setters_rebuild_uvicorn_server():
+    """Assigning host/port updates uvicorn's config with a fresh server object.
+
+    The setters intentionally recreate self.uvicorn_server so changes made
+    after __init__ are picked up by run(); document that contract.
+    """
+    server = Server(AsyncInterpreter())
+    old = server.uvicorn_server
+    server.host = "127.0.0.3"
+    assert server.host == "127.0.0.3"
+    assert server.uvicorn_server is not old
+    old = server.uvicorn_server
+    server.port = 6001
+    assert server.port == 6001
+    assert server.uvicorn_server is not old
+
+
+def test_foreign_origin_rejected_before_accept(client):
+    """Browser origins off localhost are refused with policy code 1008."""
+    with pytest.raises(WebSocketDisconnect) as excinfo:
+        with client.websocket_connect("/", headers={"Origin": "http://evil.example"}):
+            pass  # pragma: no cover - connection should be refused
+    assert excinfo.value.code == 1008
+    assert excinfo.value.reason == "Origin not allowed"
+
+
+def test_correct_auth_receives_confirmation(ws_pair):
+    """The socket echoes {\"auth\": True} after an accepted credential."""
+    client, _, _ = ws_pair
+    with client.websocket_connect("/") as ws:
+        _handshake(ws)
+
+
+def test_wrong_credential_reports_failure_then_can_retry(ws_pair, monkeypatch):
+    """Bad credentials yield {\"auth\": False}; a later good one still works."""
+    client, _, _ = ws_pair
+    monkeypatch.setenv("INTERPRETER_API_KEY", "secret")
+    with client.websocket_connect("/") as ws:
+        ws.send_text(json.dumps({"auth": "bad"}))
+        assert ws.receive_json() == {"auth": False}
+        ws.send_text(json.dumps({"auth": "secret"}))
+        assert ws.receive_json() == {"auth": True}
+
+
+def test_payload_before_authentication_is_discarded_not_processed(ws_pair):
+    """LMC chunks sent pre-auth are swallowed (no input()), answered auth:False.
+
+    KNOWN BUG-ish: payloads silently disappear instead of being queued until
+    auth completes; clients unaware of the handshake lose their first message.
+    Documenting current behavior.
+    """
+    client, _, inp = ws_pair
+    with client.websocket_connect("/") as ws:
+        ws.send_text(json.dumps({"role": "user", "start": True}))
+    assert inp.await_count == 0
+
+
+def test_authenticated_chunk_forwarded_parsed(ws_pair):
+    """After the handshake, an LMC chunk reaches input() as the parsed dict."""
+    client, _, inp = ws_pair
+    with client.websocket_connect("/") as ws:
+        _handshake(ws)
+        ws.send_text(json.dumps({"role": "user", "start": True}))
+    inp.assert_awaited_once_with({"role": "user", "start": True})
+
+
+def test_binary_frame_forwarded_raw(ws_pair):
+    """Bytes frames bypass JSON parsing and reach input() unchanged."""
+    client, _, inp = ws_pair
+    with client.websocket_connect("/") as ws:
+        _handshake(ws)
+        ws.send_bytes(b"\x00\x01binary")
+    inp.assert_awaited_once_with(b"\x00\x01binary")
+
+
+def test_acknowledgement_recorded_and_not_forwarded(
+    ws_pair, monkeypatch
+):
+    """require_acknowledge turns {\"ack\": id} frames into receipt bookkeeping.
+
+    They must be recorded in acknowledged_outputs and never reach input().
+    """
+    client, interp, inp = ws_pair
+    interp.require_acknowledge = True
+    interp.acknowledged_outputs.clear()
+    with client.websocket_connect("/") as ws:
+        _handshake(ws)
+        ws.send_text(json.dumps({"ack": "msg-id-1"}))
+    assert interp.acknowledged_outputs == ["msg-id-1"]
+    assert inp.await_count == 0
+
+
+def test_invalid_json_after_handshake_emits_server_error(ws_pair):
+    """Garbage text frames produce a server error chunk + complete marker.
+
+    The receive_input except branch formats the traceback and pushes both an
+    error message and complete_message back over the socket while connected.
+    """
+    client, _, inp = ws_pair
+    with client.websocket_connect("/") as ws:
+        _handshake(ws)
+        ws.send_text("{not valid json!!")
+        error = ws.receive_json()
+        done = ws.receive_json()
+    assert error["type"] == "error"
+    assert error["role"] == "server"
+    assert "JSONDecodeError" in error["content"]
+    assert done == {"role": "server", "type": "status", "content": "complete"}
+    assert inp.await_count == 0

--- a/tests/terminal_interface/test_local_setup.py
+++ b/tests/terminal_interface/test_local_setup.py
@@ -54,6 +54,7 @@ def test_local_setup_jan_sets_model_from_api(monkeypatch):
 
     class _Response:
         def json(self):
+            """Return the Jan /models payload this test drives."""
             return {"data": [{"id": "jan-model-1"}]}
 
     monkeypatch.setattr(
@@ -322,6 +323,7 @@ def test_local_setup_jan_custom_model_id(monkeypatch):
 
     class _Response:
         def json(self):
+            """Return the Jan /models payload this test drives."""
             return {"data": [{"id": "jan-model-1"}]}
 
     monkeypatch.setattr(

--- a/tests/terminal_interface/test_local_setup.py
+++ b/tests/terminal_interface/test_local_setup.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import inquirer
 import pytest
+import subprocess
 
 from interpreter.terminal_interface.local_setup import local_setup
 
@@ -178,9 +179,9 @@ def test_local_setup_llamafile_launches_existing_model(monkeypatch):
 
     process = mock.Mock()
     process.stdout = iter(["llama server listening at http://localhost:8080\n"])
+    popen = mock.Mock(return_value=process)
     monkeypatch.setattr(
-        "interpreter.terminal_interface.local_setup.subprocess.Popen",
-        lambda *_a, **_k: process,
+        "interpreter.terminal_interface.local_setup.subprocess.Popen", popen
     )
     monkeypatch.setattr(
         inquirer,
@@ -202,34 +203,41 @@ def test_local_setup_llamafile_launches_existing_model(monkeypatch):
     assert interpreter.llm.api_key == "dummy"
     assert interpreter.llm.temperature == 0
     assert interpreter.llm.context_window == 8000
-    process.stdout  # exercised the read-loop until server-ready line
+    # The selected llamafile path is launched with the server flags.
+    popen.assert_called_once_with(
+        '"/tmp/oi/models/tiny.llamafile" --nobrowser -ngl 9999',
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
 
 
 def test_local_setup_llamafile_downloads_new_model(monkeypatch):
-    """Choosing 'Download new model' downloads and chmods a selected model."""
+    """Choosing 'Download new model' downloads, chmods, then launches a model."""
     interpreter = _make_interpreter()
     _mock_psutil(monkeypatch, 16, disk_free_gb=50)
     interpreter.get_oi_dir.return_value = "/tmp/oi"
     monkeypatch.setattr("os.path.exists", lambda _p: True)
-    monkeypatch.setattr("os.listdir", lambda _d: [])
+    monkeypatch.setattr("os.listdir", lambda _d: ["tiny.llamafile"])
 
-    # No models present -> straight to download_model, which prompts once.
+    # An existing model is present, so this exercises the "Download new model"
+    # option rather than the empty-directory path.
+    download = mock.Mock()
     monkeypatch.setattr(
-        "interpreter.terminal_interface.local_setup.wget.download",
-        lambda *_a, **_k: None,
+        "interpreter.terminal_interface.local_setup.wget.download", download
     )
-    monkeypatch.setattr(
-        "interpreter.terminal_interface.local_setup.subprocess.run",
-        lambda *_a, **_k: None,
-    )
+    run = mock.Mock()
+    monkeypatch.setattr("interpreter.terminal_interface.local_setup.subprocess.run", run)
 
-    # inquirer.prompt used for the initial provider then model selection
+    # inquirer.prompt: provider, existing-model selection, then model download.
     monkeypatch.setattr(
         inquirer,
         "prompt",
         mock.Mock(
             side_effect=[
                 {"model": "Llamafile"},
+                {"model": "↓ Download new model"},
                 {"model": "Phi-3-mini (2.42GB)"},
             ]
         ),
@@ -242,9 +250,16 @@ def test_local_setup_llamafile_downloads_new_model(monkeypatch):
     result = local_setup(interpreter)
 
     assert result is interpreter
-    # The downloaded Phi-3 model path was assigned and server launched
     assert interpreter.llm.model == "openai/local"
     assert interpreter.llm.api_base == "http://localhost:8080/v1"
+    model_path = "/tmp/oi/models/Phi-3-mini-4k-instruct.Q4_K_M.llamafile"
+    # wget downloads the selected model's URL to the models directory.
+    download.assert_called_once_with(
+        "https://huggingface.co/Mozilla/Phi-3-mini-4k-instruct-llamafile/resolve/main/Phi-3-mini-4k-instruct.Q4_K_M.llamafile?download=true",
+        model_path,
+    )
+    # The downloaded file is made executable.
+    run.assert_called_once_with(["chmod", "+x", model_path], check=True)
 
 
 def test_local_setup_ollama_download_new_model(monkeypatch):
@@ -252,15 +267,14 @@ def test_local_setup_ollama_download_new_model(monkeypatch):
     interpreter = _make_interpreter()
     _mock_ram_gb(monkeypatch, 16)
 
-    def _run(*args, **kwargs):
-        # First call is `ollama list`; second is `ollama pull`
-        if args[0][1] == "list":
-            return mock.Mock(stdout="NAME\n", returncode=0)
-        return mock.Mock(returncode=0)
-
+    run = mock.Mock(
+        side_effect=[
+            mock.Mock(stdout="NAME\n", returncode=0),  # ollama list
+            mock.Mock(returncode=0),  # ollama pull
+        ]
+    )
     monkeypatch.setattr(
-        "interpreter.terminal_interface.local_setup.subprocess.run",
-        _run,
+        "interpreter.terminal_interface.local_setup.subprocess.run", run
     )
     monkeypatch.setattr(
         inquirer,
@@ -276,6 +290,10 @@ def test_local_setup_ollama_download_new_model(monkeypatch):
     local_setup(interpreter)
 
     assert interpreter.llm.model == "ollama/llama3.1"
+    assert run.call_count == 2
+    assert run.call_args_list[0][0] == (["ollama", "list"],)
+    assert run.call_args_list[1][0] == (["ollama", "pull", "llama3.1"],)
+    assert run.call_args_list[1].kwargs["check"] is True
 
 
 def test_local_setup_jan_custom_model_id(monkeypatch):

--- a/tests/terminal_interface/test_local_setup.py
+++ b/tests/terminal_interface/test_local_setup.py
@@ -229,6 +229,15 @@ def test_local_setup_llamafile_downloads_new_model(monkeypatch):
     )
     run = mock.Mock()
     monkeypatch.setattr("interpreter.terminal_interface.local_setup.subprocess.run", run)
+    # The freshly downloaded model is launched as a server; mock Popen with a
+    # ready-line iterator so the launch is exercised rather than a real shell
+    # "not found" that vacuously passes.
+    process = mock.Mock()
+    process.stdout = iter(["llama server listening at http://localhost:8080\n"])
+    popen = mock.Mock(return_value=process)
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.subprocess.Popen", popen
+    )
 
     # inquirer.prompt: provider, existing-model selection, then model download.
     monkeypatch.setattr(
@@ -260,6 +269,15 @@ def test_local_setup_llamafile_downloads_new_model(monkeypatch):
     )
     # The downloaded file is made executable.
     run.assert_called_once_with(["chmod", "+x", model_path], check=True)
+    # The downloaded model is launched with the server flags and its stdout is
+    # polled until the ready signal.
+    popen.assert_called_once_with(
+        f'"{model_path}" --nobrowser -ngl 9999',
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
 
 
 def test_local_setup_ollama_download_new_model(monkeypatch):

--- a/tests/terminal_interface/test_local_setup.py
+++ b/tests/terminal_interface/test_local_setup.py
@@ -147,3 +147,161 @@ def test_local_setup_low_ram_uses_smaller_context_window(monkeypatch):
 
     assert interpreter.llm.context_window == 3000
     assert interpreter.llm.max_tokens == 1000
+
+
+def _mock_psutil(monkeypatch, ram_gb, disk_free_gb=50):
+    """Pin RAM and free disk so download_model's filtering is deterministic."""
+
+    class _Memory:
+        total = ram_gb * 1024**3
+
+    class _Disk:
+        free = disk_free_gb * 1024**3
+
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.psutil.virtual_memory",
+        lambda: _Memory(),
+    )
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.psutil.disk_usage",
+        lambda _path: _Disk(),
+    )
+
+
+def test_local_setup_llamafile_launches_existing_model(monkeypatch):
+    """Selecting an already-downloaded llamafile runs it with server flags."""
+    interpreter = _make_interpreter()
+    _mock_ram_gb(monkeypatch, 16)
+    interpreter.get_oi_dir.return_value = "/tmp/oi"
+    monkeypatch.setattr("os.path.exists", lambda _p: True)
+    monkeypatch.setattr("os.listdir", lambda _d: ["tiny.llamafile"])
+
+    process = mock.Mock()
+    process.stdout = iter(["llama server listening at http://localhost:8080\n"])
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.subprocess.Popen",
+        lambda *_a, **_k: process,
+    )
+    monkeypatch.setattr(
+        inquirer,
+        "prompt",
+        mock.Mock(
+            side_effect=[
+                {"model": "Llamafile"},
+                {"model": "tiny.llamafile"},
+            ]
+        ),
+    )
+
+    result = local_setup(interpreter)
+
+    assert result is interpreter
+    assert interpreter.llm.model == "openai/local"
+    assert interpreter.llm.api_base == "http://localhost:8080/v1"
+    assert interpreter.llm.supports_functions is False
+    assert interpreter.llm.api_key == "dummy"
+    assert interpreter.llm.temperature == 0
+    assert interpreter.llm.context_window == 8000
+    process.stdout  # exercised the read-loop until server-ready line
+
+
+def test_local_setup_llamafile_downloads_new_model(monkeypatch):
+    """Choosing 'Download new model' downloads and chmods a selected model."""
+    interpreter = _make_interpreter()
+    _mock_psutil(monkeypatch, 16, disk_free_gb=50)
+    interpreter.get_oi_dir.return_value = "/tmp/oi"
+    monkeypatch.setattr("os.path.exists", lambda _p: True)
+    monkeypatch.setattr("os.listdir", lambda _d: [])
+
+    # No models present -> straight to download_model, which prompts once.
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.wget.download",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.subprocess.run",
+        lambda *_a, **_k: None,
+    )
+
+    # inquirer.prompt used for the initial provider then model selection
+    monkeypatch.setattr(
+        inquirer,
+        "prompt",
+        mock.Mock(
+            side_effect=[
+                {"model": "Llamafile"},
+                {"model": "Phi-3-mini (2.42GB)"},
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.platform.system",
+        lambda: "Linux",
+    )
+
+    result = local_setup(interpreter)
+
+    assert result is interpreter
+    # The downloaded Phi-3 model path was assigned and server launched
+    assert interpreter.llm.model == "openai/local"
+    assert interpreter.llm.api_base == "http://localhost:8080/v1"
+
+
+def test_local_setup_ollama_download_new_model(monkeypatch):
+    """Ollama '↓ Download llama3.1' triggers ollama pull for that model."""
+    interpreter = _make_interpreter()
+    _mock_ram_gb(monkeypatch, 16)
+
+    def _run(*args, **kwargs):
+        # First call is `ollama list`; second is `ollama pull`
+        if args[0][1] == "list":
+            return mock.Mock(stdout="NAME\n", returncode=0)
+        return mock.Mock(returncode=0)
+
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.subprocess.run",
+        _run,
+    )
+    monkeypatch.setattr(
+        inquirer,
+        "prompt",
+        mock.Mock(
+            side_effect=[
+                {"model": "Ollama"},
+                {"name": "↓ Download llama3.1"},
+            ]
+        ),
+    )
+
+    local_setup(interpreter)
+
+    assert interpreter.llm.model == "ollama/llama3.1"
+
+
+def test_local_setup_jan_custom_model_id(monkeypatch):
+    """Choosing the custom-model-id entry prompts for the raw id."""
+    interpreter = _make_interpreter()
+    _mock_ram_gb(monkeypatch, 16)
+
+    class _Response:
+        def json(self):
+            return {"data": [{"id": "jan-model-1"}]}
+
+    monkeypatch.setattr(
+        inquirer,
+        "prompt",
+        mock.Mock(
+            side_effect=[
+                {"model": "Jan"},
+                {"jan_model_name": ">> Type Custom Model ID"},
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "interpreter.terminal_interface.local_setup.requests.get",
+        lambda *args, **kwargs: _Response(),
+    )
+    with mock.patch("builtins.input", return_value="my-custom-model"):
+        local_setup(interpreter)
+
+    assert interpreter.llm.model == "my-custom-model"

--- a/tests/terminal_interface/test_local_setup.py
+++ b/tests/terminal_interface/test_local_setup.py
@@ -85,6 +85,7 @@ def test_local_setup_ollama_selects_model_and_pings(monkeypatch):
     _mock_ram_gb(monkeypatch, 16)
 
     def _ollama_list(*args, **kwargs):
+        """Assert the ollama list invocation and return a fake installed-model listing."""
         assert args[0] == ["ollama", "list"]
         return mock.Mock(
             stdout="NAME\nllama3.1:latest\n",

--- a/tests/terminal_interface/test_local_setup.py
+++ b/tests/terminal_interface/test_local_setup.py
@@ -151,7 +151,7 @@ def test_local_setup_low_ram_uses_smaller_context_window(monkeypatch):
 
 
 def _mock_psutil(monkeypatch, ram_gb, disk_free_gb=50):
-    """Pin RAM and free disk so download_model's filtering is deterministic."""
+    """Pin resource values so download_model's guidance and disk filtering are deterministic."""
 
     class _Memory:
         total = ram_gb * 1024**3

--- a/tests/terminal_interface/test_magic_commands.py
+++ b/tests/terminal_interface/test_magic_commands.py
@@ -9,6 +9,7 @@ from tests.helpers import TEST_LLM_MODEL
 
 
 def _interpreter(**kwargs):
+    """Build a SimpleNamespace interpreter stub, overriding defaults with kwargs."""
     base = {
         "messages": [],
         "system_message": "sys",

--- a/tests/terminal_interface/test_magic_commands.py
+++ b/tests/terminal_interface/test_magic_commands.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+import sys
 
 from interpreter.terminal_interface import magic_commands
 from tests.helpers import TEST_LLM_MODEL
@@ -292,3 +293,157 @@ def test_install_and_import_returns_existing_module():
     with mock.patch.dict("sys.modules", {"already_there": fake}):
         result = magic_commands.install_and_import("already_there")
     assert result is fake
+
+
+def test_install_and_import_installs_via_pip_then_imports():
+    """Missing packages are pip-installed, then re-imported and returned."""
+    fake = object()
+    with mock.patch(
+        "builtins.__import__",
+        side_effect=[ImportError("missing"), fake],
+    ):
+        with mock.patch.object(
+            magic_commands.subprocess, "check_call"
+        ) as check_call:
+            result = magic_commands.install_and_import("somedummy")
+
+    check_call.assert_called_once_with(
+        [sys.executable, "-m", "pip", "install", "somedummy"],
+        stdout=magic_commands.subprocess.DEVNULL,
+        stderr=magic_commands.subprocess.DEVNULL,
+    )
+    assert result is fake
+
+
+def test_install_and_import_pip_failure_unbound_module_known_bug():
+    """KNOWN BUG: when pip fails and pip3 also fails, install_and_import
+    raises UnboundLocalError instead of returning None. The function's
+    finally block references `module`, which is never bound on the failure
+    paths. Documenting current behavior."""
+    with mock.patch(
+        "builtins.__import__", side_effect=ImportError("missing")
+    ):
+        with mock.patch.object(
+            magic_commands.subprocess,
+            "check_call",
+            side_effect=[
+                magic_commands.subprocess.CalledProcessError(1, "pip"),
+                magic_commands.subprocess.CalledProcessError(1, "pip3"),
+            ],
+        ):
+            with pytest.raises(UnboundLocalError):
+                magic_commands.install_and_import("somedummy")
+
+
+def test_handle_undo_previews_removed_message_content():
+    """%undo prints a preview of each removed message's content."""
+    interpreter = _interpreter(
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "user", "content": "run it"},
+            {"role": "assistant", "content": "this is the reply"},
+        ]
+    )
+    magic_commands.handle_undo(interpreter, "")
+    assert interpreter.messages == [{"role": "user", "content": "first"}]
+    preview = interpreter.display_message.call_args[0][0]
+    assert "Removed message" in preview
+    assert "this is the reply" in preview
+
+
+def test_handle_verbose_truncates_inline_images(capsys):
+    """%verbose truncates non-path inline image content before printing."""
+    interpreter = _interpreter(
+        messages=[
+            {
+                "role": "user",
+                "type": "image",
+                "format": "base64",
+                "content": "A" * 100,
+            }
+        ]
+    )
+    magic_commands.handle_verbose(interpreter, "true")
+    assert interpreter.verbose is True
+    printed = capsys.readouterr().out
+    assert "..." in printed
+    assert "A" * 100 not in printed  # the inline content was truncated
+
+
+def test_handle_debug_truncates_inline_images(capsys):
+    """%debug truncates non-path inline image content before printing."""
+    interpreter = _interpreter(
+        messages=[
+            {
+                "role": "user",
+                "type": "image",
+                "format": "data-url",
+                "content": "B" * 100,
+            }
+        ]
+    )
+    magic_commands.handle_debug(interpreter, "true")
+    assert interpreter.debug is True
+    printed = capsys.readouterr().out
+    assert "..." in printed
+
+
+def test_markdown_default_path_uses_downloads(monkeypatch, tmp_path):
+    """%markdown without a path exports to Downloads using conversation name."""
+    interpreter = _interpreter(
+        messages=[{"role": "user", "content": "hi"}],
+        conversation_filename="chat.json",
+    )
+    monkeypatch.setattr(
+        magic_commands, "get_downloads_path", lambda: str(tmp_path)
+    )
+    with mock.patch(
+        "interpreter.terminal_interface.magic_commands.export_to_markdown"
+    ) as export:
+        magic_commands.markdown(interpreter, "")
+
+    export.assert_called_once_with(
+        interpreter.messages, f"{tmp_path}/chat.md"
+    )
+
+
+def test_jupyter_handles_assistant_markdown_and_default_language(tmp_path):
+    """%jupyter renders assistant messages as markdown and defaults code
+    cells without a format to python."""
+    import types
+
+    interpreter = _interpreter(
+        messages=[
+            {"role": "assistant", "type": "message", "content": "assistant note"},
+            {"role": "assistant", "type": "code", "content": "print(2)"},
+        ]
+    )
+    captured = {}
+
+    v4_module = types.ModuleType("nbformat.v4")
+    v4_module.new_markdown_cell = lambda content: {
+        "cell_type": "markdown",
+        "source": content,
+    }
+    v4_module.new_code_cell = lambda content: mock.Mock(metadata={}, source=content)
+    v4_module.new_notebook = lambda: captured.setdefault("nb", {"cells": []})
+
+    nbformat_module = types.ModuleType("nbformat")
+    nbformat_module.write = mock.Mock()
+    nbformat_module.v4 = v4_module
+
+    with mock.patch.object(
+        magic_commands, "install_and_import", return_value=nbformat_module
+    ):
+        with mock.patch.object(
+            magic_commands, "get_downloads_path", return_value=str(tmp_path)
+        ):
+            with mock.patch.dict(
+                "sys.modules",
+                {"nbformat": nbformat_module, "nbformat.v4": v4_module},
+            ):
+                magic_commands.jupyter(interpreter, "")
+
+    cells = captured["nb"]["cells"]
+    assert cells[0] == {"cell_type": "markdown", "source": "assistant note"}
+    assert cells[1].metadata == {"language": "python"}

--- a/tests/terminal_interface/test_magic_commands.py
+++ b/tests/terminal_interface/test_magic_commands.py
@@ -346,9 +346,11 @@ def test_handle_undo_previews_removed_message_content():
     )
     magic_commands.handle_undo(interpreter, "")
     assert interpreter.messages == [{"role": "user", "content": "first"}]
-    preview = interpreter.display_message.call_args[0][0]
-    assert "Removed message" in preview
-    assert "this is the reply" in preview
+    # One preview per removed message, in order.
+    assert interpreter.display_message.call_count == 2
+    previews = [c[0][0] for c in interpreter.display_message.call_args_list]
+    assert "run it" in previews[0]
+    assert "this is the reply" in previews[1]
 
 
 def test_handle_verbose_truncates_inline_images(capsys):
@@ -386,6 +388,7 @@ def test_handle_debug_truncates_inline_images(capsys):
     assert interpreter.debug is True
     printed = capsys.readouterr().out
     assert "..." in printed
+    assert "B" * 100 not in printed  # the inline content was truncated
 
 
 def test_markdown_default_path_uses_downloads(monkeypatch, tmp_path):

--- a/tests/terminal_interface/test_start_terminal_interface.py
+++ b/tests/terminal_interface/test_start_terminal_interface.py
@@ -125,6 +125,9 @@ def _patch_module(monkeypatch):
     interpreter.messages = []
     interpreter.disable_telemetry = False
     interpreter.chat = mock.Mock()
+    interpreter.server = mock.Mock()
+    interpreter.computer = mock.Mock()
+    interpreter.computer.vision = mock.Mock()
     # Concrete values so the model/api_base string logic sees real strings.
     interpreter.llm.model = "gpt-4o-mini"
     interpreter.llm.api_base = None
@@ -271,3 +274,143 @@ def test_start_terminal_interface_i_shortcut_prepends_command(monkeypatch, tmp_p
     assert interpreter.messages[0]["content"] == "I make a pomodoro"
     assert interpreter.custom_instructions.startswith("UPDATED INSTRUCTIONS")
     assert sys.argv == ["oi"]
+
+
+def test_start_terminal_interface_conversations_flag(monkeypatch):
+    """`--conversations` runs the conversation navigator and returns early."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--conversations"])
+
+    assert start_terminal_interface(interpreter) is None
+    sti.conversation_navigator.assert_called_once_with(interpreter)
+    interpreter.chat.assert_not_called()
+
+
+def test_start_terminal_interface_server_flag(monkeypatch):
+    """`--server` swaps in an AsyncInterpreter and runs its server."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--server"])
+
+    async_interpreter = mock.Mock()
+    async_interpreter.server = mock.Mock()
+    async_interpreter.llm.model = "gpt-4o-mini"
+    async_interpreter.llm.api_base = None
+    with mock.patch(
+        "interpreter.AsyncInterpreter", return_value=async_interpreter
+    ):
+        result = start_terminal_interface(interpreter)
+
+    assert result is None
+    async_interpreter.server.run.assert_called_once_with()
+
+
+def test_start_terminal_interface_no_highlight_active_line(monkeypatch):
+    """`--no_highlight_active_line` disables active-line highlighting."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--no_highlight_active_line"])
+
+    start_terminal_interface(interpreter)
+
+    assert interpreter.highlight_active_line is False
+
+
+def test_start_terminal_interface_local_vision_loads_moondream(monkeypatch):
+    """`--local --vision` loads the computer vision model."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--local", "--vision"])
+
+    start_terminal_interface(interpreter)
+
+    assert sti.profile.call_args[0][1] == "local.py"
+    interpreter.computer.vision.load.assert_called_once_with()
+
+
+def test_start_terminal_interface_local_os_profile(monkeypatch):
+    """`--local --os` selects the local-os profile."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--local", "--os"])
+
+    start_terminal_interface(interpreter)
+
+    assert sti.profile.call_args[0][1] == "local-os.py"
+
+
+def test_start_terminal_interface_codestral_vision_profile(monkeypatch):
+    """`--codestral --vision` selects the codestral-vision profile."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--codestral", "--vision"])
+
+    start_terminal_interface(interpreter)
+
+    assert sti.profile.call_args[0][1] == "codestral-vision.py"
+
+
+def test_start_terminal_interface_llama3_os_profile(monkeypatch):
+    """`--llama3 --os` selects the llama3-os profile."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--llama3", "--os"])
+
+    start_terminal_interface(interpreter)
+
+    assert sti.profile.call_args[0][1] == "llama3-os.py"
+
+
+def test_start_terminal_interface_assistant_profile(monkeypatch):
+    """`--assistant` selects the assistant.py profile."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--assistant"])
+
+    start_terminal_interface(interpreter)
+
+    assert sti.profile.call_args[0][1] == "assistant.py"
+
+
+def test_start_terminal_interface_groq_profile(monkeypatch):
+    """`--groq` selects the groq.py profile."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi", "--groq"])
+
+    start_terminal_interface(interpreter)
+
+    assert sti.profile.call_args[0][1] == "groq.py"
+
+
+def test_start_terminal_interface_gpt35_turbo_defaults(monkeypatch):
+    """A gpt-3.5-turbo model gets a 16000-token context window."""
+    sti, interpreter = _patch_module(monkeypatch)
+    interpreter.llm.model = "gpt-3.5-turbo"
+    interpreter.llm.context_window = None
+    interpreter.llm.max_tokens = None
+    interpreter.llm.supports_functions = None
+    monkeypatch.setattr(sys, "argv", ["oi"])
+
+    start_terminal_interface(interpreter)
+
+    assert interpreter.llm.context_window == 16000
+    assert interpreter.llm.max_tokens == 4096
+    assert interpreter.llm.supports_functions is True
+
+
+def test_start_terminal_interface_vision_model_disables_functions(monkeypatch):
+    """A vision gpt-4 model gets supports_functions=False."""
+    sti, interpreter = _patch_module(monkeypatch)
+    interpreter.llm.model = "gpt-4-vision-preview"
+    interpreter.llm.context_window = None
+    interpreter.llm.max_tokens = None
+    interpreter.llm.supports_functions = None
+    monkeypatch.setattr(sys, "argv", ["oi"])
+
+    start_terminal_interface(interpreter)
+
+    assert interpreter.llm.supports_functions is False
+
+
+def test_start_terminal_interface_disable_telemetry_env(monkeypatch):
+    """DISABLE_TELEMETRY=true sets disable_telemetry even without the flag."""
+    sti, interpreter = _patch_module(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["oi"])
+    monkeypatch.setenv("DISABLE_TELEMETRY", "true")
+
+    start_terminal_interface(interpreter)
+
+    assert interpreter.disable_telemetry is True

--- a/tests/terminal_interface/test_start_terminal_interface.py
+++ b/tests/terminal_interface/test_start_terminal_interface.py
@@ -27,6 +27,7 @@ class _Obj:
 
 
 def _obj():
+    """Build an interpreter stub whose llm is its own nested object."""
     obj = _Obj()
     obj.llm = _Obj()
     return obj

--- a/tests/terminal_interface/test_terminal_interface.py
+++ b/tests/terminal_interface/test_terminal_interface.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -21,6 +22,7 @@ def _make_interpreter():
     interpreter.verbose = False
     interpreter.multi_line = False
     interpreter.max_output = 2000
+    interpreter.debug = False
     interpreter.llm.supports_vision = False
     interpreter.llm.vision_renderer = None
     return interpreter
@@ -252,3 +254,284 @@ def test_terminal_interface_os_mode_notifies_on_message_end():
 
     # The markdown list line and the line above it are stripped before notifying.
     interpreter.computer.os.notify.assert_called_once_with("line two")
+
+
+def test_terminal_interface_pip_upgrade_hint(capsys):
+    """terminal_interface points `pip install --upgrade` users back to the CLI."""
+    interpreter = _intro_interpreter()
+    with mock.patch(
+        "builtins.input",
+        side_effect=["pip install --upgrade open-interpreter", KeyboardInterrupt()],
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            list(terminal_interface(interpreter, ""))
+
+    assert "Please exit this conversation" in capsys.readouterr().out
+    interpreter.chat.assert_not_called()
+
+
+def test_terminal_interface_confirming_code_builds_code_block():
+    """Answering y to a confirmation starts a code block with the right payload."""
+    import interpreter.terminal_interface.terminal_interface as ti
+
+    interpreter = _make_interpreter()
+    interpreter.auto_run = False
+
+    def chat(message, display=False, stream=True):
+        yield {"type": "code", "role": "assistant", "format": "python", "start": True}
+        yield {
+            "type": "confirmation",
+            "role": "assistant",
+            "content": {"format": "python", "content": "print(1)"},
+        }
+
+    interpreter.chat = chat
+    with mock.patch.object(ti, "CodeBlock") as block:
+        with mock.patch("builtins.input", return_value="y"):
+            list(terminal_interface(interpreter, "run code"))
+
+    # The code-start chunk builds a first block; the confirmation builds the
+    # runnable one with the interpreter. Assert the latter.
+    block.assert_called_with(interpreter)
+    assert block.return_value.language == "python"
+    assert block.return_value.code == "print(1)"
+
+
+def test_terminal_interface_safe_mode_auto_scans_code_before_run():
+    """safe_mode auto automatically requests a semgrep scan of pending code."""
+    import interpreter.terminal_interface.terminal_interface as ti
+
+    interpreter = _make_interpreter()
+    interpreter.auto_run = False
+    interpreter.safe_mode = "auto"
+
+    def chat(message, display=False, stream=True):
+        yield {"type": "code", "role": "assistant", "format": "python", "start": True}
+        yield {
+            "type": "confirmation",
+            "role": "assistant",
+            "content": {"format": "python", "content": "print(1)"},
+        }
+
+    interpreter.chat = chat
+    with mock.patch.object(ti, "CodeBlock"):
+        with mock.patch.object(ti, "check_for_package", return_value=True):
+            with mock.patch.object(ti, "scan_code") as scan:
+                with mock.patch("builtins.input", return_value="y"):
+                    list(terminal_interface(interpreter, "run code"))
+
+    scan.assert_called_once_with("print(1)", "python", interpreter)
+
+
+def test_terminal_interface_safe_mode_ask_scans_when_user_consents():
+    """safe_mode ask scans only if the user opts in, then still asks to run."""
+    import interpreter.terminal_interface.terminal_interface as ti
+
+    interpreter = _make_interpreter()
+    interpreter.auto_run = False
+    interpreter.safe_mode = "ask"
+
+    def chat(message, display=False, stream=True):
+        yield {"type": "code", "role": "assistant", "format": "python", "start": True}
+        yield {
+            "type": "confirmation",
+            "role": "assistant",
+            "content": {"format": "python", "content": "print(1)"},
+        }
+
+    interpreter.chat = chat
+    with mock.patch.object(ti, "CodeBlock"):
+        with mock.patch.object(ti, "scan_code") as scan:
+            with mock.patch("builtins.input", side_effect=["y", "y"]):
+                list(terminal_interface(interpreter, "run code"))
+
+    scan.assert_called_once_with("print(1)", "python", interpreter)
+
+
+def test_terminal_interface_edit_code_uses_editor_and_updates_message():
+    """Answering e to a confirmation opens $EDITOR and feeds edits back to the LLM."""
+    import interpreter.terminal_interface.terminal_interface as ti
+
+    interpreter = _make_interpreter()
+    interpreter.auto_run = False
+    interpreter.messages = [{"role": "user", "type": "message", "content": "run code"}]
+
+    def fake_editor(command):
+        # The editor rewrites the temp file; simulate that here.
+        with open(command[1], "w") as handle:
+            handle.write("edited = 2\n")
+
+    def chat(message, display=False, stream=True):
+        yield {"type": "code", "role": "assistant", "format": "python", "start": True}
+        yield {
+            "type": "confirmation",
+            "role": "assistant",
+            "content": {"format": "python", "content": "print(1)"},
+        }
+
+    interpreter.chat = chat
+    with mock.patch.object(ti, "CodeBlock"):
+        with mock.patch.object(ti.subprocess, "call", side_effect=fake_editor) as call:
+            with mock.patch.dict(os.environ, {"EDITOR": "vim"}):
+                with mock.patch("builtins.input", return_value="e"):
+                    list(terminal_interface(interpreter, "run code"))
+
+    call.assert_called_once()
+    assert "edited = 2" in interpreter.messages[-1]["content"]
+
+
+def test_terminal_interface_computer_visual_chunk_appends_console_output():
+    """Computer image chunks produce console output that is stored on messages."""
+    import interpreter.terminal_interface.terminal_interface as ti
+
+    interpreter = _make_interpreter()
+    interpreter.messages = [
+        {"role": "user", "type": "message", "content": "look at this"}
+    ]
+
+    def chat(message, display=False, stream=True):
+        yield {"role": "computer", "type": "image", "format": "path", "content": "/x.png"}
+
+    interpreter.chat = chat
+    with mock.patch.object(ti, "display_output", return_value="alt text") as display:
+        list(terminal_interface(interpreter, "look"))
+
+    display.assert_called_once_with(
+        {"role": "computer", "type": "image", "format": "path", "content": "/x.png"}
+    )
+    assert interpreter.messages[-1] == {
+        "role": "computer",
+        "type": "console",
+        "format": "output",
+        "content": "alt text",
+    }
+
+
+def test_terminal_interface_computer_visual_skipped_in_quiet_os_mode():
+    """In OS control mode the visual chunks are hidden from the user by default."""
+    import interpreter.terminal_interface.terminal_interface as ti
+
+    interpreter = _make_interpreter()
+    interpreter.os = True
+    interpreter.verbose = False
+
+    def chat(message, display=False, stream=True):
+        yield {"role": "computer", "type": "image", "format": "path", "content": "/x.png"}
+
+    interpreter.chat = chat
+    with mock.patch.object(ti, "display_output") as display:
+        list(terminal_interface(interpreter, "look"))
+
+    display.assert_not_called()
+
+
+def test_terminal_interface_active_line_shows_os_action_notification():
+    """OS mode announces computer actions described on the active line."""
+    interpreter = _make_interpreter()
+    interpreter.os = True
+
+    def chat(message, display=False, stream=True):
+        yield {"type": "code", "role": "assistant", "format": "python", "start": True}
+        yield {
+            "type": "code",
+            "role": "assistant",
+            "content": 'computer.keyboard.write("hi")\n',
+        }
+        yield {"type": "console", "role": "computer", "format": "active_line", "content": 0}
+
+    interpreter.chat = chat
+    list(terminal_interface(interpreter, "type"))
+
+    interpreter.computer.os.notify.assert_called_once_with('Typing "hi".')
+
+
+def test_terminal_interface_uses_injected_message_in_interactive_mode():
+    """A preloaded single message (i {command}) is used without asking for input."""
+    interpreter = _intro_interpreter()
+    interpreter.messages = [
+        {"role": "user", "type": "message", "content": "injected command"}
+    ]
+    chat = mock.Mock(return_value=iter([]))
+    interpreter.chat = chat
+
+    # After the injected message runs, the loop returns to the prompt; Ctrl-C exits.
+    with mock.patch(
+        "builtins.input",
+        side_effect=[KeyboardInterrupt()],
+    ):
+        with pytest.raises(KeyboardInterrupt):
+            list(terminal_interface(interpreter, ""))
+
+    assert interpreter.messages == []
+    chat.assert_called_once_with("injected command", display=False, stream=True)
+
+
+def test_terminal_interface_multi_line_uses_cli_input():
+    """multi_line mode prompts through cli_input instead of builtins.input."""
+    import interpreter.terminal_interface.terminal_interface as ti
+
+    interpreter = _intro_interpreter()
+    interpreter.multi_line = True
+
+    with mock.patch.object(
+        ti, "cli_input", side_effect=["hi", KeyboardInterrupt()]
+    ) as prompt:
+        with pytest.raises(KeyboardInterrupt):
+            list(terminal_interface(interpreter, ""))
+
+    prompt.assert_any_call("> ")
+    interpreter.chat.assert_called_once_with("hi", display=False, stream=True)
+
+
+def test_terminal_interface_skips_rendering_chunks_for_other_recipients():
+    """Chunks addressed to a non-user recipient are not rendered."""
+    import interpreter.terminal_interface.terminal_interface as ti
+
+    interpreter = _make_interpreter()
+
+    def chat(message, display=False, stream=True):
+        yield {
+            "type": "message",
+            "role": "assistant",
+            "content": "hidden",
+            "recipient": "assistant",
+        }
+
+    interpreter.chat = chat
+    with mock.patch.object(ti, "MessageBlock") as block:
+        list(terminal_interface(interpreter, "hi"))
+
+    block.assert_not_called()
+
+
+def test_terminal_interface_verbose_prints_each_chunk(capsys):
+    """verbose mode echoes every chunk flowing through the interface."""
+    interpreter = _make_interpreter()
+    interpreter.verbose = True
+
+    def chat(message, display=False, stream=True):
+        yield {"type": "message", "role": "assistant", "start": True}
+        yield {"type": "message", "role": "assistant", "content": "hi"}
+        yield {"type": "message", "role": "assistant", "end": True}
+
+    interpreter.chat = chat
+    list(terminal_interface(interpreter, "hi"))
+
+    assert "Chunk in `terminal_interface`" in capsys.readouterr().out
+
+
+def test_terminal_interface_message_content_without_start_crashes():
+    """A message content chunk with no preceding start chunk raises AttributeError.
+
+    KNOWN BUG: active_block is None until a start chunk arrives, so a content
+    chunk alone dereferences None and crashes the interface. Well-behaved LLM
+    streams always send start first; documenting current behavior.
+    """
+    interpreter = _make_interpreter()
+
+    def chat(message, display=False, stream=True):
+        yield {"type": "message", "role": "assistant", "content": "orphan"}
+
+    interpreter.chat = chat
+    with pytest.raises(AttributeError):
+        list(terminal_interface(interpreter, "hi"))

--- a/tests/terminal_interface/test_terminal_interface.py
+++ b/tests/terminal_interface/test_terminal_interface.py
@@ -33,6 +33,7 @@ def test_terminal_interface_yields_chunks_and_renders_message_block():
     interpreter = _make_interpreter()
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a plain assistant message stream."""
         yield {"type": "message", "role": "assistant", "start": True}
         yield {"type": "message", "role": "assistant", "content": "hello"}
         yield {"type": "message", "role": "assistant", "end": True}
@@ -53,6 +54,7 @@ def test_terminal_interface_yields_chunks_and_renders_code_block():
     interpreter = _make_interpreter()
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a python code block stream."""
         yield {"type": "code", "role": "assistant", "start": True, "format": "python"}
         yield {"type": "code", "role": "assistant", "content": "x = 1\n"}
         yield {"type": "code", "role": "assistant", "end": True}
@@ -178,6 +180,7 @@ def test_terminal_interface_plain_text_renders_code_fences(capsys):
     interpreter.plain_text_display = True
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a python code block for plain-text rendering."""
         yield {"type": "code", "role": "assistant", "format": "python", "start": True}
         yield {"type": "code", "role": "assistant", "content": "print(1)"}
         yield {"type": "code", "role": "assistant", "format": "python", "end": True}
@@ -223,6 +226,7 @@ def test_terminal_interface_declined_code_is_recorded():
     interpreter.auto_run = False
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a single confirmation chunk."""
         yield {
             "type": "confirmation",
             "content": {"format": "python", "content": "print(1)"},
@@ -244,6 +248,7 @@ def test_terminal_interface_os_mode_notifies_on_message_end():
     interpreter.messages = [{"role": "assistant", "content": "- item one\nline two"}]
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with an assistant message for the OS notification."""
         yield {"type": "message", "role": "assistant", "start": True}
         yield {"type": "message", "role": "assistant", "content": "hello"}
         yield {"type": "message", "role": "assistant", "end": True}
@@ -278,6 +283,7 @@ def test_terminal_interface_confirming_code_builds_code_block():
     interpreter.auto_run = False
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a code block plus confirmation for CodeBlock rendering."""
         yield {"type": "code", "role": "assistant", "format": "python", "start": True}
         yield {
             "type": "confirmation",
@@ -306,6 +312,7 @@ def test_terminal_interface_safe_mode_auto_scans_code_before_run():
     interpreter.safe_mode = "auto"
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a code block plus confirmation for a safe-mode scan."""
         yield {"type": "code", "role": "assistant", "format": "python", "start": True}
         yield {
             "type": "confirmation",
@@ -332,6 +339,7 @@ def test_terminal_interface_safe_mode_ask_scans_when_user_consents():
     interpreter.safe_mode = "ask"
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a code block plus confirmation for a safe-mode ask."""
         yield {"type": "code", "role": "assistant", "format": "python", "start": True}
         yield {
             "type": "confirmation",
@@ -357,11 +365,13 @@ def test_terminal_interface_edit_code_uses_editor_and_updates_message():
     interpreter.messages = [{"role": "user", "type": "message", "content": "run code"}]
 
     def fake_editor(command):
+        """Simulate the editor rewriting the temp file the shell opens."""
         # The editor rewrites the temp file; simulate that here.
         with open(command[1], "w") as handle:
             handle.write("edited = 2\n")
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a code block plus confirmation for the editor flow."""
         yield {"type": "code", "role": "assistant", "format": "python", "start": True}
         yield {
             "type": "confirmation",
@@ -390,6 +400,7 @@ def test_terminal_interface_computer_visual_chunk_appends_console_output():
     ]
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a computer image chunk."""
         yield {"role": "computer", "type": "image", "format": "path", "content": "/x.png"}
 
     interpreter.chat = chat
@@ -416,6 +427,7 @@ def test_terminal_interface_computer_visual_skipped_in_quiet_os_mode():
     interpreter.verbose = False
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a computer image chunk in quiet OS mode."""
         yield {"role": "computer", "type": "image", "format": "path", "content": "/x.png"}
 
     interpreter.chat = chat
@@ -431,6 +443,7 @@ def test_terminal_interface_active_line_shows_os_action_notification():
     interpreter.os = True
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a code block, keyboard write, and active-line chunk."""
         yield {"type": "code", "role": "assistant", "format": "python", "start": True}
         yield {
             "type": "code",
@@ -490,6 +503,7 @@ def test_terminal_interface_skips_rendering_chunks_for_other_recipients():
     interpreter = _make_interpreter()
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with an assistant-recipient message."""
         yield {
             "type": "message",
             "role": "assistant",
@@ -510,6 +524,7 @@ def test_terminal_interface_verbose_prints_each_chunk(capsys):
     interpreter.verbose = True
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with an assistant message for verbose echo."""
         yield {"type": "message", "role": "assistant", "start": True}
         yield {"type": "message", "role": "assistant", "content": "hi"}
         yield {"type": "message", "role": "assistant", "end": True}
@@ -530,6 +545,7 @@ def test_terminal_interface_message_content_without_start_crashes():
     interpreter = _make_interpreter()
 
     def chat(message, display=False, stream=True):
+        """Emulate interpreter.chat with a content-only assistant message (orphan chunk)."""
         yield {"type": "message", "role": "assistant", "content": "orphan"}
 
     interpreter.chat = chat


### PR DESCRIPTION
## Background

Coverage-phase work on the Python Open Interpreter. The async server's WebSocket receive path, HTTP auth middleware, and most of the terminal-interface layer had little or no test coverage. This PR documents *current* behavior with tests only — no source changes.

## Problem

None — coverage-phase discipline. Tests assert current behavior; where behavior looks buggy it is noted as `KNOWN BUG` and filed, not fixed here.

## What this PR changes

Adds seven test files (154 tests):

| File | Tests | Coverage |
|---|---|---|
| `tests/core/test_async_server_websocket.py` | 16 | WebSocket origin policy, auth handshake, chunk routing, ack handling, malformed-JSON error path, pre-auth payload discard |
| `tests/terminal_interface/test_terminal_interface.py` | 27 | upgrade prompt, safe-mode scan, code edit/visual/OS flows, quiet/verbose modes |
| `tests/terminal_interface/test_local_setup.py` | 9 | Llamafile/Ollama/Jan selection, download + launch, RAM/disk guidance |
| `tests/core/computer/display/point/test_point.py` | 12 | image search, element detection, `OI_POINT_PERMUTATE` param variation |
| `tests/terminal_interface/test_magic_commands.py` | 32 | `%undo`/`%debug`/`%markdown`, jupyter cell export, `install_and_import` |
| `tests/terminal_interface/test_start_terminal_interface.py` | 29 | `--server`, `--local`, `--os`, `--codestral`, `--llama3`, `--assistant`, `--groq`, model-flags defaults, `DISABLE_TELEMETRY` |
| `tests/core/test_async_core.py` | 29 | `Server` run/host/port, auth middleware, origin policy, approval/confirmation binding, `input()` command handling |

Also covers `is_websocket_origin_allowed`, `authenticate_function`, `confirmation_digest`, and the `Server` setter/`run()` contract.

### KNOWN BUGs (documented, filed, not fixed)

- `render_cursor` unbound in `terminal_interface.py` when a confirmation chunk arrives without a preceding code/message start → issue #248
- `install_and_import` raises `UnboundLocalError` when pip/pip3 install fails → issue #250
- WebSocket payloads sent before authentication are silently dropped (answered `{"auth": false}`) rather than queued

## Tests

- `python -m pytest -m "not integration"` → **873 passed**, 32 skipped
- `ruff check` clean
- Coverage: **74.13%** (parent 69.54%, **+4.59pp**), codecov/patch + project both pass

Related: issues #248 and #250 track the KNOWN BUGs; their source fixes land in a separate bug-fix PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for WebSocket connections, HTTP API-key authentication, origin validation, and server configuration.
  * Added checks for terminal interactions, confirmations, safe mode, visual output, editing workflows, and magic commands.
  * Improved validation of local model setup, provider selection, CLI options, telemetry settings, and model capabilities.
  * Added characterization coverage for image search, element detection, caching, filtering, and visual parameter handling.
  * Added coverage for magic commands, conversation controls, markdown and notebook exports, and model download workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->