### PR TITLE
test: smoke-test every packaged default profile

### DIFF
--- a/tests/terminal_interface/profiles/test_default_profiles_smoke.py
+++ b/tests/terminal_interface/profiles/test_default_profiles_smoke.py
@@ -1,0 +1,42 @@
+"""Smoke tests for every packaged default profile.
+
+`profiles/defaults/` ships one config per model/provider (.py start-scripts
+plus .yaml/.yml/.json configs). Loading a single representative file is already
+covered elsewhere; what was missing is proof that *every* shipped file still
+loads — a broken default would only surface when a user selects that profile.
+This parametrized test loads each real file through get_default_profile and
+checks the returned shape. Documenting current behavior only — no source
+changes.
+"""
+
+import ast
+import os
+
+import pytest
+
+from interpreter.terminal_interface.profiles import profiles
+
+
+def _default_filenames():
+    """Basenames of every file shipped in profiles/defaults/."""
+    return sorted(os.path.basename(path) for path in profiles.default_profiles_paths)
+
+
+@pytest.mark.parametrize("filename", _default_filenames())
+def test_default_profile_loads(filename):
+    """Each packaged default profile loads into a well-shaped dict.
+
+    .py profiles come back as a start_script string plus the package version;
+    .yaml/.yml/.json profiles come back as their parsed mapping. Any file that
+    fails to parse means a profile users can select is broken on arrival.
+    """
+    result = profiles.get_default_profile(filename)
+
+    assert isinstance(result, dict), filename
+    extension = os.path.splitext(filename)[-1]
+    if extension == ".py":
+        assert isinstance(result["start_script"], str), filename
+        assert result["version"] == profiles.OI_VERSION, filename
+        ast.parse(result["start_script"])
+    else:
+        assert result, filename


### PR DESCRIPTION
## Background

Issue #141 lists `profiles/defaults/*.py` (28 profile modules) with the note 'config smoke tests only?'. `get_default_profile()` was covered only with mocked file paths, so a broken shipped profile would only surface when a user selects it.

## Problem

No test loaded the real files in `profiles/defaults/` — 24 `.py` start-scripts plus 4 `.yaml`/`.yml` configs.

## What this PR changes

Adds `tests/terminal_interface/profiles/test_default_profiles_smoke.py`: one test parametrized over all 28 shipped files (28 tests). Each file is loaded through the real `get_default_profile()` and checked for shape — `.py` files come back as a parseable `start_script` string, yaml/json come back as non-empty mappings.

No source changes. No new KNOWN BUGs.

## Tests

- New file: 28 passed locally
- Full unit suite: 995 passed, 32 skipped, 12 deselected, 1 xfailed
- `ruff check` and `ruff format --check` clean

## Related work

Closes the `profiles/defaults/*.py` checkbox in #141.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added smoke-test coverage for all packaged default profiles.
  * Verified profiles load successfully and return valid, nonempty data.
  * Added format-specific validation for Python, YAML, YML, and JSON profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->