### PR TITLE
fix: profile migration nests mapped keys; language filter deletes nested key

### DIFF
--- a/interpreter/terminal_interface/profiles/profiles.py
+++ b/interpreter/terminal_interface/profiles/profiles.py
@@ -242,7 +242,7 @@ def migrate_profile(old_path, new_path):
 
     # Reformat the YAML keys with indentation
     reformatted_profile = {}
-    for key, value in profile.items():
+    for key, value in mapped_profile.items():
         keys = key.split(".")
         current_level = reformatted_profile
         # Iterate through parts of the key except the last one

--- a/interpreter/terminal_interface/profiles/profiles.py
+++ b/interpreter/terminal_interface/profiles/profiles.py
@@ -206,7 +206,7 @@ def apply_profile(interpreter, profile, profile_path):
             for i in interpreter.computer.languages
             if i.name.lower() in [l.lower() for l in profile["computer"]["languages"]]
         ]
-        del profile["computer.languages"]
+        del profile["computer"]["languages"]
 
     apply_profile_to_object(interpreter, profile)
 

--- a/tests/terminal_interface/profiles/test_profile_loading.py
+++ b/tests/terminal_interface/profiles/test_profile_loading.py
@@ -181,9 +181,11 @@ def test_apply_profile_runs_start_script():
     assert interpreter.auto_run is True
 
 
-@pytest.mark.xfail(reason="KNOWN BUG: apply_profile has `del profile[\"computer.languages\"]` instead of `del profile[\"computer\"][\"languages\"]`")
 def test_apply_profile_filters_languages(monkeypatch):
-    """apply_profile filters computer.languages to those listed in the profile."""
+    """apply_profile filters computer.languages to those listed in the profile.
+
+    Regression test for #225.
+    """
     interpreter = mock.MagicMock()
 
     class FakeLang:

--- a/tests/terminal_interface/profiles/test_profile_loading.py
+++ b/tests/terminal_interface/profiles/test_profile_loading.py
@@ -259,11 +259,11 @@ def test_profile_renames_reserved_name(tmp_path, monkeypatch):
 
 
 def test_migrate_profile_maps_old_keys():
-    """migrate_profile reformats flat keys into nested dicts.
+    """migrate_profile maps flat legacy keys to nested dotted paths.
 
-    KNOWN BUG: the source code builds reformatted_profile from the original
-    profile instead of mapped_profile, so the attribute_mapping is computed
-    but never used. This test documents the actual (buggy) behavior.
+    The attribute_mapping renames e.g. `model` to `llm.model`, and the
+    reformatting nests dotted keys, so the written profile has the new
+    structure. Regression test for #226.
     """
     old_profile = {"model": "gpt-4o", "temperature": 0.5}
     mock_dump = mock.MagicMock()
@@ -277,7 +277,7 @@ def test_migrate_profile_maps_old_keys():
         migrate_profile("/old/path", "/new/path")
     assert mock_dump.called
     dumped_profile = mock_dump.call_args[0][0]
-    assert dumped_profile == old_profile
+    assert dumped_profile == {"llm": {"model": "gpt-4o", "temperature": 0.5}}
 
 
 def test_reset_profile_raises_for_unknown_profile():

--- a/tests/terminal_interface/profiles/test_profiles_extended.py
+++ b/tests/terminal_interface/profiles/test_profiles_extended.py
@@ -282,9 +282,8 @@ def test_apply_profile_warns_on_system_message(profile_env):
 
 
 def test_apply_profile_filters_computer_languages(profile_env):
-    """apply_profile() filters computer.languages to the requested names; the
-    code then raises KeyError on the bad `del profile["computer.languages"]`
-    (tracked in #225)."""
+    """apply_profile() filters computer.languages to the requested names and
+    drops the languages key without error (regression test for #225)."""
     path = os.path.join(profile_env["profile_dir"], "p.yaml")
     interpreter = mock.Mock()
     interpreter.computer.languages = [
@@ -294,13 +293,11 @@ def test_apply_profile_filters_computer_languages(profile_env):
     interpreter.computer.languages[0].name = "python"
     interpreter.computer.languages[1].name = "javascript"
     with mock.patch("interpreter.terminal_interface.profiles.profiles.time.sleep"):
-        with pytest.raises(KeyError, match="computer.languages"):
-            profiles.apply_profile(
-                interpreter,
-                {"version": "0.2.5", "computer": {"languages": ["javascript"]}},
-                path,
-            )
-    # The filter itself ran before the crash.
+        profiles.apply_profile(
+            interpreter,
+            {"version": "0.2.5", "computer": {"languages": ["javascript"]}},
+            path,
+        )
     assert [l.name for l in interpreter.computer.languages] == ["javascript"]
 
 


### PR DESCRIPTION
## Background

Two one-line bugs in `profiles.py`, both previously documented as KNOWN BUGs with pinning tests while coverage was being built.

## Problem

1. `migrate_profile` computed `mapped_profile` via `attribute_mapping` but then built `reformatted_profile` from the original `profile` — legacy keys like `model` were never migrated to `llm.model` (#226).
2. `apply_profile` filtered `computer.languages` correctly but then ran `del profile["computer.languages"]`, raising `KeyError` since the key lives at `profile["computer"]["languages"]` (#225).

## Visible symptoms

- Migrating an old profile wrote back unchanged flat keys.
- Any profile restricting `computer.languages` crashed with `KeyError: 'computer.languages'`.

## What this PR changes

Two atomic commits, one per fix:

- `mapped_profile.items()` instead of `profile.items()` when reformatting; `test_migrate_profile_maps_old_keys` now asserts the migrated output instead of documenting the bug.
- `del profile["computer"]["languages"]`; removes the `xfail` marker from `test_apply_profile_filters_languages` and rewrites `test_apply_profile_filters_computer_languages` to assert success instead of the `KeyError`.

## Tests

- Profile suites: 101 passed (the `xfail` is now a real pass; repo-wide `xfailed` count goes to 0).
- Full unit suite: 1037 passed, 32 skipped, 12 deselected.
- `ruff check` clean.

## Related work

Fixes #226. Fixes #225.