### PR TITLE
fix: install_and_import returns None instead of raising UnboundLocalError

### DIFF
--- a/interpreter/terminal_interface/magic_commands.py
+++ b/interpreter/terminal_interface/magic_commands.py
@@ -227,6 +227,7 @@ def get_downloads_path():
 
 
 def install_and_import(package):
+    module = None
     try:
         module = __import__(package)
     except ImportError:
@@ -249,11 +250,13 @@ def install_and_import(package):
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )
+                module = __import__(package)
             except subprocess.CalledProcessError:
                 print(f"Failed to install package {package}.")
-                return
+                return None
     finally:
-        globals()[package] = module
+        if module is not None:
+            globals()[package] = module
     return module
 
 

--- a/tests/terminal_interface/test_magic_commands.py
+++ b/tests/terminal_interface/test_magic_commands.py
@@ -316,11 +316,12 @@ def test_install_and_import_installs_via_pip_then_imports():
     assert result is fake
 
 
-def test_install_and_import_pip_failure_unbound_module_known_bug():
-    """KNOWN BUG: when pip fails and pip3 also fails, install_and_import
-    raises UnboundLocalError instead of returning None. The function's
-    finally block references `module`, which is never bound on the failure
-    paths. Documenting current behavior."""
+def test_install_and_import_pip_failure_returns_none():
+    """When pip fails and pip3 also fails, install_and_import returns None.
+
+    Regression test for #250: the failure paths previously left `module`
+    unbound, so the finally block raised UnboundLocalError.
+    """
     with mock.patch(
         "builtins.__import__", side_effect=ImportError("missing")
     ):
@@ -332,8 +333,40 @@ def test_install_and_import_pip_failure_unbound_module_known_bug():
                 magic_commands.subprocess.CalledProcessError(1, "pip3"),
             ],
         ):
-            with pytest.raises(UnboundLocalError):
-                magic_commands.install_and_import("somedummy")
+            result = magic_commands.install_and_import("somedummy")
+
+    assert result is None
+
+
+def test_install_and_import_pip3_success_imports():
+    """When pip fails but pip3 succeeds, the package is imported and returned.
+
+    Regression test for #250: the pip3-success path previously never called
+    __import__ again, leaving `module` unbound and raising UnboundLocalError
+    from the finally block.
+    """
+    fake = object()
+    with mock.patch(
+        "builtins.__import__",
+        side_effect=[ImportError("missing"), fake],
+    ):
+        with mock.patch.object(
+            magic_commands.subprocess,
+            "check_call",
+            side_effect=[
+                magic_commands.subprocess.CalledProcessError(1, "pip"),
+                None,
+            ],
+        ) as check_call:
+            result = magic_commands.install_and_import("somedummy")
+
+    assert check_call.call_count == 2
+    check_call.assert_called_with(
+        [sys.executable, "-m", "pip3", "install", "somedummy"],
+        stdout=magic_commands.subprocess.DEVNULL,
+        stderr=magic_commands.subprocess.DEVNULL,
+    )
+    assert result is fake
 
 
 def test_handle_undo_previews_removed_message_content():


### PR DESCRIPTION
## Background

`install_and_import()` in `magic_commands.py` left `module` unbound on two paths, so the `finally` block raised `UnboundLocalError`.

## Problem

1. When pip fails and pip3 also fails, the `finally` block referenced the never-bound `module` instead of returning `None`.
2. When pip fails but pip3 *succeeds*, the success path never re-imported — `module` was still unbound (this path had no test).

## Visible symptoms

`install_and_import("pkg")` raised `UnboundLocalError` instead of returning the module (or `None` on total failure).

## What this PR changes

- Initialize `module = None`, re-import after a pip3 success, return `None` on total failure, and only cache in `globals()` on success.
- Flips `test_install_and_import_pip_failure_unbound_module_known_bug` into `test_install_and_import_pip_failure_returns_none` asserting `None`.
- Adds `test_install_and_import_pip3_success_imports` for the previously untested pip3-success path.

## Tests

- `test_magic_commands.py`: 32 passed.
- Full unit suite: 1037 passed, 32 skipped, 12 deselected (1 pre-existing xfail unrelated to this change).
- `ruff check` clean.

## Related work

Fixes #250.