### PR TITLE
fix: strip tool_calls via dict() so real Delta objects don't crash

### DIFF
--- a/interpreter/core/llm/run_tool_calling_llm.py
+++ b/interpreter/core/llm/run_tool_calling_llm.py
@@ -216,8 +216,11 @@ def run_tool_calling_llm(llm, request_params):
                 # No entry carried a usable function, and the raw tool_calls
                 # list is nothing the merge step can consume (merge_deltas
                 # cannot dict() it), so drop the key and let the chunk pass
-                # through empty rather than crashing.
-                delta = {key: value for key, value in delta.items() if key != "tool_calls"}
+                # through empty rather than crashing. dict() first because
+                # real streaming deltas are objects without .items().
+                stripped = dict(delta)
+                stripped.pop("tool_calls", None)
+                delta = stripped
 
         # Accumulate deltas
         accumulated_deltas = merge_deltas(accumulated_deltas, delta)


### PR DESCRIPTION
## Background

Stacked on #262 — merge after it. #262's fallback for function-less tool-call deltas strips the `tool_calls` key via a dict comprehension over `delta.items()`.

## Problem

That works on the plain-dict doubles used in unit tests, but real streaming deltas from litellm are `Delta` objects, which have no `.items()` method (probed: `dict(delta)` and `delta.get()` work; `.items()`/`.keys()` raise `AttributeError`). If such a delta ever arrives as a real object, the fallback crashes instead of skipping the chunk. Currently latent — litellm 1.89.4 pydantic-validates `function: null` away before our code runs — but a future litellm upgrade could expose it.

## What this PR changes

Build the stripped delta with `dict(delta)` first (works on both plain dicts and `Delta` objects), then pop `tool_calls`. Five lines, one hunk.

## Tests

- `tests/core/llm/`: 168 passed (plain-dict doubles exercise both paths).
- `ruff check` clean; new lines format-clean (remaining `ruff format` nit is pre-existing).
- Real-object behavior verified by probe script during development (Delta from live `litellm.completion` streaming against the mock server).

## Related work

Fixes #267. Parent PR #262 must merge first.