### PR TITLE
Send num_ctx to Ollama so the server's context matches context_window

### DIFF
--- a/interpreter/core/llm/llm.py
+++ b/interpreter/core/llm/llm.py
@@ -500,6 +500,14 @@ Continuing...
             params["max_tokens"] = self.max_tokens
         if self.temperature:
             params["temperature"] = self.temperature
+
+        # Ollama sizes its KV cache from `num_ctx`, which Open Interpreter never
+        # sent, so the model ran at the server's own default context regardless of
+        # `context_window` - while OI trimmed messages to `context_window`. When
+        # `context_window` is the larger of the two the request silently overflows
+        # what the server actually allocated. Send both so they agree.
+        if self.context_window and re.match(r"^ollama(_chat)?/", model or ""):
+            params.setdefault("num_ctx", self.context_window)
         if hasattr(self.interpreter, "conversation_id"):
             params["conversation_id"] = self.interpreter.conversation_id
 


### PR DESCRIPTION
## Problem

Ollama sizes its KV cache from the `num_ctx` option. Open Interpreter never sends it, so the model is loaded with **the server's own default context** while OI trims the message list to `self.context_window`. When `context_window` is the larger of the two, requests silently overflow what the server actually allocated — and setting `--context_window` appears to do nothing.

## Evidence

Server with `OLLAMA_CONTEXT_LENGTH=131072`, `llm.context_window = 163840`:

```
without num_ctx:   ollama ps -> CONTEXT  131072    (server default, not what OI asked for)
with num_ctx:      ollama ps -> CONTEXT  163840
```

Same model, same request, only difference is the option being sent.

## Fix

```python
if self.context_window and re.match(r"^ollama(_chat)?/", model or ""):
    params.setdefault("num_ctx", self.context_window)
```

- `setdefault`, so an explicit caller-supplied `num_ctx` still wins.
- Scoped to `ollama/` and `ollama_chat/` only.
- `re` is already imported in this module.

## Why it reaches Ollama

`num_ctx` is not in `ollama_chat`'s `get_supported_openai_params`, so LiteLLM does not map it as an OpenAI param — it falls through `add_provider_specific_params_to_optional_params`, which copies unknown non-None params into `optional_params`, and `transform_request` puts `optional_params` into the request's `options` object. Confirmed by inspecting the resulting params and by the `ollama ps` output above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ollama models now consistently honor the configured context window when processing requests.
  - This improves handling of longer conversations and helps keep server-side context capacity aligned with the application’s configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->