### PR TITLE
Escape % in retention_ratio help so --help works

### DIFF
--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -147,7 +147,7 @@ def start_terminal_interface(interpreter):
         {
             "name": "retention_ratio",
             "nickname": "rr",
-            "help_text": "enable cache-aware truncation: when the prompt outgrows the context window, drop a variable number of oldest whole turns down to this fraction of the window (e.g. 0.8 keeps 80% of the window and drops the oldest 20% at once), keeping the prefix stable so the provider's KV cache stays warm",
+            "help_text": "enable cache-aware truncation: when the prompt outgrows the context window, drop a variable number of oldest whole turns down to this fraction of the window (e.g. 0.8 keeps 80%% of the window and drops the oldest 20%% at once), keeping the prefix stable so the provider's KV cache stays warm",
             "type": float,
             "attribute": {"object": interpreter.llm, "attr_name": "retention_ratio"},
         },


### PR DESCRIPTION
argparse `%`-formats help strings, so the lone `%` signs in the `retention_ratio` help text (`"80% of the window"`, `"20% at once"`) are read as format specifiers.

This breaks on every supported Python, just at different points:

| Python | where it fails | error |
|---|---|---|
| 3.11 | formatting the help — `interpreter --help` crashes | `TypeError: %o format: an integer is required, not dict` |
| 3.14 | parser construction — `interpreter` won't start at all | `ValueError: badly formed help string` |

3.14's argparse validates eagerly, which is why the same string fails earlier there.

Escaping them as `%%` fixes both. Verified on 3.11.15 and 3.14.4: construction and `format_help()` both succeed, and the text still renders as `80%` / `20%`, so `--help` output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)