### PR TITLE
Report the exit status of failed bash commands

### DIFF
--- a/interpreter/core/terminal/languages/bash.py
+++ b/interpreter/core/terminal/languages/bash.py
@@ -26,10 +26,12 @@ class Bash(CwdTrackingMixin, SubprocessLanguage):
     def preprocess_code(self, code):
         code = self._strip_redundant_cd(code)
         code = preprocess_shell(code)
-        # Save $? the instant the user's code finishes. The cwd echo that
-        # _insert_cwd_marker adds below runs before the end marker, so reading
-        # $? in the marker itself would report that echo's status (always 0)
-        # rather than the user's.
+        # Save $? the instant the user's code finishes, before anything this
+        # method appends can overwrite it. The cwd echo that _insert_cwd_marker
+        # adds below runs before the end marker, so reading $? in the marker
+        # itself would report that echo's status (always 0) rather than the
+        # user's. add_active_line_prints skips lines that run nothing for the
+        # same reason: a marker echo after the last real command would set $?.
         code = code.replace(
             '\necho "##end_of_execution##"',
             '\n__oi_exit_code=$?\necho "##end_of_execution##$__oi_exit_code"',

--- a/interpreter/core/terminal/languages/bash.py
+++ b/interpreter/core/terminal/languages/bash.py
@@ -1,3 +1,5 @@
+import re
+
 from .cwd_tracking import CwdTrackingMixin
 from .resolve_bash import resolve_bash_executable
 from .shell_preprocess import preprocess_shell
@@ -18,10 +20,21 @@ class Bash(CwdTrackingMixin, SubprocessLanguage):
         SubprocessLanguage.__init__(self)
         self.start_cmd = [resolve_bash_executable()]
 
+    # Matches the end-of-execution marker with the exit status appended to it.
+    _EXIT_CODE_RE = re.compile(r"##end_of_execution##(\d+)")
+
     def preprocess_code(self, code):
         code = self._strip_redundant_cd(code)
         code = preprocess_shell(code)
-        end_marker = '\necho "##end_of_execution##"'
+        # Save $? the instant the user's code finishes. The cwd echo that
+        # _insert_cwd_marker adds below runs before the end marker, so reading
+        # $? in the marker itself would report that echo's status (always 0)
+        # rather than the user's.
+        code = code.replace(
+            '\necho "##end_of_execution##"',
+            '\n__oi_exit_code=$?\necho "##end_of_execution##$__oi_exit_code"',
+        )
+        end_marker = '\necho "##end_of_execution##$__oi_exit_code"'
         return self._insert_cwd_marker(code, end_marker)
 
     def _cwd_marker_echo(self):
@@ -34,3 +47,7 @@ class Bash(CwdTrackingMixin, SubprocessLanguage):
 
     def detect_end_of_execution(self, line):
         return "##end_of_execution##" in line
+
+    def detect_exit_code(self, line):
+        match = self._EXIT_CODE_RE.search(line)
+        return int(match.group(1)) if match else None

--- a/interpreter/core/terminal/languages/shell_preprocess.py
+++ b/interpreter/core/terminal/languages/shell_preprocess.py
@@ -21,8 +21,27 @@ def preprocess_shell(code):
 def add_active_line_prints(code):
     lines = code.split("\n")
     for index, line in enumerate(lines):
+        # Skip lines that execute nothing. Marking them is meaningless, and the
+        # marker is an `echo`, so one sitting after the user's last real command
+        # becomes the command that sets `$?`. Code ending in a newline splits to
+        # a trailing empty line, which is how a failing command's exit status
+        # used to be reported as 0. The index still counts skipped lines so the
+        # numbers keep matching the user's source.
+        if _runs_nothing(line):
+            continue
         lines[index] = f'echo "##active_line{index + 1}##"\n{line}'
     return "\n".join(lines)
+
+
+def _runs_nothing(line):
+    """True for blank and comment-only lines.
+
+    ``#`` is the comment character in bash; cmd uses ``rem``/``::`` instead, but
+    skipping a ``#`` line there only costs a highlight for a line that would
+    have failed anyway.
+    """
+    stripped = line.strip()
+    return not stripped or stripped.startswith("#")
 
 
 def has_multiline_commands(script_text):

--- a/interpreter/core/terminal/languages/subprocess_language.py
+++ b/interpreter/core/terminal/languages/subprocess_language.py
@@ -24,6 +24,14 @@ class SubprocessLanguage(BaseLanguage):
     def detect_active_line(self, line):
         return None
 
+    def detect_exit_code(self, line):
+        """Exit status encoded in the end-of-execution marker, or None.
+
+        Only subclasses whose marker carries the status (currently Bash)
+        override this; the default keeps every other language unchanged.
+        """
+        return None
+
     def detect_end_of_execution(self, line):
         return None
 
@@ -193,11 +201,23 @@ class SubprocessLanguage(BaseLanguage):
                             {"type": "console", "format": "output", "content": line}
                         )
                 elif self.detect_end_of_execution(line):
-                    # Sometimes there's a little extra on the same line, so be sure to send that out
-                    line = line.replace("##end_of_execution##", "").strip()
+                    exit_code = self.detect_exit_code(line)
+                    # Sometimes there's a little extra on the same line, so be sure to send that out.
+                    # \d* also consumes the exit status when the marker carries one.
+                    line = re.sub(r"##end_of_execution##\d*", "", line).strip()
                     if line:
                         self.output_queue.put(
                             {"type": "console", "format": "output", "content": line}
+                        )
+                    # Only report failures: a successful command stays silent and
+                    # costs the model nothing.
+                    if exit_code:
+                        self.output_queue.put(
+                            {
+                                "type": "console",
+                                "format": "output",
+                                "content": f"[exited with code {exit_code}]",
+                            }
                         )
                     self.done.set()
                 elif is_error_stream and "KeyboardInterrupt" in line:

--- a/tests/core/test_bash_exit_code.py
+++ b/tests/core/test_bash_exit_code.py
@@ -1,0 +1,92 @@
+import subprocess
+
+import pytest
+
+from interpreter.core.terminal.languages.bash import Bash
+from interpreter.core.terminal.languages.resolve_bash import resolve_bash_executable
+
+
+def run_preprocessed(code):
+    """Preprocess `code` the way Bash does, run it, and return the reported status.
+
+    Runs the generated script in a real shell rather than asserting on its text:
+    the whole point is what `$?` holds by the time the end marker echoes it, and
+    only bash can answer that.
+    """
+    script = Bash().preprocess_code(code)
+    completed = subprocess.run(
+        [resolve_bash_executable()],
+        input=script,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return Bash().detect_exit_code(completed.stdout)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "false",
+        # Trailing newline. add_active_line_prints splits on "\n", so this used
+        # to leave a marker echo as the last command before $? was read, and the
+        # failure was reported as 0.
+        "false\n",
+        "false\n\n\n",
+        # A trailing comment runs nothing either.
+        "false\n# all done\n",
+        "false  # inline comment",
+    ],
+)
+def test_failure_is_reported_however_the_block_ends(code):
+    assert run_preprocessed(code) == 1
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("(exit 7)\n", 7),
+        ("bash -c 'exit 42'\n", 42),
+        ("ls /definitely/not/a/real/path\n", 2),
+        # The status of the whole chain, not of its first command.
+        ("false || true\n", 0),
+        ("true && false\n", 1),
+    ],
+)
+def test_specific_exit_codes_survive(code, expected):
+    assert run_preprocessed(code) == expected
+
+
+@pytest.mark.parametrize("code", ["true", "true\n", "echo hi\n", "true\n# done\n"])
+def test_success_is_reported_as_zero(code):
+    assert run_preprocessed(code) == 0
+
+
+def test_multiline_constructs_report_their_status():
+    # has_multiline_commands() disables active-line injection here, so this
+    # exercises the path without any injected echoes at all.
+    assert run_preprocessed("if true; then false; fi\n") == 1
+    assert run_preprocessed("for i in 1 2; do true; done\n") == 0
+
+
+def test_blank_and_comment_lines_get_no_active_line_marker():
+    out = Bash().preprocess_code("echo one\n\n# a comment\necho two\n")
+    assert '##active_line1##' in out  # echo one
+    assert '##active_line2##' not in out  # blank
+    assert '##active_line3##' not in out  # comment
+    assert '##active_line4##' in out  # echo two
+
+
+def test_active_line_numbers_still_match_the_source():
+    """Skipped lines keep their index so highlighting points at the right line."""
+    out = Bash().preprocess_code("\n\necho third")
+    assert '##active_line3##' in out
+
+
+def test_detect_exit_code_parses_the_marker():
+    bash = Bash()
+    assert bash.detect_exit_code("##end_of_execution##0") == 0
+    assert bash.detect_exit_code("##end_of_execution##130") == 130
+    assert bash.detect_exit_code("trailing text ##end_of_execution##2") == 2
+    assert bash.detect_exit_code("##end_of_execution##") is None
+    assert bash.detect_exit_code("no marker here") is None

--- a/tests/core/test_terminal_languages.py
+++ b/tests/core/test_terminal_languages.py
@@ -852,7 +852,13 @@ class TestTerminalLanguages(unittest.TestCase):
         out = bash.preprocess_code("echo hi")
         self.assertLess(
             out.index('echo "##oi_pwd##$PWD"'),
-            out.index('echo "##end_of_execution##"'),
+            out.index('echo "##end_of_execution##'),
+        )
+        # $? has to be captured before the pwd echo, which would otherwise be
+        # the command whose status the end marker reports.
+        self.assertLess(
+            out.index("__oi_exit_code=$?"),
+            out.index('echo "##oi_pwd##$PWD"'),
         )
 
 


### PR DESCRIPTION
A failing bash command left no trace in the output the model sees, so a silent failure read as success and it carried on.

The end-of-execution marker now carries `$?`, and a non-zero status is reported as `[exited with code N]`. Successful commands stay silent and cost nothing.

### The part I got wrong the first time

`$?` has to be captured before anything the preprocessor appends can overwrite it, and **two** things could. The first version only handled one of them.

- The cwd echo from `_insert_cwd_marker` — handled: the assignment goes in ahead of it rather than being read inside the marker.
- The active-line markers, which are themselves `echo`s. `add_active_line_prints` emitted one before *every* line including blank and comment-only ones. Code ending in a newline — the usual shape of a generated block — splits to a trailing empty line, so the last command before `$?` was read was an `echo`, and **every failure was reported as 0**.

Verified against a real shell:

```
$ false            -> ##end_of_execution##1
$ false\n          -> ##end_of_execution##0   # before
                   -> ##end_of_execution##1   # after
```

`add_active_line_prints` now skips lines that execute nothing, keeping the index so line numbers still match the source. Marking a blank line was meaningless anyway.

### Tests

`tests/core/test_bash_exit_code.py` runs the generated script in a real shell rather than asserting on its text — the question is what `$?` holds by the time the marker echoes it, and only bash can answer that. Covers trailing newlines, trailing blank lines, trailing comments, `&&`/`||` chains, and multi-line constructs (which take the no-injection path).

8 of these fail against the previous version of this branch.

Also fixes `test_bash_preprocess_appends_pwd_marker_before_end_marker`, which this branch had been breaking — it still asserted the old marker string. Nothing caught that because the workflow only runs on PRs to `main`, so nothing runs on PRs here.

Rebased onto current `classic/develop`. No new failures against the base, `ruff check` output identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bash command results now accurately preserve and report the exit status of the user’s code, including when working-directory information is also recorded.
  - Blank and comment-only shell lines no longer produce unnecessary active-line markers, while source line numbering remains accurate.

- **Tests**
  - Added coverage for successful and failed commands, chained and multiline scripts, comments, whitespace, marker placement, and missing execution markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->